### PR TITLE
Allow user to turn off saving (uploading) SVGs/PNGs in notebooks

### DIFF
--- a/onecodex/viz/__init__.py
+++ b/onecodex/viz/__init__.py
@@ -1,7 +1,9 @@
 import altair as alt
+from functools import partial
 import json
 import uuid
 
+from onecodex.exceptions import OneCodexException
 from onecodex.viz._heatmap import VizHeatmapMixin
 from onecodex.viz._pca import VizPCAMixin
 from onecodex.viz._primitives import dendrogram, boxplot
@@ -40,7 +42,10 @@ def onecodex_theme():
     }
 
 
-def onecodex_renderer(spec, **metadata):
+def onecodex_renderer(spec, png=None, svg=None, save_json=None, **metadata):
+    if png is None or svg is None or save_json is None:
+        raise OneCodexException("One Codex Vega renderer is not properly configured")
+
     # see https://github.com/vega/vega-embed/issues/8
     vega_js = """
 // store the vega spec in an element unique to this figure. can't rely on `element` being the
@@ -108,51 +113,102 @@ require(["vega-embed"], function(vegaEmbed) {{
     defaultStyle: true,
     loader: {{ target: "_blank", http: {{ credentials: "same-origin" }} }},
     mode: "vega-lite"
-  }})
-    .then(result => {{
-      const imageData = result.view
-        .toSVG()
-        .then(imageData => {{
-          if (output_area !== undefined && output_area.outputs !== undefined) {{
-            // figure out which output cell belongs to this render block. there may be
-            // multiple jupyter-vega cells per input cell, but only one will match our id
-            for (const cell_num in output_area.outputs) {{
-              let cell = output_area.outputs[cell_num];
-              if (cell.metadata && cell.metadata["jupyter-vega"] === "#{id}") {{
-                output_area.outputs[cell_num]["data"]["image/svg+xml"] = imageData;
-              }}
-            }}
-          }}
-        }})
-        .catch(error => showError(out_target, error));
-    }})
-    .catch(error => showError(out_target, error));
+  }}){image_save_js}.catch(error => showError(out_target, error));
 }}, function (err) {{
   if (err.requireType !== "scripterror") {{
     throw(err);
   }}
 }});
     """
-    el_uuid = uuid.uuid4().hex
+
+    image_save_js = """
+.then(result => {{
+    const imageData = result.view.{image_save_func}.then(imageData => {{
+      if (output_area !== undefined && output_area.outputs !== undefined) {{
+        // figure out which output cell belongs to this render block. there may be
+        // multiple jupyter-vega cells per input cell, but only one will match our id
+        for (const cell_num in output_area.outputs) {{
+          let cell = output_area.outputs[cell_num];
+          if (cell.metadata && cell.metadata["jupyter-vega"] === "#{id}") {{
+            output_area.outputs[cell_num]["data"]["{image_mime_type}"] = imageData;
+          }}
+        }}
+      }}
+    }}).catch(error => showError(out_target, error));
+  }})
+"""
+    element_uuid = uuid.uuid4().hex
 
     # CSS selector ids cannot start with numbers. if ours does, rename it
-    if el_uuid[0] in map(str, range(10)):
-        el_uuid = "a" + el_uuid[1:]
+    if element_uuid[0] in map(str, range(10)):
+        element_uuid = "a" + element_uuid[1:]
 
-    return (
-        {
-            "application/javascript": vega_js.format(
-                id=el_uuid, spec=json.dumps(spec), cdn=ONE_CODEX_VEGA_CDN
-            ),
-            "application/vnd.vegalite.v2+json": json.dumps(spec),
-        },
-        {"jupyter-vega": "#{0}".format(el_uuid)},
-    )
+    # figure out what to call to save SVG/PNGs
+    if svg:
+        image_save_func = "toSVG()"
+        image_mime_type = "image/svg+xml"
+
+    if png:
+        image_save_func = "toImageURL('png')"
+        image_mime_type = "image/png"
+
+    if svg or png:
+        image_save_js = image_save_js.format(
+            id=element_uuid, image_save_func=image_save_func, image_mime_type=image_mime_type
+        )
+    else:
+        image_save_js = ""
+
+    ret_metadata = {"jupyter-vega": "#{0}".format(element_uuid)}
+    ret_dict = {
+        "application/javascript": vega_js.format(
+            id=element_uuid,
+            spec=json.dumps(spec),
+            cdn=ONE_CODEX_VEGA_CDN,
+            image_save_js=image_save_js,
+        )
+    }
+
+    if save_json:
+        ret_dict["application/vnd.vegalite.v2+json"] = json.dumps(spec)
+
+    return (ret_dict, ret_metadata)
+
+
+def renderer_settings(svg_or_png=None, save_json=True, enable=True):
+    """Change behavior of Vega/Altair renderer in IPython notebook for this session.
+
+    Parameters
+    ----------
+    svg_or_png : `str` in {"png", "svg"} or `False` to disable saving images
+        Save rendered image in PNG or SVG format in an output cell. Defaults to "svg"
+    save_json : `bool`
+        Store Altair-generated JSON in output cell.
+    enable : `bool`
+        If True, after updating renderer settings, will enable the renderer. If False, user must
+        call `altair.renderers.enable("onecodex")` before changes will take effect.
+    """
+    svg = png = False
+
+    if svg_or_png is None or svg_or_png == "svg":
+        svg = True
+    elif svg_or_png == "png":
+        png = True
+    elif svg_or_png is False:
+        pass
+    else:
+        raise OneCodexException("svg_or_png kwarg must be one of: png, svg")
+
+    renderer = partial(onecodex_renderer, svg=svg, png=png, save_json=save_json)
+    alt.renderers.register("onecodex", renderer)
+
+    if enable:
+        alt.renderers.enable("onecodex")
 
 
 alt.themes.register("onecodex", onecodex_theme)
 alt.themes.enable("onecodex")
-alt.renderers.register("onecodex", onecodex_renderer)
+renderer_settings(enable=False)
 
 
 try:

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -333,7 +333,7 @@ def test_html_export(mock_reports, mock_notebook):
 
     # svg gets encoded for embedding in HTML
     assert (
-        output.cells[0]["outputs"][0]["data"]["image/svg+xml"]
+        output.cells[0]["outputs"][0]["data"]["text/html"]
         == '<img src="data:image/svg+xml;charset=utf-8;base64,MTIzNDU2Nzg5MA==">'
     )
 
@@ -379,7 +379,7 @@ def test_pdf_export(mock_reports, mock_notebook):
     output, resources = obj.from_notebook_node(mock_notebook)
 
     # not much to do here without actually importing weasyprint
-    assert len(output) == 609
+    assert len(output) == 605
 
 
 def test_doc_portal_export():


### PR DESCRIPTION
This PR addresses an issue with large notebooks in the notebook service. Rendered images have to be uploaded back to the notebook service to save a `.ipynb` and this can hang indefinitely and/or result in partially saved/exported notebooks.

```python
from onecodex.viz import renderer_settings

# disable saving images to notebooks
renderer_settings(png_or_svg=False)
```

Users can switch between PNGs (smaller), SVGs, or saving no images using this new settings function. If no images are saved, they will be rendered on the server using node and the `vega-cli` package.