### PR TITLE
File pairing bug and ClassificationsDataFrame bug

### DIFF
--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -374,6 +374,13 @@ def upload(
         paired_files = []
         single_files = set(files)
 
+        if single_files.symmetric_difference(files):
+            click.echo(
+                "Duplicate filenames detected in command line--please specific each file only once",
+                err=True,
+            )
+            ctx.exit(1)
+
         for filename in files:
             # convert "read 1" filenames into "read 2" and check that they exist; if they do
             # upload the files as a pair, autointerleaving them

--- a/onecodex/dataframes.py
+++ b/onecodex/dataframes.py
@@ -97,7 +97,7 @@ class ClassificationsDataFrame(pd.DataFrame):
         kwargs["max_cols"] = 10
 
         # round abundances to avoid long trails of zeros, and sort taxa in order of abundance
-        if "classification_id" in self.columns:
+        if "classification_id" in self.columns and "tax_id" in self.columns:
             # long format
             df = self.copy()
             df[self.ocx_field] = df[self.ocx_field].round(6)


### PR DESCRIPTION
This PR closes the following issues:

#266 - Catches when users specify the same filename on the command line more than once and raise
#268 - Detect long format data frames better to avoid issue where `reset_index()` moves `classification_id` into `DataFrame.columns`