### PR TITLE
Revert check_version removal, improve SampleCollection

### DIFF
--- a/onecodex/models/__init__.py
+++ b/onecodex/models/__init__.py
@@ -63,7 +63,7 @@ class ResourceList(object):
             if len(set(self_ids + other_ids)) != len(self_ids + other_ids):
                 raise OneCodexException('{} cannot contain duplicate objects'.format(self.__class__.__name__))
 
-    def __init__(self, _resource, oc_model):
+    def __init__(self, _resource, oc_model, **kwargs):
         if not issubclass(oc_model, OneCodexBase):
             raise ValueError("Expected object of type '{}', got '{}'"
                              .format(OneCodexBase.__name__, oc_model.__name__))
@@ -71,6 +71,7 @@ class ResourceList(object):
         # turn potion Resource objects into OneCodex objects
         self._resource = _resource
         self._oc_model = oc_model
+        self._kwargs = kwargs
         self._update()
 
     def __eq__(self, other):
@@ -94,7 +95,7 @@ class ResourceList(object):
     def __getitem__(self, x):
         wrapped = self._res_list[x]
         if isinstance(wrapped, list):
-            return self.__class__(self._resource[x], self._oc_model)
+            return self.__class__(self._resource[x], self._oc_model, **self._kwargs)
         else:
             return wrapped
 
@@ -134,7 +135,7 @@ class ResourceList(object):
         self._res_list.clear()
 
     def copy(self):
-        new_obj = self.__class__(self._resource[:], self._oc_model)
+        new_obj = self.__class__(self._resource[:], self._oc_model, **self._kwargs)
         return new_obj
 
     def count(self, x):
@@ -515,12 +516,13 @@ class OneCodexBase(object):
 
 
 from onecodex.models.analysis import Analyses, Classifications, Alignments, Panels  # noqa
+from onecodex.models.collection import SampleCollection  # noqa
 from onecodex.models.misc import Jobs, Projects, Tags, Users, Documents  # noqa
 from onecodex.models.sample import Samples, Metadata  # noqa
 
 
-__all__ = ['Samples', 'Classifications', 'Alignments', 'Panels', 'Jobs', 'Projects', 'Tags',
-           'Users', 'Metadata', 'Documents']
+__all__ = ['Alignments', 'Classifications', 'Documents', 'Jobs', 'Metadata', 'Panels',
+           'Projects', 'Samples', 'SampleCollection', 'Tags', 'Users']
 
 
 def pretty_print_error(err_json):

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -152,7 +152,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
         self._cached['classifications'] = new_classifications
 
     @property
-    def primary_classifications(self):
+    def _classifications(self):
         if 'classifications' not in self._cached:
             self._classification_fetch()
 
@@ -171,7 +171,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
         DEFAULT_FIELDS = None
         metadata = []
 
-        for c in self.primary_classifications:
+        for c in self._classifications:
             m = c.sample.metadata
 
             if DEFAULT_FIELDS is None:
