### PR TITLE
Bug fix related to Vega plots

### DIFF
--- a/onecodex/notebooks/exporters.py
+++ b/onecodex/notebooks/exporters.py
@@ -165,7 +165,8 @@ class OneCodexPDFExporter(OneCodexHTMLExporter):
 
 
 class OneCodexDocumentExporter(OneCodexPDFExporter):
-    export_from_notebook = 'Export to One Codex Document Portal'
+    # make this a string and it will appear in the 'Download as...' menu
+    export_from_notebook = None
 
     def from_notebook_node(self, nb, resources=None, **kw):
         """Takes PDF output from PDFExporter and uploads to One Codex Documents portal."""

--- a/onecodex/viz/__init__.py
+++ b/onecodex/viz/__init__.py
@@ -127,7 +127,14 @@ require(["vega-embed"], function(vegaEmbed) {{
         .toSVG()
         .then(imageData => {{
           if (output_area !== undefined && output_area.outputs !== undefined) {{
-            output_area.outputs[0]["data"]["image/svg+xml"] = imageData;
+            // figure out which output cell belongs to this render block. there may be
+            // multiple jupyter-vega cells per input cell, but only one will match our id
+            for (const cell_num in output_area.outputs) {{
+              let cell = output_area.outputs[cell_num];
+              if (cell.metadata && cell.metadata["jupyter-vega"] === "#{id}") {{
+                output_area.outputs[cell_num]["data"]["image/svg+xml"] = imageData;
+              }}
+            }}
           }}
         }})
         .catch(error => showError(out_target, error));


### PR DESCRIPTION
This PR addresses two issues:

In jupyter notebooks, if you did something like this (in the same cell):

```
print('foobar')
my_altair_plot.display()
```

You'd trigger a JavaScript error. That's because our altair renderer tries to save the plot as an SVG within the notebook cell it's been executed from. Before this PR, the renderer was trying to save the data in the first output cell (e.g., `output_area.outputs[0]`). In the above example, that means it was trying to save an SVG to be associated with the `text/plain` output cell containing `foobar`. Obviously, this is wrong. It should be saving the SVG in the /second/ output cell, to be associated with the altair plot.

This PR solves that problem by instead searching through all the output cells (associated with the input cell the renderer was executed from) and saves the SVG inside the output cell with the same UUID. That UUID is generated from within Python (`onecodex/viz/__init__.py`) and is unique.

In addition, this PR removes the "doc portal export" option from the "Download as..." menu of jupyter notebook by default. It should never have really been there, since it only works if the `docker-onecodex-notebook/notebook/onecodex.js` file is installed in `~/.jupyter/custom`, which is only true on our notebook service.