### PR TITLE
Minor auth and sentry changes, bash completion

### DIFF
--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -13,8 +13,7 @@ import warnings
 
 from onecodex.api import Api
 from onecodex.auth import _login, _logout, _remove_creds, login_required
-from onecodex.exceptions import (ValidationWarning,
-                                 ValidationError, UploadException)
+from onecodex.exceptions import (ValidationWarning, ValidationError)
 from onecodex.metadata_upload import validate_appendables
 from onecodex.scripts import filter_reads
 from onecodex.utils import (cli_resource_fetcher, download_file_helper,
@@ -203,12 +202,12 @@ def upload(ctx, files, max_threads, clean, no_interleave, prompt, validate,
 
     if (forward or reverse) and not (forward and reverse):
         click.echo('You must specify both forward and reverse files', err=True)
-        sys.exit(1)
+        ctx.exit(1)
     if forward and reverse:
         if len(files) > 0:
             click.echo('You may not pass a FILES argument when using the '
                        ' --forward and --reverse options.', err=True)
-            sys.exit(1)
+            ctx.exit(1)
         files = [(forward, reverse)]
         no_interleave = True
     if len(files) == 0:
@@ -277,12 +276,12 @@ def upload(ctx, files, max_threads, clean, no_interleave, prompt, validate,
         sys.stderr.write('\nERROR: {}. {}'.format(
             e, 'Running with the --clean flag will suppress this error.'
         ))
-        sys.exit(1)
-    except (ValidationError, UploadException, Exception) as e:
+        ctx.exit(1)
+    except ValidationError as e:
         # TODO: Some day improve specific other exception error messages, e.g., gzip CRC IOError
         sys.stderr.write('\nERROR: {}'.format(e))
         sys.stderr.write('\nPlease feel free to contact us for help at help@onecodex.com\n\n')
-        sys.exit(1)
+        ctx.exit(1)
 
 
 @onecodex.command('login')
@@ -302,7 +301,7 @@ def login(ctx):
         if ocx._client.Account.instances()['email'] != email:
             click.echo('Your login credentials do not match the provided email!', err=True)
             _remove_creds()
-            sys.exit(1)
+            ctx.exit(1)
 
 
 @onecodex.command('logout')

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -333,12 +333,6 @@ def telemetry(fn):
 
         try:
             return fn(*args, **kwargs)
-        except SystemExit as e:
-            if client:
-                client.captureException()
-                client.context.clear()
-                sys.stdout = StringIO()  # See: https://github.com/getsentry/raven-python/issues/904
-            sys.exit(e.code)  # make sure we still exit with the proper code
         except Exception as e:
             if client:
                 client.captureException()

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,27 @@ Links
 
 """
 from setuptools import setup, find_packages
+from setuptools.command.install import install
+
+
+class PostInstallCommand(install):
+    def run(self):
+        install.run(self)
+
+        # try to enable bash completion, if possible
+        import os
+
+        paths_to_try = ['/etc/bash_completion.d', '/usr/local/etc/bash_completion.d']
+
+        for path in paths_to_try:
+            if os.access(path, os.W_OK):
+                try:
+                    with open(os.path.join(path, 'onecodex'), 'w') as f:
+                        f.write('eval "$(_ONECODEX_COMPLETE=source onecodex)"')
+                    print('Enabled bash auto-completion for onecodex')
+                    return
+                except Exception:
+                    print('Unable to enable bash auto-completion for onecodex')
 
 
 with open('onecodex/version.py') as import_file:
@@ -30,10 +51,10 @@ setup(
     version=__version__,  # noqa
     packages=find_packages(exclude=['*test*']),
     install_requires=[
-        'boto3>=1.4.2', 
+        'boto3>=1.4.2',
         'click>=6.6',
         'jsonschema>=2.4'
-        'python-dateutil>=2.5.3', 
+        'python-dateutil>=2.5.3',
         'pytz>=2014.1',
         'raven>=6.1.0',
         'requests>=2.9',
@@ -46,7 +67,7 @@ setup(
     extras_require={
         'all': [
             'altair==2.3.0',
-            'networkx>=1.11,<2.0', 
+            'networkx>=1.11,<2.0',
             'numpy>=1.11.0',
             'pandas>=0.20.0,<0.21.0',
             'scikit-bio==0.4.2',
@@ -68,6 +89,7 @@ setup(
     dependency_links=[],
     author='Kyle McChesney & Nick Greenfield & Roderick Bovee',
     author_email='opensource@onecodex.com',
+    cmdclass={'install': PostInstallCommand},
     description='One Codex API client and Python library',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,12 +346,17 @@ def ocx_schemas():
 
 @pytest.fixture(scope='session')
 def ocx_w_raven():
-    patched_env = {
+    patched_env = os.environ.copy()
+    patch = {
         'ONE_CODEX_API_BASE': 'http://localhost:3000',
         'ONE_CODEX_API_KEY': '1eab4217d30d42849dbde0cd1bb94e39',
         'ONE_CODEX_SENTRY_DSN': 'https://key:pass@sentry.example.com/1',
+        'ONE_CODEX_NO_TELEMETRY': None,
     }
-    with mock.patch.dict(os.environ, patched_env):
+
+    patched_env.update(patch)
+
+    with mock.patch.object(os, 'environ', patched_env):
         with mock_requests(SCHEMA_ROUTES):
             return Api(cache_schema=False, telemetry=True)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 import datetime
 import json
+import mock
 import os
 import pytest
 from testfixtures import Replace
@@ -166,6 +167,26 @@ def test_logout_creds_dne(runner, mocked_creds_path):
     result = runner.invoke(Cli, ["logout"])
     assert result.exit_code == 1
     assert expected_message in result.output
+
+
+def test_auth_from_env(runner, api_data):
+    # no authentication method, no stored login
+    result = runner.invoke(Cli, ['samples'], catch_exceptions=False)
+    assert 'requires authentication' in result.output
+
+    # bearer token in environment
+    with mock.patch.dict(os.environ, {'ONE_CODEX_BEARER_TOKEN': '00000000000000000000000000000000'}):
+        assert 'ONE_CODEX_BEARER_TOKEN' in os.environ
+        assert 'ONE_CODEX_API_KEY' not in os.environ
+        result = runner.invoke(Cli, ['samples'], catch_exceptions=False)
+    assert 'requires authentication' not in result.output
+
+    # bearer token in environment
+    with mock.patch.dict(os.environ, {'ONE_CODEX_API_KEY': '00000000000000000000000000000000'}):
+        assert 'ONE_CODEX_BEARER_TOKEN' not in os.environ
+        assert 'ONE_CODEX_API_KEY' in os.environ
+        result = runner.invoke(Cli, ['samples'], catch_exceptions=False)
+    assert 'requires authentication' not in result.output
 
 
 # Uploads

--- a/tests/test_raven.py
+++ b/tests/test_raven.py
@@ -42,8 +42,13 @@ def test_ocx_with_raven(ocx_w_raven, mocked_creds_file):
 
 
 def test_good_sentry_dsn():
-    raven = get_raven_client()
-    assert isinstance(raven, RavenClient)
+    patched_env = os.environ.copy()
+    patch = {'ONE_CODEX_NO_TELEMETRY': None}
+    patched_env.update(patch)
+
+    with mock.patch.object(os, 'environ', patched_env):
+        raven = get_raven_client()
+        assert isinstance(raven, RavenClient)
 
 
 def test_bad_sentry_dsn():


### PR DESCRIPTION
This PR addresses the following issues:

- #153 Removes capturing `SystemExit` calls and is more choosey about when to `sys.exit()`
- #154 Allows CLI to authenticate via `API_KEY` or `BEARER_TOKEN` environment variables
- #155 Adds a post-install script which tries to enable bash completion if the user has a `bash-completion` package installed in a writeable way

Low priority, can go into a larger release.