@@ -229,7 +229,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
 
         # we'll fill these dicts that eventually turn into DataFrames
         df = {
-            'classification_id': [c.id for c in self.primary_classifications]
+            'classification_id': [c.id for c in self._classifications]
         }
 
         tax_info = {
@@ -244,7 +244,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
 
         self._cached['field'] = field
 
-        for c_idx, c in enumerate(self.primary_classifications):
+        for c_idx, c in enumerate(self._classifications):
             # pulling results from mainline is the slowest part of the function
             result = c.results()['table']
 
@@ -257,7 +257,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
                         tax_info[k].append(d[k])
 
                     # first time we've seen this taxon, so make a vector for it
-                    df[d_tax_id] = [0] * len(self.primary_classifications)
+                    df[d_tax_id] = [0] * len(self._classifications)
 
                 df[d_tax_id][c_idx] = d[field]
 
@@ -328,7 +328,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
         rows = defaultdict(dict)
 
         tax_ids_to_names = {}
-        for classification in self.primary_classifications:
+        for classification in self._classifications:
             col_id = len(otu['columns'])  # 0 index
 
             # Re-encoding the JSON is a bit of a hack, but

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -82,6 +82,36 @@ class SampleCollection(ResourceList, AnalysisMixin):
         self._kwargs = {'skip_missing': skip_missing, 'field': field}
         super(SampleCollection, self).__init__(resources, model, **self._kwargs)
 
+    def filter(self, filter_func):
+        """Return a new SampleCollection containing only samples meeting the filter criteria.
+
+        Will pass any kwargs (e.g., field or skip_missing) used when instantiating the current class
+        on to the new SampleCollection that is returned.
+
+        Parameters
+        ----------
+        filter_func : `callable`
+            A function that will be evaluated on every object in the collection. The function must
+            return a `bool`. If True, the object will be kept. If False, it will be removed from the
+            SampleCollection that is returned.
+
+        Returns
+        -------
+        `onecodex.models.SampleCollection` containing only objects `filter_func` returned True on.
+
+        Examples
+        --------
+        Generate a new collection of Samples that have a specific filename extension:
+
+            new_collection = samples.filter(lambda s: s.filename.endswith('.fastq.gz'))
+        """
+        if callable(filter_func):
+            return self.__class__([obj for obj in self if filter_func(obj) is True], **self._kwargs)
+        else:
+            raise OneCodexException(
+                'Expected callable for filter, got: {}'.format(type(filter_func).__name__)
+            )
+
     def _update(self):
         self._cached = {}
         super(SampleCollection, self)._update()

--- a/onecodex/models/sample.py
+++ b/onecodex/models/sample.py
@@ -107,7 +107,7 @@ class Samples(OneCodexBase, ResourceDownloadMixin):
             # TODO: implement this (see above block)
             samples = metadata_samples
 
-        return SampleCollection([w._resource for w in samples[:limit]], Samples)
+        return SampleCollection([s._resource for s in samples[:limit]], Samples)
 
     @classmethod
     def search_public(cls, *filters, **keyword_filters):

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -154,6 +154,12 @@ def test_samplecollection(ocx, api_data):
         onecodex.models.SampleCollection([s._resource for s in all_samples[:7]])
     assert 'can only contain' in str(e.value)
 
+    # test filtering of Samples in a collection
+    new_collection = all_samples.filter(lambda s: s.filename.endswith('9.fastq.gz'))
+    assert all([s.filename.endswith('9.fastq.gz') for s in new_collection])
+    assert len(new_collection) == 7
+    assert id(new_collection) != id(all_samples)
+
 
 def test_dir_method(ocx, api_data):
     sample = ocx.Samples.get('761bc54b97f64980')
@@ -304,6 +310,17 @@ def test_where_clauses_with_tags(ocx, api_data):
         query_in_urls.append(query in url)
 
     assert any(query_in_urls)
+
+
+def test_where_filter(ocx, api_data):
+    samples = ocx.Samples.where(filter=lambda s: s.filename.endswith('9.fastq.gz'))
+    assert all([s.filename.endswith('9.fastq.gz') for s in samples])
+    assert len(samples) == 7
+
+    # filter kwarg must be callable
+    with pytest.raises(OneCodexException) as e:
+        ocx.Samples.where(filter='not_callable')
+    assert 'Expected callable' in str(e.value)
 
 
 def test_where_primary_classification(ocx, api_data):

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -136,6 +136,24 @@ def test_samplecollection(ocx, api_data):
         samples + single_sample
     assert 'can only concatenate' in str(e.value)
 
+    # you can make a new SampleCollection from a list of Samples
+    onecodex.models.SampleCollection([s for s in all_samples[:7]])
+
+    # and from a list of Classifications
+    onecodex.models.SampleCollection([s.primary_classification for s in all_samples[:7]])
+
+    # but not a combination of both
+    with pytest.raises(OneCodexException) as e:
+        onecodex.models.SampleCollection(
+            [s.primary_classification for s in all_samples[:3]] + [s for s in all_samples[4:7]]
+        )
+    assert 'but not both' in str(e.value)
+
+    # and not using unwrapped potion resources
+    with pytest.raises(OneCodexException) as e:
+        onecodex.models.SampleCollection([s._resource for s in all_samples[:7]])
+    assert 'can only contain' in str(e.value)
+
 
 def test_dir_method(ocx, api_data):
     sample = ocx.Samples.get('761bc54b97f64980')

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,8 @@
+import pytest
 from requests.auth import HTTPBasicAuth
 
 from onecodex import Api
-from onecodex.lib.auth import BearerTokenAuth
+from onecodex.lib.auth import BearerTokenAuth, check_version
 
 
 def test_bearer_auth_from_env(api_data, monkeypatch):
@@ -26,3 +27,25 @@ def test_bearer_auth_from_kwargs(api_data):
 def test_api_key_auth_from_kwargs(api_data):
     ocx = Api(api_key='mysecretkey', base_url='http://localhost:3000', cache_schema=True)
     assert isinstance(ocx._req_args['auth'], HTTPBasicAuth)
+
+
+@pytest.mark.parametrize('client_version,server_version,requires_update', [
+    ('0.1.3', '0.1.3', False),
+    ('0.1.4', '0.1.3', False),
+    ('0.1.3', '0.1.4', True),
+    ('0.2.3', '0.10.4', True),
+])
+def test_check_version(client_version, server_version, requires_update):
+    from tests.conftest import mock_requests
+
+    json_data = {
+        "POST::api/v0/check_for_cli_update": {
+            "latest_version": server_version
+        },
+    }
+
+    server = "http://localhost:3000/"
+
+    with mock_requests(json_data):
+        result, error_code = check_version(client_version, server)
+        assert result == requires_update

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -64,8 +64,8 @@ def test_classification_fetch(ocx, api_data):
 
     # should work with a list of classifications as input, not just samples
     samples._oc_model = ocx.Classifications
-    samples._res_list = samples.primary_classifications
-    samples._resource = [x._resource for x in samples.primary_classifications]
+    samples._res_list = samples._classifications
+    samples._resource = [x._resource for x in samples._classifications]
     samples._classification_fetch()
 
     # should issue a warning if a classification did not succeed


### PR DESCRIPTION
This PR includes the following:

- Reverts prior commit that removed `check_version()` code, as we are keeping that route in the API and maintaining it indefinitely
- Allows users to create new SampleCollections by passing in an iterable containing Samples
- #226 Add a new `SampleCollection.filter` method and `Samples.where(filter=)` kwarg allowing users to filter samples based on the outcome of function
- Fixed a bug (no issue) where slices of a SampleCollection instantiated with a custom `field` or `skip_missing` kwarg would lose those and take on the default params