### PR TITLE
Add Sentry logging. Closes #1852.

### DIFF
--- a/onecodex/api.py
+++ b/onecodex/api.py
@@ -31,7 +31,7 @@ class Api(object):
 
     def __init__(self, api_key=None,
                  bearer_token=None, cache_schema=False,
-                 base_url=None, telemetry=False,
+                 base_url=None, telemetry=None,
                  schema_path='/api/v1/schema'):
 
         if base_url is None:
@@ -42,7 +42,6 @@ class Api(object):
         self._req_args = {}
         self._base_url = base_url
         self._schema_path = schema_path
-        self._telemetry = telemetry
 
         # Attempt to automatically fetch API key from
         # ~/.onecodex file, API key, or bearer token environment vars
@@ -73,10 +72,12 @@ class Api(object):
         self._copy_resources()
 
         # Optionally configure Raven
-        if self._telemetry:
+        if telemetry is True or (telemetry is None and os.environ.get('ONE_CODEX_AUTO_TELEMETRY', False)):
             self._raven_client = get_raven_client(user_context={'email': self._fetch_account_email()})
+            self._telemetry = True
         else:
             self._raven_client = None
+            self._telemetry = False
 
         # Try to import and copy key modules onto the Api object
         for module_name in ['onecodex.viz', 'onecodex.distance']:

--- a/onecodex/api.py
+++ b/onecodex/api.py
@@ -74,7 +74,7 @@ class Api(object):
 
         # Optionally configure Raven
         if self._telemetry:
-            self._raven_client = get_raven_client()
+            self._raven_client = get_raven_client(user_context={'email': self._fetch_account_email()})
         else:
             self._raven_client = None
 
@@ -83,6 +83,13 @@ class Api(object):
             module = ModuleAlias(module_name)
             if module._imported:
                 setattr(self, module._name, module)
