### PR TITLE
Fix Samples.where() query when no metadata matches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	py.test --ignore tests/test_minimal.py tests/
+	py.test -W ignore::DeprecationWarning --ignore tests/test_minimal.py tests/
 	@echo "Successfully passed all tests (one environment only, use tox to full suite)."
 
 lint:
@@ -9,10 +9,10 @@ lint:
 	@echo "Successfully linted all files."
 
 coverage:
-	py.test --cov-report=term-missing --cov=onecodex --ignore tests/test_minimal.py tests/
+	py.test -W ignore::DeprecationWarning --cov-report=term-missing --cov=onecodex --ignore tests/test_minimal.py tests/
 
 coveragehtml:
-	py.test --cov-report=html --cov=onecodex --ignore tests/test_minimal.py tests/
+	py.test -W ignore::DeprecationWarning --cov-report=html --cov=onecodex --ignore tests/test_minimal.py tests/
 
 install:
 	python setup.py install

--- a/onecodex/viz/__init__.py
+++ b/onecodex/viz/__init__.py
@@ -84,10 +84,10 @@ var output_area = this;
 requirejs.config({{
   baseUrl: '{cdn}',
   paths: {{
-    "vega-embed":  "vega-embed@3?noext",
-    "vega-lib": "vega-lib?noext",
-    "vega-lite": "vega-lite@2?noext",
-    "vega": "vega@3?noext"
+    "vega-embed":  "vega-embed@4?noext",
+    "vega-lib": "vega-lib@4?noext",
+    "vega-lite": "vega-lite@3?noext",
+    "vega": "vega@5?noext"
   }}
 }});
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     extras_require={
         ':python_version == "2.7"': ["futures"],
         'all': [
-            'altair==2.3.0',
+            'altair==3.0.1',
             'networkx>=1.11,<2.0',
             'numpy>=1.11.0',
             'pandas>=0.23.0',


### PR DESCRIPTION
This PR addresses #252 by changing the logic behind taking the intersection of querying `Samples` by `Metadata` and other filters/keyword_filters.