### PR TITLE
Clean up docstrings, tweak reports module

### DIFF
--- a/onecodex/__init__.py
+++ b/onecodex/__init__.py
@@ -1,7 +1,3 @@
-"""
-__init__.py
-author: @mbiokyle29
-"""
 import logging
 
 __all__ = ["Api"]

--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -53,7 +53,7 @@ class AnalysisMixin(VizPCAMixin, VizHeatmapMixin, VizMetadataMixin, VizDistanceM
 
         Metadata fields are returned as is, from the `self.metadata` DataFrame. If multiple metadata
         fields are specified in a tuple, their values are joined as strings separated by underscore.
-        Multiple metadata fields in tuple must both be categorical. That is, a numerical field and
+        Multiple metadata fields in a tuple must both be categorical. That is, a numerical field and
         boolean can not be joined, or the result would be something like '87.4_True'.
 
         The 'Label' field name is transformed to '_display_name'. This lets us label points in plots

--- a/onecodex/api.py
+++ b/onecodex/api.py
@@ -1,9 +1,3 @@
-"""
-api.py
-author: @mbiokyle29
-
-One Codex API
-"""
 from __future__ import print_function
 from datetime import datetime
 import errno
@@ -28,10 +22,8 @@ log = logging.getLogger(__name__)
 
 
 class Api(object):
-    """
-    This is the base One Codex Api object class. It instantiates a Potion-Client
-        object under the hood for making requests.
-    """
+    """This is the base One Codex Api object class. It instantiates a Potion-Client object under the
+    hood for making requests."""
 
     def __init__(self, api_key=None,
                  bearer_token=None, cache_schema=True,

--- a/onecodex/assets/notebook_template.css
+++ b/onecodex/assets/notebook_template.css
@@ -37,13 +37,13 @@ img.logo-right {
     color: black;
     font-size: 11pt;
   }
-  @bottom-left {
+  @bottom-center {
     content: "NOT FOR DIAGNOSTIC USE";
     text-align: left;
     color: #aaa;
     font-size: 11pt;
   }
-  @bottom-center {
+  @bottom-left {
     content: string(reportdate);
     text-align: center;
     color: #aaa;

--- a/onecodex/assets/notebook_template.less
+++ b/onecodex/assets/notebook_template.less
@@ -47,14 +47,14 @@ img.logo-right {
 		font-size: 11pt;
 	}
 
-	@bottom-left {
+	@bottom-center {
 		content: "NOT FOR DIAGNOSTIC USE";
 		text-align: left;
 		color: #aaa;
 		font-size: 11pt;
 	}
 
-	@bottom-center {
+	@bottom-left {
 		content: string(reportdate);
 		text-align: center;
 		color: #aaa;

--- a/onecodex/auth.py
+++ b/onecodex/auth.py
@@ -1,8 +1,3 @@
-"""
-auth.py
-author: @mbiokyle29 / @boydgreenfield
-- Adapted from v0 auth.py
-"""
 from __future__ import print_function
 import click
 import datetime

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-"""
-cli.py
-author: @mbiokyle29
-"""
 from __future__ import print_function
 import click
 import copy

--- a/onecodex/dataframes.py
+++ b/onecodex/dataframes.py
@@ -16,22 +16,25 @@ class ClassificationsDataFrame(pd.DataFrame):
 
     Parameters
     ----------
-        ocx_rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
-            Analysis was restricted to abundances of taxa at the specified level.
+    ocx_rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
+        Analysis was restricted to abundances of taxa at the specified level.
 
-        ocx_field : {'readcount_w_children', 'readcount', 'abundance'}
-            Which field was used for the abundance/count of a particular taxon in a sample.
+    ocx_field : {'readcount_w_children', 'readcount', 'abundance'}
+        Which field was used for the abundance/count of a particular taxon in a sample.
 
-            - 'readcount_w_children': total reads of this taxon and all its descendants
-            - 'readcount': total reads of this taxon
-            - 'abundance': genome size-normalized relative abundances, from shotgun sequencing
+        - 'readcount_w_children': total reads of this taxon and all its descendants
+        - 'readcount': total reads of this taxon
+        - 'abundance': genome size-normalized relative abundances, from shotgun sequencing
 
-        ocx_metadata : `pandas.DataFrame`
-            A DataFrame containing collated metadata fields for all samples in this analysis.
+    ocx_metadata : `pandas.DataFrame`
+        A DataFrame containing collated metadata fields for all samples in this analysis.
 
-        ocx_taxonomy : `pandas.DataFrame`
-            A DataFrame containing taxonomy information (i.e., id, name, rank, parent) for all taxa
-            referenced in this analysis.
+    ocx_taxonomy : `pandas.DataFrame`
+        A DataFrame containing taxonomy information (i.e., id, name, rank, parent) for all taxa
+        referenced in this analysis.
+
+    ocx_normalized : `bool`
+        Whether the results in this DataFrame were normalized, each sample summing to 1.0.
     """
 
     _metadata = ['ocx_rank', 'ocx_field', 'ocx_taxonomy', 'ocx_metadata', 'ocx_normalized']

--- a/onecodex/lib/auth.py
+++ b/onecodex/lib/auth.py
@@ -1,6 +1,3 @@
-"""
-Functions for connecting to the One Codex server; these should be used across CLI and GUI clients
-"""
 import re
 import requests
 

--- a/onecodex/lib/upload.py
+++ b/onecodex/lib/upload.py
@@ -1,7 +1,3 @@
-"""
-Functions for connecting to the One Codex server; these should be rolled out
-into the onecodex python library at some point for use across CLI and GUI clients
-"""
 from __future__ import print_function, division
 
 import bz2
@@ -238,10 +234,8 @@ def _file_size(file_path, uncompressed=False):
             with bz2.BZ2File(file_path, mode='rb') as fp:
                 fp.seek(0, os.SEEK_END)
                 return fp.tell()
-        else:
-            return os.path.getsize(file_path)
-    else:
-        return os.path.getsize(file_path)
+
+    return os.path.getsize(file_path)
 
 
 def _file_stats(file_path, enforce_fastx=True):
@@ -583,7 +577,7 @@ def upload_sequence(files, session, samples_resource, threads=1, metadata=None, 
 
 
 def upload_sequence_fileobj(file_obj, file_name, fields, session, samples_resource, log=None):
-    """Uploads a single file-like object to the One Codex server either via fastx-proxy or directly
+    """Uploads a single file-like object to the One Codex server via either fastx-proxy or directly
     to S3.
 
     Parameters

--- a/onecodex/models/__init__.py
+++ b/onecodex/models/__init__.py
@@ -174,8 +174,7 @@ class ResourceList(object):
 
 
 class OneCodexBase(object):
-    """
-    A parent object for all the One Codex objects that wraps the Potion-Client API and makes
+    """A parent object for all the One Codex objects that wraps the Potion-Client API and makes
     access and usage easier.
     """
 
@@ -358,17 +357,15 @@ class OneCodexBase(object):
 
     @classmethod
     def all(cls, sort=None, limit=None):
-        """
-        Returns all of the {classname}. Alias for {classname}.where() (without filter arguments).
+        """Returns all objects of this type. Alias for where() (without filter arguments).
 
-        See `{classname}.where` for documentation on the `sort` and `limit` parameters.
-        """.format(classname=cls.__name__)
+        See `where` for documentation on the `sort` and `limit` parameters.
+        """
         return cls.where(sort=sort, limit=limit)
 
     @classmethod
     def where(cls, *filters, **keyword_filters):
-        """
-        Retrieves {classname} from the One Codex server.
+        """Retrieves objects (Samples, Classifications, etc.) from the One Codex server.
 
         Parameters
         ----------
@@ -388,9 +385,9 @@ class OneCodexBase(object):
         Returns
         -------
         list
-            A list of all {classname} matching these filters. If no filters are passed, this
-            matches all {classname}.
-        """.format(classname=cls.__name__)
+            A list of all objects matching these filters. If no filters are passed, this
+            matches all objects.
+        """
         check_bind(cls)
 
         public = False
@@ -436,26 +433,24 @@ class OneCodexBase(object):
 
     @classmethod
     def get(cls, uuid):
-        """
-        Retrieve one specific {classname} object from the server by its UUID
-        (unique 16-character id). UUIDs can be found in the web browser's address bar while
-        viewing analyses and other objects.
+        """Retrieve one specific object from the server by its UUID (unique 16-character id). UUIDs
+        can be found in the web browser's address bar while viewing analyses and other objects.
 
         Parameters
         ----------
         uuid : string
-            UUID of the {classname} object to retrieve.
+            UUID of the object to retrieve.
 
         Returns
         -------
         OneCodexBase | None
-            The {classname} object with that UUID or None if no {classname} object could be found.
+            The object with that UUID or None if no object could be found.
 
         Examples
         --------
         >>> api.Samples.get('xxxxxxxxxxxxxxxx')
         <Sample xxxxxxxxxxxxxxxx>
-        """.format(classname=cls.__name__)
+        """
         check_bind(cls)
 
         # we're just retrieving one object from its uuid
@@ -477,9 +472,7 @@ class OneCodexBase(object):
         return cls(_resource=resource)
 
     def delete(self):
-        """
-        Delete this {classname} object off the One Codex server.
-        """.format(classname=self.__class__.__name__)
+        """Delete this object from the One Codex server."""
         check_bind(self)
         if self.id is None:
             raise ServerError('{} object does not exist yet'.format(self.__class__.name))
@@ -495,9 +488,7 @@ class OneCodexBase(object):
                 raise e
 
     def save(self):
-        """
-        Either create or persist changes on this {classname} object back to the One Codex server.
-        """.format(classname=self.__class__.__name__)
+        """Either create or persist changes on this object back to the One Codex server."""
         check_bind(self)
 
         creating = self.id is None
@@ -533,8 +524,7 @@ __all__ = ['Samples', 'Classifications', 'Alignments', 'Panels', 'Jobs', 'Projec
 
 
 def pretty_print_error(err_json):
-    """Pretty print Flask-Potion error messages for the user
-    """
+    """Pretty print Flask-Potion error messages for the user."""
     # Special case validation errors
     if len(err_json) == 1 and 'validationOf' in err_json[0]:
         required_fields = ', '.join(err_json[0]['validationOf']['required'])

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -14,7 +14,7 @@ from onecodex.models import ResourceList
 
 
 class SampleCollection(ResourceList, AnalysisMixin):
-    """A collection of `Samples` or `Classifications` objects with many methods are analysis of
+    """A collection of `Samples` or `Classifications` objects with many methods for analysis of
     classifications results.
 
     Notes

--- a/onecodex/notebooks/exporters.py
+++ b/onecodex/notebooks/exporters.py
@@ -89,8 +89,9 @@ class OneCodexHTMLExporter(HTMLExporter):
 
         # add one codex logo unless told not to
         if not os.environ.get('ONE_CODEX_REPORT_NO_LOGO', False):
-            logo_path = 'file:///' + os.path.join(ASSETS_PATH, 'one_codex_logo.png').replace('\\', '/')
-            logo_html = report.set_logo(logo_path, position='right')._repr_mimebundle_()['text/html']
+            img = b64encode(bytes(open(os.path.join(ASSETS_PATH, 'one_codex_logo.png'), 'rb').read())).decode()
+            img = 'data:image/png;charset=utf-8;base64,%s' % (img,)
+            logo_html = report.set_logo(img, position='right')._repr_mimebundle_()['text/html']
             head_block = resources['metadata'].get('head_block', '') + logo_html
             resources['metadata']['head_block'] = head_block
 
@@ -100,10 +101,10 @@ class OneCodexHTMLExporter(HTMLExporter):
             head_block = resources['metadata'].get('head_block', '') + date_div
             resources['metadata']['head_block'] = head_block
 
-        # add link to our custom CSS using system path
-        css_path = 'file:///' + os.path.join(ASSETS_PATH, CSS_TEMPLATE_FILE).replace('\\', '/')
-        css_link = '<link rel="stylesheet" href="{}" />'.format(css_path)
-        head_block = resources['metadata'].get('head_block', '') + css_link
+        # embed the default CSS
+        css = open(os.path.join(ASSETS_PATH, CSS_TEMPLATE_FILE), 'r').read()
+        css = '<style type="text/css">{}</style>'.format(css)
+        head_block = resources['metadata'].get('head_block', '') + css
         resources['metadata']['head_block'] = head_block
 
         # tag this report for traceability, if run from notebook service. these will be transferred

--- a/onecodex/notebooks/exporters.py
+++ b/onecodex/notebooks/exporters.py
@@ -44,8 +44,8 @@ class OneCodexHTMLExporter(HTMLExporter):
         Notes
         -----
         This exporter will only save cells generated with Altair/Vega if they have an SVG image type
-        stored with them. This data is only stored if our fork of `ipyvega` is installed--otherwise,
-        they will be low-resolution PNGs, which will not be exported.
+        stored with them. This data is only stored if our fork of `ipyvega` is installed or the onecodex
+        # renderer is used--otherwise, they will be low-resolution PNGs, which will not be exported.
         """
         nb = copy.deepcopy(nb)
 

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -1,7 +1,3 @@
-"""
-utils.py
-author: @mbiokyle29
-"""
 import base64
 from click import BadParameter, Context, echo
 from functools import wraps

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -85,6 +85,8 @@ class VizBargraphMixin(object):
         else:
             tooltip = []
 
+        tooltip.append("Label")
+
         # takes metadata columns and returns a dataframe with just those columns
         # renames columns in the case where columns are taxids
         magic_metadata, magic_fields = self._metadata_fetch(tooltip)
@@ -93,9 +95,6 @@ class VizBargraphMixin(object):
             df[magic_fields[f]] = magic_metadata[magic_fields[f]][
                 df["classification_id"]
             ].tolist()
-
-        # add sample filenames
-        df["display_name"] = self.metadata["_display_name"][df["classification_id"]].tolist()
 
         # add taxa names
         df["tax_name"] = [
@@ -114,13 +113,13 @@ class VizBargraphMixin(object):
         #
 
         ylabel = self._field if ylabel is None else ylabel
-        xlabel = 'Sample' if xlabel is None else xlabel
+        xlabel = 'Label' if xlabel is None else xlabel
 
         chart = (
             alt.Chart(df)
             .mark_bar()
             .encode(
-                x=alt.X("display_name", axis=alt.Axis(title=xlabel)),
+                x=alt.X("Label", axis=alt.Axis(title=xlabel)),
                 y=alt.Y(self._field, axis=alt.Axis(title=ylabel)),
                 color=alt.Color("tax_name", legend=alt.Legend(title=legend)),
                 tooltip=["{}:Q".format(self._field)] + [magic_fields[f] for f in tooltip],

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -3,53 +3,55 @@ from onecodex.exceptions import OneCodexException
 
 
 class VizBargraphMixin(object):
-    """Plot a bargraph of relative abundance of taxa for multiple samples
-
-    Parameters
-    ----------
-    rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
-        Analysis will be restricted to abundances of taxa at the specified level.
-    normalize : 'auto' or `bool`, optional
-        Convert read counts to relative abundances such that each sample sums to 1.0. Setting
-        'auto' will choose automatically based on the data.
-    return_chart : `bool`, optional
-        When True, return an `altair.Chart` object instead of displaying the resulting plot in
-        the current notebook.
-    top_n : `int`, optional
-        Display the top N most abundant taxa in the entire cohort of samples.
-    threshold : `float`
-        Display only taxa that are more abundant that this threshold in one or more samples.
-    title : `string`, optional
-        Text label at the top of the plot.
-    xlabel : `string`, optional
-        Text label along the horizontal axis.
-    ylabel : `string`, optional
-        Text label along the vertical axis.
-    tooltip : `string` or `list`, optional
-        A string or list containing strings representing metadata fields. When a point in the
-        plot is hovered over, the value of the metadata associated with that sample will be
-        displayed in a modal.
-
-    Examples
-    --------
-    Plot a bargraph of the top 10 most abundant genera
-
-    >>> plot_bargraph(rank='genus', top_n=10)
-    """
-
     def plot_bargraph(
         self,
         rank="auto",
         normalize="auto",
-        threshold="auto",
         top_n="auto",
+        threshold="auto",
         title=None,
         xlabel=None,
         ylabel=None,
         tooltip=None,
         return_chart=False,
+        legend="auto",
     ):
+        """Plot a bargraph of relative abundance of taxa for multiple samples.
 
+        Parameters
+        ----------
+        rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
+            Analysis will be restricted to abundances of taxa at the specified level.
+        normalize : 'auto' or `bool`, optional
+            Convert read counts to relative abundances such that each sample sums to 1.0. Setting
+            'auto' will choose automatically based on the data.
+        return_chart : `bool`, optional
+            When True, return an `altair.Chart` object instead of displaying the resulting plot in
+            the current notebook.
+        top_n : `int`, optional
+            Display the top N most abundant taxa in the entire cohort of samples.
+        threshold : `float`
+            Display only taxa that are more abundant that this threshold in one or more samples.
+        title : `string`, optional
+            Text label at the top of the plot.
+        xlabel : `string`, optional
+            Text label along the horizontal axis.
+        ylabel : `string`, optional
+            Text label along the vertical axis.
+        tooltip : `string` or `list`, optional
+            A string or list containing strings representing metadata fields. When a point in the
+            plot is hovered over, the value of the metadata associated with that sample will be
+            displayed in a modal.
+        legend: `string`, optional
+            Title for color scale. Defaults to the field used to generate the plot, e.g.
+            readcount_w_children or abundance.
+
+        Examples
+        --------
+        Plot a bargraph of the top 10 most abundant genera
+
+        >>> plot_bargraph(rank='genus', top_n=10)
+        """
         if rank is None:
             raise OneCodexException(
                 "Please specify a rank or 'auto' to choose automatically"
@@ -65,6 +67,9 @@ class VizBargraphMixin(object):
             top_n = None
         elif top_n != "auto" and threshold == "auto":
             threshold = None
+
+        if legend == 'auto':
+            legend = self._field
 
         df = self.to_df(
             rank=rank,
@@ -117,7 +122,7 @@ class VizBargraphMixin(object):
             .encode(
                 x=alt.X("display_name", axis=alt.Axis(title=xlabel)),
                 y=alt.Y(self._field, axis=alt.Axis(title=ylabel)),
-                color=alt.Color("tax_name"),
+                color=alt.Color("tax_name", legend=alt.Legend(title=legend)),
                 tooltip=["{}:Q".format(self._field)] + [magic_fields[f] for f in tooltip],
                 href="url:N",
             )

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -42,7 +42,8 @@ class VizHeatmapMixin(object):
             plot is hovered over, the value of the metadata associated with that sample will be
             displayed in a modal.
         legend: `string`, optional
-            Variable to map the color scale to (default is 'abundance')
+            Title for color scale. Defaults to the field used to generate the plot, e.g.
+            readcount_w_children or abundance.
 
         Examples
         --------

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,6 +1,3 @@
-"""
-Unit tests for One Codex
-"""
 from onecodex.lib.auth import check_version
 from onecodex.version import __version__
 

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -346,10 +346,10 @@ def test_html_export(mock_reports, mock_notebook):
     head_block = resources['metadata']['head_block']
 
     # custom date caused suppression of today's date in header
-    assert 'reportdate' not in head_block
+    assert 'id="reportdate"' not in head_block
 
-    # one codex logo is on by default
-    assert 'one_codex_logo.png' in head_block
+    # one codex logo is on by default. this will have to be updated if logo is changed
+    assert 'iVBORw0KGgoAAA' in head_block
 
     # custom CSS injected into head block
     assert '<style type="text/css">h1 { text-align: center; }</style>' in head_block

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,3 @@
-"""
-test_api.py
-author: @mbiokyle29
-"""
 from click import BadParameter
 from functools import partial
 import pytest

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -270,7 +270,7 @@ def test_plot_bargraph_chart_result(ocx, api_data):
     )
 
     assert chart.title == 'Glorious Bargraph'
-    assert chart.encoding.x.shorthand == 'display_name'
+    assert chart.encoding.x.shorthand == 'Label'
     assert chart.encoding.x.axis.title == 'Exemplary Samples'
     assert chart.encoding.y.shorthand == 'readcount_w_children'
     assert chart.encoding.y.axis.title == 'Glorious Abundances'


### PR DESCRIPTION
This PR mostly cleans up docstrings, but also makes the following small changes that I'm sneaking in:

- Embed CSS and One Codex logo in exported HTML reports, rather than use links
- Allow users to override color scale legend in `viz.bargraph`
- Move 'NOT FOR DIAGNOSTIC USE' to center of reports footer by default (overridable with CSS)
- Rename default xlabel in `viz.bargraph` to 'Label' for consistency with rest of viz module