### PR TITLE
Add support for experimental models

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default: false  # disable the default status that measures entire project
+      onecodex:
+        paths: "onecodex/"
+        threshold: 2.5%
+    patch:
+      default:
+        target: 0%
+
+ignore:
+  - "onecodex/vendored/"

--- a/onecodex/api.py
+++ b/onecodex/api.py
@@ -36,6 +36,7 @@ class Api(object):
         base_url=None,
         telemetry=None,
         schema_path="/api/v1/schema",
+        **kwargs
     ):
 
         if base_url is None:
@@ -43,8 +44,12 @@ class Api(object):
             if base_url != "https://app.onecodex.com":
                 warnings.warn("Using base API URL: {}".format(base_url))
 
-        if schema_path != "/api/v1/schema":
-            warnings.warn("Using schema path: {}".format(schema_path))
+        if kwargs.get("experimental", False):
+            warnings.warn(
+                "Experimental API mode enabled. Features of the experimental API are subject to "
+                "change without notice and should not be relied upon in a production enviroment."
+            )
+            schema_path = "/api/v1_experimental/schema"
 
         self._req_args = {}
         self._base_url = base_url

--- a/onecodex/api.py
+++ b/onecodex/api.py
@@ -43,6 +43,9 @@ class Api(object):
             if base_url != "https://app.onecodex.com":
                 warnings.warn("Using base API URL: {}".format(base_url))
 
+        if schema_path != "/api/v1/schema":
+            warnings.warn("Using schema path: {}".format(schema_path))
+
         self._req_args = {}
         self._base_url = base_url
         self._schema_path = schema_path
@@ -122,12 +125,30 @@ class Api(object):
         return os.environ.get("ONE_CODEX_USER_EMAIL", os.environ.get("ONE_CODEX_USER_UUID"))
 
     def _copy_resources(self):
-        """
-        Copy all of the resources over to the toplevel client
+        """Copies available subclassed potion resources (e.g., onecodex.models.Samples) into this
+        instance of Api().
 
