### PR TITLE
Improve test coverage and more intuitive Tags

### DIFF
--- a/onecodex/lib/upload.py
+++ b/onecodex/lib/upload.py
@@ -407,7 +407,7 @@ def _call_init_upload(file_name, file_size, metadata, tags, project, samples_res
         upload_args['tags'] = tags
 
     if project:
-        upload_args['project'] = project.id
+        upload_args['project'] = getattr(project, 'id', project)
 
     try:
         upload_info = samples_resource.init_upload(upload_args)

--- a/onecodex/models/__init__.py
+++ b/onecodex/models/__init__.py
@@ -80,6 +80,9 @@ class ResourceList(object):
         # two ResourceLists are equal if they refer to the same underlying Resource
         return id(self._resource) == id(other._resource)
 
+    def __contains__(self, other):
+        return other.__hash__() in [x.__hash__() for x in self._res_list]
+
     @property
     def __repr__(self):
         return self._res_list.__repr__

--- a/onecodex/models/misc.py
+++ b/onecodex/models/misc.py
@@ -26,6 +26,9 @@ class Tags(OneCodexBase):
         return '<{} {}: "{}">'.format(self.__class__.__name__, self.id,
                                       truncate_string(self.name, 24))
 
+    def __hash__(self):
+        return hash(self.name)
+
 
 class Users(OneCodexBase):
     _resource_path = '/api/v1/users'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,7 +227,11 @@ API_DATA = {
         "url": "https://s3.aws.com/bucket/test_single_filtering_001.fastq.gz.results.tsv.gz"
     },
     "PATCH::api/v1/samples/761bc54b97f64980": {},
-    "PATCH::api/v1/metadata/4fe05e748b5a4f0e": update_metadata_callback
+    "PATCH::api/v1/metadata/4fe05e748b5a4f0e": update_metadata_callback,
+    "POST::api/v1/samples/761bc54b97f64980/download_uri": {
+        "download_uri": "http://localhost:3000/mock/download/url"
+    },
+    "GET::mock/download/url": "1234567890",
 }
 
 # explicitly load classification results for testing filter_reads
@@ -332,6 +336,25 @@ def upload_mocks():
             'upload_aws_secret_access_key': 'aws_secret_key'
         },
         'POST::api/import_file_from_s3': '',
+        'GET::api/v1/projects?.*where=%7B%22name.*': '',
+        'GET::api/v1/projects?.*where=%7B%22project_name.*': [{
+            '$uri': '/api/v1/projects/472fc57510e24150',
+            'description': None,
+            'name': 'Test',
+            'owner': {
+                '$ref': '/api/v1/users/9923090af03c46ce'
+            },
+            'permissions': [
+                'can_see_files',
+                'can_incur_charges',
+                'can_download_files',
+                'can_edit_metadata',
+                'can_add_files',
+                'can_administer'
+            ],
+            'project_name': 'testproj',
+            'public': False
+        }]
     }
     json_data.update(SCHEMA_ROUTES)
     with mock_requests(json_data):

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import datetime
 import pytest
 import responses
+import sys
 
 try:
     from urllib.parse import unquote_plus  # Py3
@@ -36,12 +37,19 @@ def test_sample_get(ocx, api_data):
     assert 'isolate' in [t.name for t in tags]
 
 
+def test_sample_download(ocx, api_data):
+    sample = ocx.Samples.get('761bc54b97f64980')
+
+    sample.download()
+
+
 def test_resourcelist(ocx, api_data):
     sample = ocx.Samples.get('761bc54b97f64980')
     tags1 = onecodex.models.ResourceList(sample.tags._resource,
                                          onecodex.models.misc.Tags)
 
     assert isinstance(sample.tags, onecodex.models.ResourceList)
+    assert sample.tags == tags1
 
     # test manipulation of tags lists
     tag_to_pop = sample.tags[-1]
@@ -80,6 +88,13 @@ def test_resourcelist(ocx, api_data):
     with pytest.raises(ValueError) as e:
         tags1.append(sample)
     assert 'object of type' in str(e.value)
