### PR TITLE
Bugfixes related to notebooks

### DIFF
--- a/onecodex/dataframes.py
+++ b/onecodex/dataframes.py
@@ -73,7 +73,14 @@ class ClassificationsDataFrame(pd.DataFrame):
         kwargs['max_cols'] = 10
 
         # round abundances to avoid long trails of zeros, and sort taxa in order of abundance
-        df = self.round(6).reindex(columns=self.sum().sort_values(ascending=False).index)
+        if 'classification_id' in self.columns:
+            # long format
+            df = self.copy()
+            df[self.ocx_field] = df[self.ocx_field].round(6)
+            df = df.sort_values(self.ocx_field, ascending=False)
+        else:
+            # wide format
+            df = self.round(6).reindex(columns=self.sum().sort_values(ascending=False).index)
 
         return super(ClassificationsDataFrame, df).to_html(*args, **kwargs)
 

--- a/onecodex/notebooks/exporters.py
+++ b/onecodex/notebooks/exporters.py
@@ -23,6 +23,11 @@ class OneCodexHTMLExporter(HTMLExporter):
     def __init__(self, config=None, **kw):
         super(OneCodexHTMLExporter, self).__init__(config=config, **kw)
 
+        try:
+            from jupyter_contrib_nbextensions.nbconvert_support import PyMarkdownPreprocessor  # noqa
+        except ImportError:
+            return
+
         # this preprocessor converts {{variable}} tags in markdown blocks to their values
         # see https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/python-
         # markdown/readme.html

--- a/onecodex/notebooks/report.py
+++ b/onecodex/notebooks/report.py
@@ -43,7 +43,7 @@ class set_date(object):
             ipy = get_ipython()
             ipy.meta['customdate'] = self.date
         except NameError:
-            raise OneCodexException('Must be run from within IPython')
+            pass
 
     def display(self):
         from IPython.display import display


### PR DESCRIPTION
This PR addresses the following issues:

- #206 Just pass if iPython is unavailable on `set_date` since we don't really need access to a notebook's metadata
- #211 Remove legacy jQuery call, check if DOM element returned directly, and manually load `requirejs` if unavailable (i.e., we're in jupyterlab)
- #212 PyMarkdownPreprocessor registration is only relevant if it's available. So, pass if it's not.
- #213 Sort long format tables differently than wide tables