### PR TITLE
Add import time speed tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ version: 2
 jobs:
   test-py3:
     docker:
-      - image: circleci/python:3.6.7-stretch
+      - image: circleci/python:3.7-stretch
     steps:
       - checkout
       - run:
@@ -31,7 +31,7 @@ jobs:
             py.test -v -W ignore::DeprecationWarning tests/
   test-py2:
     docker:
-      - image: circleci/python:2.7.15-stretch
+      - image: circleci/python:2.7-stretch
     steps:
       - checkout
       - run:
@@ -66,7 +66,7 @@ jobs:
             py.test -v -W ignore::DeprecationWarning tests/
   test-simplejson:
     docker:
-      - image: circleci/python:3.6.7-stretch
+      - image: circleci/python:3.7-stretch
     steps:
       - checkout
       - run:
@@ -85,7 +85,7 @@ jobs:
             py.test -v -W ignore::DeprecationWarning tests/
   lint:
     docker:
-      - image: circleci/python:3.6.7-stretch
+      - image: circleci/python:3.7-stretch
     steps:
       - checkout
       - run:
@@ -103,7 +103,7 @@ jobs:
             make lint
   coverage:
     docker:
-      - image: circleci/python:3.6.7-stretch
+      - image: circleci/python:3.7-stretch
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ workflows:
   all-tests:
     jobs:
       - test-py3
+      - test-import-times
       - test-py2
       - test-minimal
       - test-simplejson
@@ -28,7 +29,31 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            py.test -v -W ignore::DeprecationWarning tests/
+            py.test -v -W ignore::DeprecationWarning --ignore tests/test_speed.py tests/
+  test-import-times:
+    docker:
+      - image: circleci/python:3.7-stretch
+    steps:
+      - checkout
+      - run:
+          name: Install Python deps in virtual environment
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -q -U pip
+            pip install --progress-bar=off numpy tuna
+            pip install --progress-bar=off .[all,testing]
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            py.test -v tests/test_speed.py
+            python -X importtime -c 'import onecodex; onecodex.cli.onecodex()' 2> import.log
+            mkdir tuna && mkdir tuna/static
+            tuna -o tuna/ import.log
+      - store_artifacts:
+          path: tuna/
+          prefix: tuna
   test-py2:
     docker:
       - image: circleci/python:2.7-stretch
@@ -82,7 +107,7 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            py.test -v -W ignore::DeprecationWarning tests/
+            py.test -v -W ignore::DeprecationWarning --ignore tests/test_speed.py tests/
   lint:
     docker:
       - image: circleci/python:3.7-stretch
@@ -118,6 +143,6 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            py.test -v -W ignore::DeprecationWarning --cov-report=html --cov=onecodex tests/
+            py.test -v -W ignore::DeprecationWarning --ignore tests/test_speed.py tests/
             codecov
 

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -13,8 +13,8 @@ import pytest
     [
         # Fast imports
         ("import onecodex", {"onecodex": 0.25}, 0.25),
-        ("from onecodex import Cli", {"onecodex": 0.25, "onecodex.cli": 0.05}, 0.25),
-        ("from onecodex import Api", {"onecodex": 0.25, "onecodex.api": 0.10}, 0.25),
+        ("from onecodex import Cli", {"onecodex": 0.25, "onecodex.cli": 0.20}, 0.25),
+        ("from onecodex import Api", {"onecodex": 0.25, "onecodex.api": 0.20}, 0.25),
         # Full startup of the CLI (prints help message)
         ("import onecodex; onecodex.cli.onecodex()", {"onecodex": 0.25}, 0.25),
         # Our slow imports should be lazy and still import fast
@@ -22,16 +22,16 @@ import pytest
             "from onecodex.viz import VizPCAMixin",
             {
                 "onecodex": 0.25,
-                "onecodex.viz": 0.75,  # TODO: Get this time down
+                "onecodex.viz": 1.00,  # TODO: Get this time down
                 "onecodex.viz._pca": 0.01,
                 "onecodex.viz._distance": 0.01,
             },
-            0.75,
+            1.00,
         ),
         (
             "from onecodex.analyses import AnalysisMixin",
-            {"onecodex": 0.25, "onecodex.analyses": 0.75},
-            0.75,
+            {"onecodex": 0.25, "onecodex.analyses": 1.00},
+            1.00,
         ),
     ],
 )

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -1,0 +1,81 @@
+# Test import speed of the module. This is important as it affects click auto-complete
+# and our general CLI startup time.
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
+@pytest.mark.parametrize(
+    "import_command,package_max_import_times,total_time_secs",
+    [
+        # Fast imports
+        ("import onecodex", {"onecodex": 0.25}, 0.25),
+        ("from onecodex import Cli", {"onecodex": 0.25, "onecodex.cli": 0.05}, 0.25),
+        ("from onecodex import Api", {"onecodex": 0.25, "onecodex.api": 0.10}, 0.25),
+        # Full startup of the CLI (prints help message)
+        ("import onecodex; onecodex.cli.onecodex()", {"onecodex": 0.25}, 0.25),
+        # Our slow imports should be lazy and still import fast
+        (
+            "from onecodex.viz import VizPCAMixin",
+            {
+                "onecodex": 0.25,
+                "onecodex.viz": 0.75,  # TODO: Get this time down
+                "onecodex.viz._pca": 0.01,
+                "onecodex.viz._distance": 0.01,
+            },
+            0.75,
+        ),
+        (
+            "from onecodex.analyses import AnalysisMixin",
+            {"onecodex": 0.25, "onecodex.analyses": 0.75},
+            0.75,
+        ),
+    ],
+)
+def test_import_speed(import_command, package_max_import_times, total_time_secs):
+    """Test the import speed for key onecodex modules
+
+    Note we test the `package`, so `onecodex` will test *everything*
+    while `onecodex.cli` will test the incremental impact of loads the cli.py
+    module.
+    """
+    from pathlib import Path
+
+    try:
+        import pandas as pd  # noqa
+    except ImportError:
+        assert False, "Must run test in an environment with onecodex[all] dependencies"
+
+    # Get the virtualenv and try to activate it
+    activate_path = Path(os.environ["VIRTUAL_ENV"]).joinpath("bin/activate")
+    cmd = [
+        "/bin/bash",
+        "-c",
+        "source {} && python -X importtime -c '{}'".format(activate_path, import_command),
+    ]
+    cmd = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cmd_out, cmd_err = cmd.communicate()
+
+    # Format is like `import time:       227 |     112546 | onecodex`
+    # Convert to a list of lists and skip anything with a header value (`self [us]`)
+    table = [
+        [y.strip() for y in x.replace("import time:", "").split("|")]
+        for x in cmd_err.decode().split("\n")
+        if x and "self [us]" not in x
+    ]
+    df = pd.DataFrame(table)
+    df.columns = ["time", "cumulative", "package"]
+    df.time = df.time.astype(int)
+    df.cumulative = df.cumulative.astype(int)
+
+    # Check times
+    for package, max_time_secs in package_max_import_times.items():
+        cumulative_import_time_us = df[df.package == package].cumulative.values[0]
+        cumulative_import_time_secs = cumulative_import_time_us / 1e6
+        assert cumulative_import_time_secs < max_time_secs
+
+    # Check max time
+    assert max(df.cumulative) / 1e6 < total_time_secs


### PR DESCRIPTION
Adds new `python-import-times` CircleCI job (not required). Also creates artifacts with [tuna](https://github.com/nschloe/tuna) import time plots.

Here's an example CircleCI artifact: https://3084-25324077-gh.circle-artifacts.com/0/home/circleci/project/tuna/index.html