### PR TITLE
Address some outstanding priority issues with upload refactor

### DIFF
--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -238,25 +238,25 @@ def upload(ctx, files, max_threads, prompt, forward, reverse, tags, metadata, pr
 
                 single_files.remove(filename)
 
-            auto_pair = True
+        auto_pair = True
 
-            if prompt and len(paired_files) > 0:
-                pair_list = ''
-                for p in paired_files:
-                    pair_list += '\n  {}  &  {}'.format(os.path.basename(p[0]), os.path.basename(p[1]))
+        if prompt and len(paired_files) > 0:
+            pair_list = ''
+            for p in paired_files:
+                pair_list += '\n  {}  &  {}'.format(os.path.basename(p[0]), os.path.basename(p[1]))
 
-                answer = click.confirm(
-                    'It appears there are paired files:{}\nInterleave them after upload?'.format(
-                        pair_list
-                    ),
-                    default='Y'
-                )
+            answer = click.confirm(
+                'It appears there are paired files:{}\nInterleave them after upload?'.format(
+                    pair_list
+                ),
+                default='Y'
+            )
 
-                if not answer:
-                    auto_pair = False
+            if not answer:
+                auto_pair = False
 
-            if auto_pair:
-                files = paired_files + list(single_files)
+        if auto_pair:
+            files = paired_files + list(single_files)
 
     upload_kwargs = {
         'threads': max_threads,

--- a/onecodex/lib/upload.py
+++ b/onecodex/lib/upload.py
@@ -328,12 +328,16 @@ class FakeProgressBar(object):
 def process_api_error(resp, state=None):
     """Raise an exception with a pretty message in various states of upload"""
     error_code = resp.status_code
-    error_json = resp.json()
 
     if error_code == 402:
         error_message = ('Please add a payment method to upload more samples. If you continue to '
                          'experience problems, contact us at help@onecodex.com for assistance.')
     else:
+        try:
+            error_json = resp.json()
+        except ValueError:
+            error_json = {}
+
         if 'msg' in error_json:
             error_message = error_json['msg'].rstrip('.')
         elif 'message' in error_json:

--- a/onecodex/lib/upload.py
+++ b/onecodex/lib/upload.py
@@ -563,11 +563,14 @@ def upload(files, session, samples_resource, threads=None, metadata=None, tags=N
                 # we need to do this funky wait loop to ensure threads get killed by ctrl-c
                 while True:
                     for thread in upload_threads:
-                        # hopefully no one has a file that takes longer than a week to upload
-                        thread.join(604800)
+                        thread.join(0.1)
 
                     if all(not thread.is_alive() for thread in upload_threads):
                         break
+
+                    if bar.pct > 0.98 and bar.label == 'Uploading... ':
+                        bar.label = 'Finalizing... '
+                        bar.update(1)
             except KeyboardInterrupt:
                 # cancel in progress upload(s)
                 for sample_id in set(uuids_in_progress).difference(uuids_completed):


### PR DESCRIPTION
This PR addresses the following issues:

- #194 What appeared to be a schema caching issue was a failure of `process_api_error()` to handle 500s from fastx-proxy. Now they will result in an upload failed message.
- #195 This was a dumb issue where I left some code indented after removing a chunk in `cli.py`. Sorry.
- #196 Added a "Finalizing..." label to the progressbar when it gets to be above 98% completed in multi-threaded mode. It's more complicated to do this in single-threaded mode and that's off by default so I'm leaving it as-is.