+
+    def _fetch_account_email(self):
+        creds_fp = os.path.expanduser('~/.onecodex')
+        if os.path.exists(creds_fp):
+            with open(creds_fp) as f:
+                creds = json.load(f)
+                return creds.get('email')
 
     def _copy_resources(self):
         """

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -72,7 +72,7 @@ def onecodex(ctx, api_key, no_pprint, verbose, telemetry):
             if api_key is not None:
                 ctx.obj['API'] = Api(cache_schema=True, api_key=api_key, telemetry=telemetry)
             else:
-                click.echo("No One Codex API key is available - running anonymously", err=True)
+                click.echo("No One Codex API credentials found - running anonymously", err=True)
                 ctx.obj['API'] = Api(cache_schema=True, telemetry=telemetry)
 
     # handle checking insecure platform, we let upload command do it by itself

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -84,6 +84,7 @@ def onecodex(ctx, api_key, no_pprint, verbose, telemetry):
 @onecodex.command('analyses')
 @click.argument('analyses', nargs=-1, required=False)
 @click.pass_context
+@telemetry
 def analyses(ctx, analyses):
     """Retrieve performed analyses"""
     cli_resource_fetcher(ctx, "analyses", analyses)
@@ -98,6 +99,7 @@ def analyses(ctx, analyses):
               help=OPTION_HELP['results'])
 @click.pass_context
 @click.argument('classifications', nargs=-1, required=False)
+@telemetry
 def classifications(ctx, classifications, results, readlevel, readlevel_path):
     """Retrieve performed metagenomic classifications"""
 
@@ -133,6 +135,7 @@ def classifications(ctx, classifications, results, readlevel, readlevel_path):
 @onecodex.command('panels')
 @click.pass_context
 @click.argument('panels', nargs=-1, required=False)
+@telemetry
 def panels(ctx, panels):
     """Retrieve performed in silico panel results"""
     cli_resource_fetcher(ctx, "panels", panels)
@@ -141,6 +144,7 @@ def panels(ctx, panels):
 @onecodex.command('samples')
 @click.pass_context
 @click.argument('samples', nargs=-1, required=False)
+@telemetry
 def samples(ctx, samples):
     """Retrieve uploaded samples"""
     cli_resource_fetcher(ctx, "samples", samples)

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -112,10 +112,10 @@ def _cli_resource_fetcher(ctx, resource, uris):
         for uri in uris:
             try:
                 instance = getattr(ctx.obj['API'], resource_name).get(uri)
-                # if instance is not None:
-                instances.append(instance._resource._properties)
-                # else:
-                # cli_log.error('Could not find {} {} (404 status code)'.format(resource_name, uri))
+                if instance is not None:
+                    instances.append(instance._resource._properties)
+                else:
+                    cli_log.error('Could not find {} {} (404 status code)'.format(resource_name, uri))
             except requests.exceptions.HTTPError as e:
                 cli_log.error('Could not find %s %s (%d status code)'.format(
                     resource_name, uri, e.response.status_code

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -211,7 +211,7 @@ def collapse_user(fp):
     return abs_path.replace(home_dir, "~")
 
 
-def get_raven_client(**extra):
+def get_raven_client(user_context=None, extra_context=None):
     if os.environ.get('ONE_CODEX_NO_TELEMETRY') is None:
         key = base64.b64decode(
             b'NmFlMjMwYWY4NjI5NDg3NmEyYzYwYjZjNDhhZDJiYzI6ZTMyZmYwZTVhNjUwNGQ5NGJhODc0NWZlMmU1ZjNmZjA='
@@ -233,8 +233,15 @@ def get_raven_client(**extra):
                 include_paths=[],
                 release=__version__
             )
-            extra['platform'] = platform.platform()
-            client.extra_context(extra)
+
+            if extra_context is None:
+                extra_context = {}
+            if user_context is None:
+                user_context = {}
+
+            extra_context['platform'] = platform.platform()
+            client.user_context(user_context)
+            client.extra_context(extra_context)
             return client
         except Exception:
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ networkx>=1.11
 seaborn==0.8
 sklearn
 scikit-bio==0.4.2
+raven>=6.1.0
 
 # testing
 tox

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
     zip_safe=False,
     extras_require={
         'all': ['numpy>=1.11.0', 'pandas>=0.18.1', 'matplotlib>1.5.1',
-                'seaborn>=0.8', 'scikit-learn>=0.19.0', 'scikit-bio==0.4.2']
+                'seaborn>=0.8', 'scikit-learn>=0.19.0', 'scikit-bio==0.4.2',
+                'networkx>=1.11', 'raven>=6.1.0']
     },
     dependency_links=[],
     author='Kyle McChesney & Nick Greenfield & Roderick Bovee',
@@ -49,7 +50,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
     ],
     entry_points={
-        'console_scripts': ['onecodex = onecodex.cli:onecodex']
+        'console_scripts': ['onecodex = onecodex.cli:onecodex'],
     },
     test_suite='tests'
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -357,6 +357,7 @@ def mocked_creds_path(monkeypatch, tmpdir):
 def mocked_creds_file(mocked_creds_path):
     with open(os.path.expanduser('~/.onecodex'), mode='w') as f:
         f.write(json.dumps({
+            'email': 'test@onecodex.com',
             'api_key': None,
             'saved_at': datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
         }))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,7 +92,12 @@ def mock_fetch_api_key(username, password, server_url):
 def make_creds_file():
     api_key = '123yuixha87yd87q3123uiqhsd8q2738'
     now = datetime.datetime.now().strftime(DATE_FORMAT)
-    fake_creds = {'api_key': api_key, 'saved_at': now, 'updated_at': None}
+    fake_creds = {
+        'api_key': api_key,
+        'saved_at': now,
+        'updated_at': None,
+        'email': 'demo@onecodex.com'
+    }
     path = os.path.expanduser("~/.onecodex")
     with open(path, mode='w') as f:
         f.write(json.dumps(fake_creds))

--- a/tests/test_raven.py
+++ b/tests/test_raven.py
@@ -1,0 +1,52 @@
+import os
+
+import mock
+import pytest
+from raven import Client as RavenClient
+
+from onecodex import Cli
+from onecodex.utils import get_raven_client, telemetry
+
+
+def test_raven_off_by_default(ocx):
+    assert ocx._telemetry is False
+    assert ocx._raven_client is None
+
+
+def test_no_raven_in_test_env(runner):
+    assert runner.env.get('ONE_CODEX_NO_TELEMETRY') is not None
+
+
+@pytest.mark.parametrize('cli_args,call_count', [
+    (['logout'], 2),  # Once for the `onecodex` entry and once for `logout` since no Api client
+    (['--no-telemetry', 'logout'], 0),
+    (['--version'], 0)  # Built-in, no @click.pass_context
+])
+def test_telemetry_decorator(cli_args, call_count):
+
+    @telemetry
+    def cli_exception(cli_args):
+        Cli.main(cli_args)
+
+    with mock.patch('onecodex.utils.get_raven_client') as grc:
+        with pytest.raises(SystemExit):
+            cli_exception(cli_args)
+        assert grc.call_count == call_count
+
+
+def test_ocx_with_raven(ocx_w_raven):
+    assert ocx_w_raven._telemetry is True
+    assert isinstance(ocx_w_raven._raven_client, RavenClient)
+    assert ocx_w_raven._raven_client.remote.base_url == 'https://sentry.example.com'
+    assert ocx_w_raven._raven_client.is_enabled() is True
+
+
+def test_good_sentry_dsn():
+    raven = get_raven_client()
+    assert isinstance(raven, RavenClient)
+
+
+def test_bad_sentry_dsn():
+    with mock.patch.dict(os.environ, {'ONE_CODEX_SENTRY_DSN': 'bad'}):
+        raven = get_raven_client()
+        assert raven is None

--- a/tests/test_raven.py
+++ b/tests/test_raven.py
@@ -34,11 +34,12 @@ def test_telemetry_decorator(cli_args, call_count):
         assert grc.call_count == call_count
 
 
-def test_ocx_with_raven(ocx_w_raven):
+def test_ocx_with_raven(ocx_w_raven, mocked_creds_file):
     assert ocx_w_raven._telemetry is True
     assert isinstance(ocx_w_raven._raven_client, RavenClient)
     assert ocx_w_raven._raven_client.remote.base_url == 'https://sentry.example.com'
     assert ocx_w_raven._raven_client.is_enabled() is True
+    assert 'email' in ocx_w_raven._raven_client.context['user']
 
 
 def test_good_sentry_dsn():


### PR DESCRIPTION
Adds support for logging CLI errors to One Codex's Sentry server. This is enabled by default for CLI operations but can be disabled with a `--no-telemetry` flag. Sentry error logging is _disabled_ by default in all other user environments (e.g., for an `Api` instance outside of the CLI).