### PR TITLE
Switch to a single namespaced logger for both CLI and API

### DIFF
--- a/onecodex/__init__.py
+++ b/onecodex/__init__.py
@@ -1,10 +1,15 @@
 import logging
+import sys
 
 __all__ = ["Api"]
 
-log = logging.getLogger(__name__)
-log.setLevel(logging.WARN)
-log_formatter = logging.Formatter("%(asctime)s {%(levelname)s}: %(message)s")
+formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+stream_handler = logging.StreamHandler(sys.stderr)
+stream_handler.setFormatter(formatter)
+
+log = logging.getLogger("onecodex")
+log.setLevel(logging.INFO)
+log.addHandler(stream_handler)
 
 from onecodex.api import Api  # noqa
 from onecodex.cli import onecodex as Cli  # noqa

--- a/onecodex/api.py
+++ b/onecodex/api.py
@@ -22,7 +22,7 @@ from onecodex.vendored.potion_client.utils import upper_camel_case
 from onecodex.version import __version__
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger("onecodex")
 
 
 class Api(object):

--- a/onecodex/auth.py
+++ b/onecodex/auth.py
@@ -14,7 +14,7 @@ from onecodex.utils import collapse_user
 from onecodex.version import __version__
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger("onecodex")
 DATE_FORMAT = "%Y-%m-%d %H:%M"
 API_KEY_LEN = 32
 

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -5,7 +5,6 @@ import dateutil
 import logging
 import os
 import re
-import sys
 import time
 import warnings
 
@@ -33,16 +32,7 @@ from onecodex.version import __version__
 
 # set the context for getting -h also
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
-
-# Modify the root logger directly
-log = logging.getLogger()
-log.setLevel(logging.INFO)
-
-# Setup log formatter. TODO: Evaluate click-log instead
-log_formatter = CliLogFormatter()
-stream_handler = logging.StreamHandler(sys.stderr)
-stream_handler.setFormatter(log_formatter)
-log.addHandler(stream_handler)
+log = logging.getLogger("onecodex")
 
 
 def warning_msg(message, category, filename, lineno, file=None, line=None):
@@ -67,6 +57,11 @@ warnings.showwarning = warning_msg
 @telemetry
 def onecodex(ctx, api_key, no_pprint, verbose, telemetry):
     """One Codex v1 API command line interface"""
+    # Setup log formatter. TODO: Evaluate click-log instead
+    log_formatter = CliLogFormatter()
+    log.setLevel(logging.INFO)
+    log.handlers[0].setFormatter(log_formatter)
+
     # set up the context for sub commands
     click.Context.get_usage = click.Context.get_help
     ctx.obj = {}

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -26,8 +26,7 @@ from onecodex.exceptions import OneCodexException, UploadException
 from onecodex.version import __version__
 
 
-log = logging.getLogger(__name__)
-cli_log = logging.getLogger("onecodex.cli")
+log = logging.getLogger("onecodex")
 
 OPTION_HELP = {
     "api_key": "Manually provide a One Codex API key",
@@ -147,13 +146,13 @@ def cli_resource_fetcher(ctx, resource, uris, print_results=True):
         if len(uris) == 0:
 
             # if non given fetch all
-            cli_log.debug("No %s IDs given, fetching all...", resource_name)
+            log.debug("No %s IDs given, fetching all...", resource_name)
             instances = getattr(ctx.obj["API"], resource_name).all()
-            cli_log.debug("Fetched %i %ss", len(instances), resource)
+            log.debug("Fetched %i %ss", len(instances), resource)
             objs_to_return = [x._resource._properties for x in instances]
         else:
             uris = list(set(uris))
-            cli_log.debug("Fetching %s: %s", resource_name, ",".join(uris))
+            log.debug("Fetching %s: %s", resource_name, ",".join(uris))
 
             instances = []
             for uri in uris:
@@ -162,11 +161,11 @@ def cli_resource_fetcher(ctx, resource, uris, print_results=True):
                     if instance is not None:
                         instances.append(instance._resource._properties)
                     else:
-                        cli_log.error(
+                        log.error(
                             "Could not find {} {} (404 status code)".format(resource_name, uri)
                         )
                 except requests.exceptions.HTTPError as e:
-                    cli_log.error(
+                    log.error(
                         "Could not find %s %s (%d status code)".format(
                             resource_name, uri, e.response.status_code
                         )
@@ -229,7 +228,7 @@ def warn_if_insecure_platform():
         click.echo(m, err=True)
         return True
     else:
-        cli_log.debug("Python SSLContext passed")
+        log.debug("Python SSLContext passed")
         return False
 
 
@@ -248,7 +247,7 @@ def download_file_helper(url, input_path):
     """
     r = requests.get(url, stream=True)
     if r.status_code != 200:
-        cli_log.error("Failed to download file: %s" % r.json()["message"])
+        log.error("Failed to download file: %s" % r.json()["message"])
     local_full_path = get_download_dest(input_path, r.url)
     original_filename = os.path.split(local_full_path)[-1]
     with open(local_full_path, "wb") as f:

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     extras_require={
         ':python_version == "2.7"': ["futures"],
         'all': [
-            'altair==3.0.1',
+            'altair==3.1.0',
             'networkx>=1.11,<2.0',
             'numpy>=1.11.0',
             'pandas>=0.23.0',


### PR DESCRIPTION
This PR closes #254 by using the `onecodex` namespaced logger throughout the library. We switch the format of the log to one without timestamps in `cli.py`, and only when actually executed from the command line (not at import time).