### PR TITLE
Check for updates automatically and warn user if available

### DIFF
--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -224,7 +224,7 @@ def upload(ctx, files, max_threads, clean, no_interleave, prompt, validate):
 def login(ctx):
     """Add an API key (saved in ~/.onecodex)"""
     base_url = os.environ.get("ONE_CODEX_API_BASE", "https://app.onecodex.com")
-    _login(base_url, check_for_update=False)
+    _login(base_url)
 
 
 @onecodex.command('logout')

--- a/onecodex/lib/auth.py
+++ b/onecodex/lib/auth.py
@@ -70,13 +70,13 @@ def check_version(version, server_url, client='cli'):
     latest_version = data['latest_version']
 
     if client == 'cli':
-        uploader_text = ' from http://www.onecodex.com/uploader.html'
+        uploader_text = ' using the command `pip install --upgrade onecodex`.'
     else:
         uploader_text = (' from the '
                          '<a href="http://www.onecodex.com/uploader.html">One Codex website</a>')
 
-    # TODO: once the cli route returns this, remove this outer check
-    if 'min_supported_version' in data:
+    # Only warn on minimum supported for version for the GUI, always warn about upgrades for CLI
+    if client != 'cli' and 'min_supported_version' in data:
         min_version = data['min_supported_version']
         if version_inadequate(version, min_version):
             return True, ('Please upgrade your client to the latest version ' +

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from click.testing import CliRunner
 from contextlib import contextmanager
+import datetime
 import json
 import os
 from pkg_resources import resource_string
@@ -239,7 +240,7 @@ def runner():
 
 # CLI / FILE SYSTEM FIXTURE
 @pytest.fixture(scope='function')
-def mocked_creds_file(monkeypatch, tmpdir):
+def mocked_creds_path(monkeypatch, tmpdir):
     # TODO: tmpdir is actually a LocalPath object
     # from py.path, and we coerce it into a string
     # for compatibility with the existing library code
@@ -249,3 +250,12 @@ def mocked_creds_file(monkeypatch, tmpdir):
     def mockreturn(path):
         return os.path.join(str(tmpdir), '.onecodex')
     monkeypatch.setattr(os.path, 'expanduser', mockreturn)
+
+
+@pytest.fixture(scope='function')
+def mocked_creds_file(mocked_creds_path):
+    with open(os.path.expanduser('~/.onecodex'), mode='w') as f:
+        f.write(json.dumps({
+            'api_key': None,
+            'saved_at': datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
+        }))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,7 +98,7 @@ def make_creds_file():
         f.write(json.dumps(fake_creds))
 
 
-def test_api_login(runner, mocked_creds_file):
+def test_api_login(runner, mocked_creds_path):
     login_input = 'user@example.com' + '\n' + 'userpassword' + '\n'
     successful_login_msg = 'Your ~/.onecodex credentials file was successfully created.'
     with Replace('onecodex.auth.fetch_api_key_from_uname', mock_fetch_api_key):
@@ -146,7 +146,7 @@ def test_logout_creds_exists(runner, mocked_creds_file):
         assert os.path.exists(path) is False
 
 
-def test_logout_creds_dne(runner, mocked_creds_file):
+def test_logout_creds_dne(runner, mocked_creds_path):
     expected_message = "No One Codex API keys found."
     result = runner.invoke(Cli, ["logout"])
     assert result.exit_code == 1


### PR DESCRIPTION
~This simply prints to stderr if the user's package is outdated. We should consider only doing this in CLI-mode vs. API/client library mode.~ We now use `click.echo` to warn, so this only happens in CLI invocation.