### PR TITLE
Bump Altair version to 3.1.0

### DIFF
--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -153,7 +153,7 @@ class VizMetadataMixin(object):
                     sort=sort_x(df[magic_fields[haxis]].tolist()) if sort_x else None,
                 ),
                 y=alt.Y(magic_fields[vaxis], axis=alt.Axis(title=ylabel)),
-                tooltip=["Label", "{}:Q".format(vaxis)],
+                tooltip=["Label", "{}:Q".format(magic_fields[vaxis])],
                 href="url:N",
                 url="https://app.onecodex.com/classification/" + alt.datum.classification_id,
             )

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     extras_require={
         ':python_version == "2.7"': ["futures"],
         'all': [
-            'altair==3.0.1',
+            'altair==3.1.0',
             'networkx>=1.11,<2.0',
             'numpy>=1.11.0',
             'pandas>=0.23.0',


### PR DESCRIPTION
This PR bumps our Altair version to 3.1.0, closing #269.