-        -return: populates self with a pointer to each ._client.Resource
+        Notes
+        -----
+        Will only make available any objects that were listed in the REST API schema, either cached
+        or retrieved from the server. If a non-standard schema_path was given, make sure we match
+        e.g., /api/v1_experimental/samples up with /api/v1/samples.
+
+        Returns
+        -------
+        `None`
         """
         from onecodex.models import _model_lookup
+
+        if self._schema_path != "/api/v1/schema":
+            new_schema_base = self._schema_path.rstrip("schema")
+
+            aliased_resources = {}
+
+            for resource, oc_cls in _model_lookup.items():
+                aliased_resources[resource.replace("/api/v1/", new_schema_base)] = oc_cls
+
+            _model_lookup.update(aliased_resources)
 
         for resource in self._client._resources:
             # set the name param, the keys now have / in them

--- a/onecodex/models/__init__.py
+++ b/onecodex/models/__init__.py
@@ -580,8 +580,8 @@ __all__ = [
     "Users",
 ]
 
-# import and expose experimental darwin models
-from onecodex.models.darwin import AnnotationSets, Assemblies, Genomes, Taxa  # noqa
+# import and expose experimental models
+from onecodex.models.experimental import AnnotationSets, Assemblies, Genomes, Taxa  # noqa
 
 __all__.extend(["AnnotationSets", "Assemblies", "Genomes", "Taxa"])
 

--- a/onecodex/models/__init__.py
+++ b/onecodex/models/__init__.py
@@ -580,6 +580,11 @@ __all__ = [
     "Users",
 ]
 
+# import and expose experimental darwin models
+from onecodex.models.darwin import AnnotationSets, Assemblies, Genomes, Taxa  # noqa
+
+__all__.extend(["AnnotationSets", "Assemblies", "Genomes", "Taxa"])
+
 
 def pretty_print_error(err_json):
     """Pretty print Flask-Potion error messages for the user."""

--- a/onecodex/models/darwin.py
+++ b/onecodex/models/darwin.py
@@ -1,0 +1,101 @@
+from onecodex.models import OneCodexBase, ResourceList
+from onecodex.models.helpers import ResourceDownloadMixin
+
+
+class AnnotationSets(OneCodexBase, ResourceDownloadMixin):
+    _resource_path = "/api/v1/annotation_sets"
+
+    def download(self, path=None, file_obj=None, progressbar=False):
+        """Downloads an AnnotationSet in GenBank format.
+
+        Parameters
+        ----------
+        path : `string`, optional
+            Full path to save the file to. If omitted, defaults to the original filename
+            in the current working directory.
+        file_obj : file-like object, optional
+            Rather than save the file to a path, write it to this file-like object.
+        progressbar : `bool`
+            Display a progress bar using Click for the download?
+
+        Returns
+        -------
+        `string`
+            The path the file was downloaded to, if applicable. Otherwise, None.
+
+        Notes
+        -----
+        If no arguments specified, defaults to download the file as the original filename
+        in the current working directory. If `file_obj` given, will write data into the
+        passed file-like object. If `path` given, will download the file to the path provided,
+        but will not overwrite any existing files.
+        """
+        return self._download(
+            "download_uri",
+            "annotation_set_" + self.id + ".gbk.gz",
+            use_potion_session=False,
+            path=path,
+            file_obj=file_obj,
+            progressbar=progressbar,
+        )
+
+    def download_csv(self, path=None, file_obj=None, progressbar=False):
+        """Downloads an AnnotationSet in CSV format, including Annotation coordinates and sequences
+        in both amino acid and nucleotide space.
+
+        Parameters
+        ----------
+        path : `string`, optional
+            Full path to save the file to. If omitted, defaults to the original filename
+            in the current working directory.
+        file_obj : file-like object, optional
+            Rather than save the file to a path, write it to this file-like object.
+        progressbar : `bool`
+            Display a progress bar using Click for the download?
+
+        Returns
+        -------
+        `string`
+            The path the file was downloaded to, if applicable. Otherwise, None.
+
+        Notes
+        -----
+        If no arguments specified, defaults to download the file as the original filename
+        in the current working directory. If `file_obj` given, will write data into the
+        passed file-like object. If `path` given, will download the file to the path provided,
+        but will not overwrite any existing files.
+        """
+        return self._download(
+            "download_csv",
+            "annotation_set_" + self.id + ".csv",
+            use_potion_session=True,
+            path=path,
+            file_obj=file_obj,
+            progressbar=progressbar,
+        )
+
+
+class Assemblies(OneCodexBase, ResourceDownloadMixin):
+    _resource_path = "/api/v1/assemblies"
+
+
+class Genomes(OneCodexBase):
+    _resource_path = "/api/v1/genomes"
+
+    def __repr__(self):
+        return "<Genome {} {} ({})>".format(self.id, self.taxon.name, self.name)
+
+
+class Taxa(OneCodexBase):
+    _resource_path = "/api/v1/taxa"
+
+    def __repr__(self):
+        return "<Taxa {} {} ({})>".format(self.taxon_id, self.name, self.rank)
+
+    def genomes(self):
+        """Returns a list of all Genomes belonging to descendants of this Taxon."""
+        return ResourceList(self._resource.genomes(), Genomes)
+
+    def parents(self):
+        """Returns a list of all parents of this Taxon, at all ranks."""
+        return ResourceList(self._resource.parents(), Taxa)

--- a/onecodex/models/experimental.py
+++ b/onecodex/models/experimental.py
@@ -3,7 +3,7 @@ from onecodex.models.helpers import ResourceDownloadMixin
 
 
 class AnnotationSets(OneCodexBase, ResourceDownloadMixin):
-    _resource_path = "/api/v1/annotation_sets"
+    _resource_path = "/api/v1_experimental/annotation_sets"
 
     def download(self, path=None, file_obj=None, progressbar=False):
         """Downloads an AnnotationSet in GenBank format.
@@ -76,18 +76,18 @@ class AnnotationSets(OneCodexBase, ResourceDownloadMixin):
 
 
 class Assemblies(OneCodexBase, ResourceDownloadMixin):
-    _resource_path = "/api/v1/assemblies"
+    _resource_path = "/api/v1_experimental/assemblies"
 
 
 class Genomes(OneCodexBase):
-    _resource_path = "/api/v1/genomes"
+    _resource_path = "/api/v1_experimental/genomes"
 
     def __repr__(self):
         return "<Genome {} {} ({})>".format(self.id, self.taxon.name, self.name)
 
 
 class Taxa(OneCodexBase):
-    _resource_path = "/api/v1/taxa"
+    _resource_path = "/api/v1_experimental/taxa"
 
     def __repr__(self):
         return "<Taxa {} {} ({})>".format(self.taxon_id, self.name, self.rank)


### PR DESCRIPTION
This PR enables access to `AnnotationSet`, `Assembly`, `Genome` and `Taxon` models when the appropriate kwarg is passed to `Api()`