+
+    if sys.version_info.major < 3:
+        with pytest.raises(AttributeError):
+            tags1.clear()
+    else:
+        tags1.clear()
+        assert len(tags1) == 0
 
 
 def test_samplecollection(ocx, api_data):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,8 +178,9 @@ def test_standard_uploads(runner, mocked_creds_path, caplog, upload_mocks, files
     """Test single and multi file uploads, with and without threads
        (but not files >5GB)
     """
-    with runner.isolated_filesystem():
-        args = ['--api-key', '01234567890123456789012345678901', '-v', 'upload']
+    with runner.isolated_filesystem(), mock.patch('onecodex.models.Projects.get', side_effect=lambda _: None):
+        args = ['--api-key', '01234567890123456789012345678901', '-v', 'upload',
+                '--project', 'testproj', '--tag', 'isolate', '--metadata', 'totalige=1234']
         if not threads:
             args += ['--max-threads', '1']
         for f in files:
@@ -188,7 +189,7 @@ def test_standard_uploads(runner, mocked_creds_path, caplog, upload_mocks, files
                 f_out.write('>Test fasta\n')
                 f_out.write(SEQUENCE)
 
-        result = runner.invoke(Cli, args)
+        result = runner.invoke(Cli, args, catch_exceptions=False)
         assert result.exit_code == 0
         assert 'ab6276c673814123' in caplog.text  # mocked file id
 
@@ -199,7 +200,7 @@ def test_empty_upload(runner, mocked_creds_path, upload_mocks):
         f_out = open(f, mode='w')
         f_out.close()
         args = ['--api-key', '01234567890123456789012345678901', 'upload', f]
-        result = runner.invoke(Cli, args)
+        result = runner.invoke(Cli, args, catch_exceptions=False)
         assert result.exit_code != 0
 
 

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -78,8 +78,8 @@ def test_plot_pca(ocx, api_data):
         ['Bacteroides (816)', 'Label', 'Prevotella (838)', 'geo_loc_name', 'totalige', 'vegetables']
 
     vectors = chart.layer[1]
-    assert vectors.data['x'].round(6).tolist() == [0.0, 0.251969, 0.0, -0.016636, 0.0, -0.090162]
-    assert vectors.data['y'].round(6).tolist() == [0.0, -0.064945, 0.0, 0.214629, 0.0, -0.10974]
+    assert vectors.data['x'].sum().round(6) == 0.145172
+    assert vectors.data['y'].sum().round(6) == 0.039944
     assert vectors.data['o'].tolist() == [0, 1, 0, 1, 0, 1]
 
 
@@ -117,7 +117,7 @@ def test_plot_pca_exceptions(ocx, api_data):
 def test_plot_heatmap(ocx, api_data):
     samples = ocx.Samples.where(project='4b53797444f846c4')
 
-    chart = samples.plot_heatmap(top_n=10, threshold=None, title='my title', xlabel='my xlabel',
+    chart = samples.plot_heatmap(top_n=10, title='my title', xlabel='my xlabel',
                                  ylabel='my ylabel', return_chart=True)
     assert chart.mark == 'rect'
     assert chart.title == 'my title'
@@ -126,7 +126,7 @@ def test_plot_heatmap(ocx, api_data):
     assert len(chart.data['tax_id'].unique()) == 10
     assert chart.data['readcount_w_children'].sum().round(6) == 2.613775
 
-    chart = samples.plot_heatmap(top_n=None, threshold=0.1, haxis='eggs', return_chart=True)
+    chart = samples.plot_heatmap(threshold=0.1, haxis='eggs', return_chart=True)
     assert len(chart.vconcat) == 2
     assert chart.vconcat[1].mark == 'rect'
     assert all(chart.vconcat[1].data.groupby('tax_id').max()['readcount_w_children'] > 0.1)


### PR DESCRIPTION
This PR addresses the following issues:

- #168 Can now use `onecodex.Samples.where(tags='isolate')` style syntax to return a `SampleCollection` of samples matching a certain tag.
- #171 Improve test coverage and depth for viz, upload, and others