### PR TITLE
Add ability to login with API key vs. password

### DIFF
--- a/onecodex/auth.py
+++ b/onecodex/auth.py
@@ -90,20 +90,26 @@ def _login(server, creds_file=None, api_key=None):
     return email
 
 
-def _logout(creds_file=None):
+def _remove_creds(creds_file=None):
     """
-    Logout main function, just rm ~/.onecodex more or less
+    Remove ~/.onecodex file, returning True if successul or False if the file didn't exist
     """
-
-    # creds file path setup
     if creds_file is None:
         fp = os.path.expanduser("~/.onecodex")
     else:
         fp = creds_file
 
     if os.path.exists(fp):
-        # we might not want to do this if there's there are cached schema in it?
         os.remove(fp)
+        return True
+    return False
+
+
+def _logout(creds_file=None):
+    """
+    Logout main function, just rm ~/.onecodex more or less
+    """
+    if _remove_creds(creds_file=creds_file):
         click.echo("Successfully removed One Codex credentials.", err=True)
         sys.exit(0)
     else:

--- a/onecodex/auth.py
+++ b/onecodex/auth.py
@@ -22,11 +22,15 @@ DATE_FORMAT = "%Y-%m-%d %H:%M"
 API_KEY_LEN = 32
 
 
-def login_uname_pwd(server):
+def login_uname_pwd(server, api_key=None):
     """
     Prompts user for username and password, gets API key from server
+    if not provided.
     """
-    username = click.prompt("Please enter your One Codex  (email)")
+    username = click.prompt("Please enter your One Codex (email)")
+    if api_key is not None:
+        return username, api_key
+
     password = click.prompt("Please enter your password (typing will be hidden)",
                             hide_input=True)
 
@@ -39,7 +43,7 @@ def login_uname_pwd(server):
     return username, api_key
 
 
-def _login(server, creds_file=None):
+def _login(server, creds_file=None, api_key=None):
     """
     Login main function
     """
@@ -58,14 +62,14 @@ def _login(server, creds_file=None):
                 if 'email' in creds:
                     click.echo('Credentials file already exists ({})'.format(collapse_user(fp)),
                                err=True)
-                    return
+                    return creds['email']
         except ValueError:
             click.echo("Your ~/.onecodex credentials file appears to be corrupted."  # noqa
                        "Please delete it and re-authorize.", err=True)
             sys.exit(1)
 
     # else make it
-    email, api_key = login_uname_pwd(server)
+    email, api_key = login_uname_pwd(server, api_key=api_key)
 
     if api_key is None:
         click.echo("We could not verify your credentials. Either you mistyped your email "
@@ -83,6 +87,7 @@ def _login(server, creds_file=None):
     with open(fp, mode='w') as f:
         json.dump(creds, f)
     click.echo("Your ~/.onecodex credentials file was successfully created.", err=True)
+    return email
 
 
 def _logout(creds_file=None):

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -18,7 +18,7 @@ from onecodex.utils import (cli_resource_fetcher, download_file_helper,
                             warn_simplejson, telemetry)
 from onecodex.api import Api
 from onecodex.exceptions import ValidationWarning, ValidationError, UploadException
-from onecodex.auth import _login, _logout, _silent_login
+from onecodex.auth import _login, _logout, _remove_creds, _silent_login
 from onecodex.scripts import filter_reads
 from onecodex.version import __version__
 
@@ -280,7 +280,7 @@ def login(ctx):
         # with, e.g., connection error catching (it's not part of our formally documeted API at the moment)
         if ocx._client.Account.instances()['email'] != email:
             click.echo('Your login credentials do not match the provided email!', err=True)
-            _logout()
+            _remove_creds()
             sys.exit(1)
 
 

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -270,7 +270,18 @@ def upload(ctx, files, max_threads, clean, no_interleave, prompt, validate,
 def login(ctx):
     """Add an API key (saved in ~/.onecodex)"""
     base_url = os.environ.get("ONE_CODEX_API_BASE", "https://app.onecodex.com")
-    _login(base_url)
+    if not ctx.obj['API_KEY']:
+        _login(base_url)
+    else:
+        email = _login(base_url, api_key=ctx.obj['API_KEY'])
+        ocx = Api(cache_schema=True, api_key=ctx.obj['API_KEY'], telemetry=ctx.obj['TELEMETRY'])
+
+        # TODO: This should be protected or built in as a first class resource
+        # with, e.g., connection error catching (it's not part of our formally documeted API at the moment)
+        if ocx._client.Account.instances()['email'] != email:
+            click.echo('Your login credentials do not match the provided email!', err=True)
+            _logout()
+            sys.exit(1)
 
 
 @onecodex.command('logout')

--- a/onecodex/lib/auth.py
+++ b/onecodex/lib/auth.py
@@ -19,6 +19,7 @@ def fetch_api_key_from_uname(username, password, server_url):
     """
     Retrieves an API key from the One Codex webpage given the username and password
     """
+    # TODO: Hit programmatic endpoint to fetch JWT key, not API key
     with requests.Session() as session:
         # get the login page normally
         text = session.get(server_url + 'login').text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,6 +112,16 @@ def test_api_login(runner, mocked_creds_path):
         assert successful_login_msg in result.output
 
 
+@pytest.mark.parametrize('email,success,code', [
+    ('incorrect+email@onecodex.com', False, 1),
+    ('asmngs@onecodex.com', True, 0),
+])
+def test_api_key_login(runner, api_data, mocked_creds_path, email, success, code):
+    result = runner.invoke(Cli, ['--api-key', '0' * 32, 'login'], input=email)
+    assert result.exit_code == code
+    assert os.path.exists(os.path.expanduser('~/.onecodex')) is success
+
+
 def test_creds_file_exists(runner, mocked_creds_file):
     with runner.isolated_filesystem():
         make_creds_file()


### PR DESCRIPTION
This is necessary for organizations with SSO, which is not directly supported in the CLI. Closes #85.