### PR TITLE
Docstring linting, path autocompletion, upload cancel exception catching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ lint:
 	flake8 onecodex/
 	flake8 tests/
 	black --check -l 100 --exclude vendored/* onecodex/ tests/
+	pydocstyle --convention=numpy --add-ignore=D100,D101,D102,D103,D104,D105,D202 --match-dir='[^vendored].*' onecodex/
 	@echo "Successfully linted all files."
 
 coverage:

--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -25,7 +25,7 @@ class AnalysisMixin(
     """
 
     def _get_auto_rank(self, rank):
-        """Tries to figure out what rank we should use for analyses"""
+        """Attempt to figure out what rank we should use for analyses."""
 
         if rank == "auto":
             # if we're an accessor for a ClassificationsDataFrame, use its _rank property
@@ -40,7 +40,7 @@ class AnalysisMixin(
             return rank
 
     def _guess_normalized(self):
-        """Returns true if the collated counts in `self._results` appear to be normalized.
+        """Return True if the collated counts in `self._results` appear to be normalized.
 
         Notes
         -----
@@ -54,7 +54,9 @@ class AnalysisMixin(
         )  # noqa
 
     def _metadata_fetch(self, metadata_fields, label=None):
-        """Takes a list of metadata fields, some of which can contain taxon names or taxon IDs, and
+        """Fetch and transform given metadata fields from `self.metadata`.
+
+        Takes a list of metadata fields, some of which can contain taxon names or taxon IDs, and
         returns a DataFrame with transformed data that can be used for plotting.
 
         Parameters
@@ -232,7 +234,9 @@ class AnalysisMixin(
         normalize="auto",
         table_format="wide",
     ):
-        """Takes the ClassificationsDataFrame associated with these samples, or SampleCollection,
+        """Generate a ClassificationDataFrame, performing any specified transformations.
+
+        Takes the ClassificationsDataFrame associated with these samples, or SampleCollection,
         does some filtering, and returns a ClassificationsDataFrame copy.
 
         Parameters

--- a/onecodex/api.py
+++ b/onecodex/api.py
@@ -24,8 +24,10 @@ log = logging.getLogger("onecodex")
 
 
 class Api(object):
-    """This is the base One Codex Api object class. It instantiates a Potion-Client object under the
-    hood for making requests."""
+    """One Codex Base API object class.
+
+    Instantiates a Potion-Client object under the hood for making requests.
+    """
 
     def __init__(
         self,
@@ -130,8 +132,7 @@ class Api(object):
         return os.environ.get("ONE_CODEX_USER_EMAIL", os.environ.get("ONE_CODEX_USER_UUID"))
 
     def _copy_resources(self):
-        """Copies available subclassed potion resources (e.g., onecodex.models.Samples) into this
-        instance of Api().
+        """Copy subclassed potion resources into this instance of Api().
 
         Notes
         -----
@@ -169,9 +170,7 @@ class Api(object):
 
 
 class ExtendedPotionClient(PotionClient):
-    """
-    An extention of the PotionClient that caches schema
-    """
+    """Extend PotionClient to support caching API schema."""
 
     DATE_FORMAT = "%Y-%m-%d %H:%M"
     SCHEMA_SAVE_DURATION = 1  # day

--- a/onecodex/auth.py
+++ b/onecodex/auth.py
@@ -20,10 +20,7 @@ API_KEY_LEN = 32
 
 
 def login_uname_pwd(server, api_key=None):
-    """
-    Prompts user for username and password, gets API key from server
-    if not provided.
-    """
+    """Prompts user for username and password, gets API key from server if not provided."""
     username = click.prompt("Please enter your One Codex (email)")
     if api_key is not None:
         return username, api_key
@@ -36,9 +33,7 @@ def login_uname_pwd(server, api_key=None):
 
 
 def _login(server, creds_file=None, api_key=None, silent=False):
-    """
-    Login main function
-    """
+    """Login main function."""
     # fetch_api_key and check_version expect server to end in /
     if server[-1] != "/":
         server = server + "/"
@@ -139,9 +134,7 @@ def _login(server, creds_file=None, api_key=None, silent=False):
 
 
 def _remove_creds(creds_file=None):
-    """
-    Remove ~/.onecodex file, returning True if successul or False if the file didn't exist
-    """
+    """Remove ~/.onecodex file, returning True if successul or False if the file didn't exist."""
     if creds_file is None:
         creds_file = os.path.expanduser("~/.onecodex")
 
@@ -162,9 +155,7 @@ def _remove_creds(creds_file=None):
 
 
 def _logout(creds_file=None):
-    """
-    Logout main function, just rm ~/.onecodex more or less
-    """
+    """Logout main function, just rm ~/.onecodex more or less."""
     if _remove_creds(creds_file=creds_file):
         click.echo("Successfully removed One Codex credentials.", err=True)
         sys.exit(0)
@@ -174,8 +165,9 @@ def _logout(creds_file=None):
 
 
 def login_required(fn):
-    """Requires login before proceeding, but does not prompt the user to login. Decorator should
-    be used only on Click CLI commands.
+    """Require login before proceeding, but does not prompt the user to login.
+
+    Decorator should be used only on Click CLI commands.
 
     Notes
     -----

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -56,7 +56,7 @@ warnings.showwarning = warning_msg
 @click.pass_context
 @telemetry
 def onecodex(ctx, api_key, no_pprint, verbose, telemetry):
-    """One Codex v1 API command line interface"""
+    """One Codex v1 API command line interface."""
     # Setup log formatter. TODO: Evaluate click-log instead
     log_formatter = CliLogFormatter()
     log.setLevel(logging.INFO)
@@ -169,7 +169,7 @@ def documents_list(ctx, json):
 @telemetry
 @login_required
 def documents_upload(ctx, max_threads, files):
-    """Upload a document file (of any type) to One Codex"""
+    """Upload a document file (of any type) to One Codex."""
     if len(files) == 0:
         click.echo(ctx.get_help())
         return
@@ -226,7 +226,7 @@ documents.add_command(documents_download, "download")
 @telemetry
 @login_required
 def analyses(ctx, analyses):
-    """Retrieve performed analyses"""
+    """Retrieve performed analyses."""
     cli_resource_fetcher(ctx, "analyses", analyses)
 
 
@@ -245,7 +245,7 @@ def analyses(ctx, analyses):
 @telemetry
 @login_required
 def classifications(ctx, classifications, results, readlevel, readlevel_path):
-    """Retrieve performed metagenomic classifications"""
+    """Retrieve performed metagenomic classifications."""
 
     # basic operation -- just print
     if not readlevel and not results:
@@ -291,7 +291,7 @@ def classifications(ctx, classifications, results, readlevel, readlevel_path):
 @telemetry
 @login_required
 def panels(ctx, panels):
-    """Retrieve performed in silico panel results"""
+    """Retrieve performed in silico panel results."""
     cli_resource_fetcher(ctx, "panels", panels)
 
 
@@ -301,7 +301,7 @@ def panels(ctx, panels):
 @telemetry
 @login_required
 def samples(ctx, samples):
-    """Retrieve uploaded samples"""
+    """Retrieve uploaded samples."""
     cli_resource_fetcher(ctx, "samples", samples)
 
 
@@ -328,8 +328,7 @@ def samples(ctx, samples):
 def upload(
     ctx, files, max_threads, prompt, forward, reverse, tags, metadata, project_id, coerce_ascii
 ):
-    """Upload a FASTA or FASTQ (optionally gzip'd) to One Codex"""
-
+    """Upload a FASTA or FASTQ (optionally gzip'd) to One Codex."""
     appendables = {}
     if tags:
         appendables["tags"] = []
@@ -445,7 +444,7 @@ def upload(
 @click.pass_context
 @telemetry
 def login(ctx):
-    """Add an API key (saved in ~/.onecodex)"""
+    """Add an API key (saved in ~/.onecodex)."""
     base_url = os.environ.get("ONE_CODEX_API_BASE", "https://app.onecodex.com")
     if not ctx.obj["API_KEY"]:
         _login(base_url)
@@ -465,5 +464,5 @@ def login(ctx):
 @click.pass_context
 @telemetry
 def logout(ctx):
-    """Delete your API key (saved in ~/.onecodex)"""
+    """Delete an API key (saved in ~/.onecodex)."""
     _logout()

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -2,12 +2,12 @@ from __future__ import print_function
 import click
 import copy
 import dateutil
+from functools import partial
 import logging
 import os
 import re
 import time
 import warnings
-
 
 from onecodex.api import Api
 from onecodex.auth import _login, _logout, _remove_creds, login_required
@@ -15,6 +15,7 @@ from onecodex.lib.upload import DEFAULT_THREADS, _file_size
 from onecodex.metadata_upload import validate_appendables
 from onecodex.scripts import subset_reads
 from onecodex.utils import (
+    click_path_autocomplete_helper,
     cli_resource_fetcher,
     CliLogFormatter,
     download_file_helper,
@@ -163,7 +164,13 @@ def documents_list(ctx, json):
     help=OPTION_HELP["max_threads"],
     metavar="<int:threads>",
 )
-@click.argument("files", nargs=-1, required=False, type=click.Path(exists=True))
+@click.argument(
+    "files",
+    nargs=-1,
+    required=False,
+    type=click.Path(exists=True),
+    autocompletion=partial(click_path_autocomplete_helper, directory=False),
+)
 @click.pass_context
 @pretty_errors
 @telemetry
@@ -195,6 +202,7 @@ def documents_upload(ctx, max_threads, files):
     help="Write document to PATH",
     required=False,
     type=click.Path(dir_okay=False, allow_dash=True),
+    autocompletion=partial(click_path_autocomplete_helper, filename=False),
 )
 @click.pass_context
 @pretty_errors
@@ -238,6 +246,7 @@ def analyses(ctx, analyses):
     type=click.Path(),
     default="./",
     help=OPTION_HELP["readlevel_path"],
+    autocompletion=partial(click_path_autocomplete_helper, filename=False),
 )
 @click.option("--results", "results", is_flag=True, help=OPTION_HELP["results"])
 @click.pass_context
@@ -308,15 +317,31 @@ def samples(ctx, samples):
 # utilites
 @onecodex.command("upload")
 @click.option("--max-threads", default=4, help=OPTION_HELP["max_threads"], metavar="<int:threads>")
-@click.argument("files", nargs=-1, required=False, type=click.Path(exists=True))
+@click.argument(
+    "files",
+    nargs=-1,
+    required=False,
+    type=click.Path(exists=True),
+    autocompletion=partial(click_path_autocomplete_helper, directory=False),
+)
 @click.option(
     "--coerce-ascii",
     is_flag=True,
     default=False,
     help="automatically rename unicode filenames to ASCII",
 )
-@click.option("--forward", type=click.Path(exists=True), help=OPTION_HELP["forward"])
-@click.option("--reverse", type=click.Path(exists=True), help=OPTION_HELP["reverse"])
+@click.option(
+    "--forward",
+    type=click.Path(exists=True),
+    help=OPTION_HELP["forward"],
+    autocompletion=partial(click_path_autocomplete_helper, directory=False),
+)
+@click.option(
+    "--reverse",
+    type=click.Path(exists=True),
+    help=OPTION_HELP["reverse"],
+    autocompletion=partial(click_path_autocomplete_helper, directory=False),
+)
 @click.option("--prompt/--no-prompt", is_flag=True, help=OPTION_HELP["prompt"], default=True)
 @click.option("--tag", "-t", "tags", multiple=True, help=OPTION_HELP["tag"])
 @click.option("--metadata", "-md", multiple=True, help=OPTION_HELP["metadata"])

--- a/onecodex/dataframes.py
+++ b/onecodex/dataframes.py
@@ -5,7 +5,9 @@ from onecodex.analyses import AnalysisMixin
 
 
 class ClassificationsDataFrame(pd.DataFrame):
-    """A subclassed `pandas.DataFrame` containing additional metadata pertinent to analysis of
+    """A DataFrame containing additional One Codex metadata.
+
+    A subclassed `pandas.DataFrame` containing additional metadata pertinent to analysis of
     One Codex Classifications results. These fields, once part of the DataFrame, will no longer be
     updated when the contents of the associated `SampleCollection` change. In comparison, the
     corresponding attributes `_rank`, `_field`, `taxonomy` and `metadata` in a `SampleCollection`
@@ -111,7 +113,9 @@ class ClassificationsDataFrame(pd.DataFrame):
 
 
 class ClassificationsSeries(pd.Series):
-    """A subclassed `pandas.Series` containing additional metadata pertinent to analysis of
+    """A Series containing additional One Codex metadata.
+
+    A subclassed `pandas.Series` containing additional metadata pertinent to analysis of
     One Codex Classifications results. See the docstring for `ClassificationsDataFrame`.
     """
 
@@ -171,7 +175,9 @@ class ClassificationsSeries(pd.Series):
 
 @pd.api.extensions.register_dataframe_accessor("ocx")
 class OneCodexAccessor(AnalysisMixin):
-    """Accessor object alllowing access of `AnalysisMixin` methods from the 'ocx' namespace of a
+    """A pandas accessor object with One Codex methods and metadata.
+
+    Accessor object alllowing access of `AnalysisMixin` methods from the 'ocx' namespace of a
     `ClassificationsDataFrame`.
 
     Notes

--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -6,7 +6,7 @@ from onecodex.taxonomy import TaxonomyMixin
 
 class DistanceMixin(TaxonomyMixin):
     def alpha_diversity(self, metric="simpson", rank="auto"):
-        """Caculate the diversity within a community.
+        """Calculate the diversity within a community.
 
         Parameters
         ----------
@@ -76,8 +76,10 @@ class DistanceMixin(TaxonomyMixin):
         return skbio.diversity.beta_diversity(metric, counts, df.index.tolist())
 
     def unifrac(self, weighted=True, rank="auto"):
-        """A beta diversity metric that takes into account the relative relatedness of community
-        members. Weighted UniFrac looks at abundances, unweighted UniFrac looks at presence.
+        """Calculate the UniFrac beta diversity metric.
+
+        UniFrac takes into account the relatedness of community members. Weighted UniFrac considers
+        abundances, unweighted UniFrac considers presence.
 
         Parameters
         ----------

--- a/onecodex/exceptions.py
+++ b/onecodex/exceptions.py
@@ -3,9 +3,7 @@ class OneCodexException(Exception):
 
 
 class MethodNotSupported(OneCodexException):
-    """
-    The object does not support this operation.
-    """
+    """The object does not support this operation."""
 
     pass
 
@@ -19,9 +17,7 @@ class ServerError(OneCodexException):
 
 
 class UnboundObject(OneCodexException):
-    """
-    To use against the One Codex server, all classes must be derived from an Api instance.
-    """
+    """To use against the One Codex server, all classes must be derived from an Api() instance."""
 
     pass
 
@@ -31,9 +27,7 @@ class ValidationError(OneCodexException):
 
 
 class UploadException(Exception):
-    """
-    An exception for when things go wrong with uploading
-    """
+    """An exception for when things go wrong with uploading."""
 
     pass
 
@@ -43,7 +37,7 @@ class RetryableUploadException(UploadException):
 
 
 def raise_api_error(resp, state=None):
-    """Raise an exception with a pretty message in various states of upload"""
+    """Raise an exception with a pretty message in various states of upload."""
     # TODO: Refactor into an Exception class
     error_code = resp.status_code
 

--- a/onecodex/lib/__init__.py
+++ b/onecodex/lib/__init__.py
@@ -1,4 +1,0 @@
-"""
-"Pure" (well, more deterministic than most) functions for handling
-common One Codex operations (to be shared across multiple projects)
-"""

--- a/onecodex/lib/auth.py
+++ b/onecodex/lib/auth.py
@@ -3,7 +3,7 @@ import requests
 
 
 class BearerTokenAuth(requests.auth.AuthBase):
-    """Attaches Bearer Auth headers to a given Request object."""
+    """Attache Bearer Auth headers to the given Request object."""
 
     def __init__(self, token):
         self.token = token
@@ -14,9 +14,7 @@ class BearerTokenAuth(requests.auth.AuthBase):
 
 
 def fetch_api_key_from_uname(username, password, server_url):
-    """
-    Retrieves an API key from the One Codex webpage given the username and password
-    """
+    """Retrieve an API key from the One Codex webpage given the username and password."""
     # TODO: Hit programmatic endpoint to fetch JWT key, not API key
     with requests.Session() as session:
         # get the login page normally
@@ -60,8 +58,8 @@ def check_version(version, server):
     def version_inadequate(client_version, server_version):
         """Simple, fast check for version inequality.
 
-        Could use python package `semver` if we need more precise checks in
-        edge cases, but this generally works for now.
+        Could use python package `semver` if we need more precise checks in edge cases, but this
+        generally works for now.
         """
         client_version = tuple([int(x) for x in client_version.split("-")[0].split(".")])
         server_version = tuple([int(x) for x in server_version.split(".")])

--- a/onecodex/lib/upload.py
+++ b/onecodex/lib/upload.py
@@ -66,7 +66,9 @@ class Buffer(object):
 
 
 class FASTXInterleave(object):
-    """Wrapper around two `file` objects that decompresses gzip or bz2, where applicable, and
+    """Decompress and interleave two FASTX files.
+
+    Wrapper around two `file` objects that decompresses gzip or bz2, where applicable, and
     interleaves the two files either two or four lines at a time. Yields uncompressed data.
 
     Parameters
@@ -143,7 +145,12 @@ class FASTXInterleave(object):
         return bytes_read
 
     def seek(self, loc):
-        """Called if upload fails and must be retried."""
+        """Seek to a position in the file.
+
+        Notes
+        -----
+        This is called if an upload fails and must be retried.
+        """
         assert loc == 0
 
         # rewind progress bar
@@ -205,7 +212,12 @@ class FilePassthru(object):
         return self._fsize - self._fp.tell()
 
     def seek(self, loc):
-        """Called if upload fails and must be retried."""
+        """Seek to a position in the file.
+
+        Notes
+        -----
+        This is called if an upload fails and must be retried.
+        """
         assert loc == 0
 
         # rewind progress bar
@@ -219,8 +231,10 @@ class FilePassthru(object):
 
 
 def interleaved_filename(file_path):
-    """Return filename used to represent a set of paired-end files. Assumes Illumina-style naming
-    conventions where each file has _R1_ or _R2_ in its name."""
+    """Return filename used to represent a set of paired-end files.
+
+    Assumes Illumina-style naming conventions where each file has _R1_ or _R2_ in its name.
+    """
     if not isinstance(file_path, tuple):
         raise OneCodexException("Cannot get the interleaved filename without a tuple.")
     if re.match(".*[._][Rr][12][_.].*", file_path[0]):
@@ -231,7 +245,7 @@ def interleaved_filename(file_path):
 
 
 def _file_size(file_path, uncompressed=False):
-    """Return size of a single file, compressed or uncompressed"""
+    """Return size of a single file, compressed or uncompressed."""
     _, ext = os.path.splitext(file_path)
 
     if uncompressed:
@@ -318,10 +332,11 @@ def _file_stats(file_path, enforce_fastx=True):
 
 
 def _choose_boto3_chunksize(file_obj):
-    """Choose the minimum chunk size for a boto3 direct-to-S3 upload that will result in less than
-    10000 chunks (the maximum).
+    """Return the appropriate chunksize for use in uploading the given file object.
 
-    This function will raise if there is no allowed chunk size big enough to accomodate the file.
+    Choose the minimum chunk size for a boto3 direct-to-S3 upload that will result in less than
+    10000 chunks (the maximum). This function will raise if there is no allowed chunk size big
+    enough to accomodate the file.
 
     Parameters
     ----------
@@ -438,8 +453,9 @@ def _call_init_upload(file_name, file_size, metadata, tags, project, samples_res
 
 
 def _make_retry_fields(file_name, metadata, tags, project):
-    """Generate fields to send to init_multipart_upload in the case that a Sample upload via
-    fastx-proxy fails.
+    """Generate fields to send to init_multipart_upload.
+
+    The fields returned by this function are used when a Sample upload via fastx-proxy fails.
 
     Parameters
     ----------
@@ -486,7 +502,7 @@ def upload_sequence(
     coerce_ascii=False,
     progressbar=None,
 ):
-    """Uploads a sequence file (or pair of files) to the One Codex server via either our proxy or directly to S3.
+    """Upload a sequence file (or pair of files) to One Codex via our proxy or directly to S3.
 
     Parameters
     ----------
@@ -584,8 +600,10 @@ def upload_sequence(
 
 
 def _direct_upload(file_obj, file_name, fields, session, samples_resource):
-    """Uploads a single file-like object via our validating proxy. Maintains compatibility with
-    direct upload to a user's S3 bucket as well in case we disable our validating proxy.
+    """Upload a single file-like object via our validating proxy.
+
+    Maintains compatibility with direct upload to a user's S3 bucket in case our validating proxy
+    is disabled for this user.
 
     Parameters
     ----------
@@ -685,8 +703,7 @@ def _direct_upload(file_obj, file_name, fields, session, samples_resource):
 
 
 def upload_sequence_fileobj(file_obj, file_name, fields, retry_fields, session, samples_resource):
-    """Uploads a single file-like object to the One Codex server via either fastx-proxy or directly
-    to S3.
+    """Upload a single file-like object to One Codex via either fastx-proxy or directly to S3.
 
     Parameters
     ----------
@@ -766,8 +783,7 @@ def upload_sequence_fileobj(file_obj, file_name, fields, retry_fields, session, 
 
 
 def upload_document(file_path, session, documents_resource, progressbar=None):
-    """Uploads multiple document files to the One Codex server directly to S3 via an intermediate
-    bucket.
+    """Upload multiple document files to One Codex directly to S3 via an intermediate bucket.
 
     Parameters
     ----------
@@ -808,7 +824,7 @@ def upload_document(file_path, session, documents_resource, progressbar=None):
 
 
 def upload_document_fileobj(file_obj, file_name, session, documents_resource):
-    """Uploads a single file-like object to the One Codex server directly to S3.
+    """Upload a single file-like object to One Codex directly to S3 via an intermediate bucket.
 
     Parameters
     ----------
@@ -860,8 +876,9 @@ def upload_document_fileobj(file_obj, file_name, session, documents_resource):
 
 
 def _s3_intermediate_upload(file_obj, file_name, fields, session, callback_url):
-    """Uploads a single file-like object to an intermediate S3 bucket which One Codex can pull from
-    after receiving a callback.
+    """Upload a single file-like object to an intermediate S3 bucket.
+
+    One Codex will pull the file from S3 after receiving a callback.
 
     Parameters
     ----------

--- a/onecodex/models/__init__.py
+++ b/onecodex/models/__init__.py
@@ -188,9 +188,7 @@ class ResourceList(object):
 
 
 class OneCodexBase(object):
-    """A parent object for all the One Codex objects that wraps the Potion-Client API and makes
-    access and usage easier.
-    """
+    """Parent of all the One Codex objects that wraps the Potion-Client API."""
 
     def __init__(self, _resource=None, **kwargs):
         # FIXME: allow setting properties via kwargs?
@@ -343,8 +341,9 @@ class OneCodexBase(object):
         return self._resource._uri == other._resource._uri
 
     def _to_json(self, include_references=True):
-        """Convert the model to JSON using the PotionJSONEncode and automatically
-        resolving the resource as needed (`_properties` call handles this).
+        """Convert model to JSON using the PotionJSONEncode.
+
+        Automatically resolves the resource as needed (`_properties` call handles this).
         """
         if include_references:
             return json.dumps(self._resource._properties, cls=PotionJSONEncoder)
@@ -377,7 +376,7 @@ class OneCodexBase(object):
 
     @classmethod
     def all(cls, sort=None, limit=None):
-        """Returns all objects of this type. Alias for where() (without filter arguments).
+        """Return all objects of this type. Alias for where() (without filter arguments).
 
         See `where` for documentation on the `sort` and `limit` parameters.
         """
@@ -385,21 +384,21 @@ class OneCodexBase(object):
 
     @classmethod
     def where(cls, *filters, **keyword_filters):
-        """Retrieves objects (Samples, Classifications, etc.) from the One Codex server.
+        """Retrieve objects (Samples, Classifications, etc.) from the One Codex server.
 
         Parameters
         ----------
-        filters : objects
+        filters : `object`
             Advanced filters to use (not implemented)
-        sort : string | list, optional
+        sort : `str` or `list`, optional
             Sort the results by this field (or list of fields). By default in descending order,
             but if any of the fields start with the special character ^, sort in ascending order.
             For example, sort=['size', '^filename'] will sort by size from largest to smallest and
             filename from A-Z for items with the same size.
-        limit : integer, optional
+        limit : `int`, optional
             Number of records to return. For smaller searches, this can reduce the number of
             network requests made.
-        keyword_filters : strings | objects
+        keyword_filters : `str` or `object`
             Filter the results by specific keywords (or filter objects, in advanced usage)
 
         Examples
@@ -411,7 +410,7 @@ class OneCodexBase(object):
 
         Returns
         -------
-        list
+        `list`
             A list of all objects matching these filters. If no filters are passed, this
             matches all objects.
         """
@@ -478,17 +477,18 @@ class OneCodexBase(object):
 
     @classmethod
     def get(cls, uuid):
-        """Retrieve one specific object from the server by its UUID (unique 16-character id). UUIDs
-        can be found in the web browser's address bar while viewing analyses and other objects.
+        """Retrieve one specific object from the server by its UUID (unique 16-character id).
+
+        UUIDs are found in the web browser's address bar while viewing analyses and other objects.
 
         Parameters
         ----------
-        uuid : string
+        uuid : `str`
             UUID of the object to retrieve.
 
         Returns
         -------
-        OneCodexBase | None
+        `OneCodexBase` or `None`
             The object with that UUID or None if no object could be found.
 
         Examples

--- a/onecodex/models/analysis.py
+++ b/onecodex/models/analysis.py
@@ -6,8 +6,7 @@ class Analyses(OneCodexBase):
     _cached_result = None
 
     def results(self, json=True):
-        """
-        Fetch the results for an Analyses resource.
+        """Fetch the results of an Analyses resource.
 
         Parameters
         ----------
@@ -16,8 +15,8 @@ class Analyses(OneCodexBase):
 
         Returns
         -------
-        Return type varies by Analyses resource sub-type. See, e.g.,
-        Classifications or Panels for documentation.
+        Return type varies by Analyses resource sub-type. See, e.g., Classifications or Panels for
+        documentation.
         """
         if json is True:
             return self._results()
@@ -42,19 +41,17 @@ class Classifications(Analyses):
     _cached_table = None
 
     def results(self, json=True):
-        """
-        Returns the complete results table for the classification.
+        """Return the complete results table for a classification.
 
         Parameters
         ----------
-        json : bool, optional
+        json : `bool`, optional
             Return result as JSON? Default True.
 
         Returns
         -------
-        table : dict | DataFrame
-            Return a JSON object with the classification results or a Pandas DataFrame
-            if json=False.
+        table : `dict` or `pd.DataFrame`
+            Return a JSON object with the classification results or a `pd.DataFrame` if json=False.
         """
         if json is True:
             return self._results()
@@ -72,20 +69,17 @@ class Classifications(Analyses):
         return self._cached_table
 
     def table(self):
-        """
-        Returns the complete results table for the classification.
+        """Return the complete results table for the classification.
 
         Returns
         -------
-        table : DataFrame
+        table : `pd.DataFrame`
             A Pandas DataFrame of the classification results.
         """
         return self.results(json=False)
 
     def abundances(self, ids=None):
-        """
-        Query the results table to get abundance data for all or some tax ids
-        """
+        """Query the results table to get abundance data for all or some tax ids."""
         # TODO: Consider removing this method... since it's kind of trivial
         #       May want to replace with something that actually gets genome-size adjusted
         #       abundances from the results table

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -17,8 +17,9 @@ from onecodex.models import OneCodexBase, ResourceList
 
 
 class SampleCollection(ResourceList, AnalysisMixin):
-    """A collection of `Samples` or `Classifications` objects with many methods for analysis of
-    classifications results.
+    """A collection of `Samples` or `Classifications` objects.
+
+    Includes lots of methods for analysis of classifications results.
 
     Notes
     -----
@@ -121,8 +122,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
         super(SampleCollection, self)._update()
 
     def _classification_fetch(self, skip_missing=None):
-        """Turns a list of objects associated with a classification result into a list of
-        Classifications objects.
+        """Transform a list of Samples or Classifications into a list of Classifications objects.
 
         Parameters
         ----------
@@ -163,8 +163,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
         return self._cached["classifications"]
 
     def _collate_metadata(self):
-        """Turns a list of objects associated with a classification result into a DataFrame of
-        metadata.
+        """Transform a list of Samples or Classifications into a `pd.DataFrame` of metadata.
 
         Returns
         -------
@@ -210,8 +209,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
         return self._cached["metadata"]
 
     def _collate_results(self, field=None):
-        """For a list of objects associated with a classification result, return the results as a
-        DataFrame and dict of taxa info.
+        """Transform a list of Classifications into `pd.DataFrames` of taxonomy and results data.
 
         Parameters
         ----------
@@ -292,8 +290,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
         return self._cached["taxonomy"]
 
     def to_otu(self, biom_id=None):
-        """Converts a list of objects associated with a classification result into a `dict` resembling
-        an OTU table.
+        """Transform a list of Classifications objects into a `dict` resembling an OTU table.
 
         Parameters
         ----------

--- a/onecodex/models/experimental.py
+++ b/onecodex/models/experimental.py
@@ -6,7 +6,7 @@ class AnnotationSets(OneCodexBase, ResourceDownloadMixin):
     _resource_path = "/api/v1_experimental/annotation_sets"
 
     def download(self, path=None, file_obj=None, progressbar=False):
-        """Downloads an AnnotationSet in GenBank format.
+        """Download an AnnotationSet in GenBank format.
 
         Parameters
         ----------
@@ -40,8 +40,9 @@ class AnnotationSets(OneCodexBase, ResourceDownloadMixin):
         )
 
     def download_csv(self, path=None, file_obj=None, progressbar=False):
-        """Downloads an AnnotationSet in CSV format, including Annotation coordinates and sequences
-        in both amino acid and nucleotide space.
+        """Download an AnnotationSet in CSV format.
+
+        Includes Annotation coordinates and sequences in both amino acid and nucleotide space.
 
         Parameters
         ----------
@@ -93,9 +94,9 @@ class Taxa(OneCodexBase):
         return "<Taxa {} {} ({})>".format(self.taxon_id, self.name, self.rank)
 
     def genomes(self):
-        """Returns a list of all Genomes belonging to descendants of this Taxon."""
+        """Return a list of all Genomes belonging to descendants of this Taxon."""
         return ResourceList(self._resource.genomes(), Genomes)
 
     def parents(self):
-        """Returns a list of all parents of this Taxon, at all ranks."""
+        """Return a list of all parents of this Taxon, at all ranks."""
         return ResourceList(self._resource.parents(), Taxa)

--- a/onecodex/models/helpers.py
+++ b/onecodex/models/helpers.py
@@ -91,7 +91,7 @@ def truncate_string(s, length=24):
 
 class ResourceDownloadMixin(object):
     def download(self, path=None, file_obj=None, progressbar=False):
-        """Downloads files from One Codex.
+        """Download files from One Codex.
 
         Parameters
         ----------

--- a/onecodex/models/misc.py
+++ b/onecodex/models/misc.py
@@ -56,7 +56,7 @@ class Documents(OneCodexBase, ResourceDownloadMixin):
 
     @classmethod
     def upload(cls, file_path, progressbar=None):
-        """Uploads a series of files to the One Codex server.
+        """Upload a series of files to the One Codex server.
 
         Parameters
         ----------

--- a/onecodex/models/sample.py
+++ b/onecodex/models/sample.py
@@ -124,9 +124,9 @@ class Samples(OneCodexBase, ResourceDownloadMixin):
         return cls.where(*filters, **keyword_filters)
 
     def save(self):
-        """
-        Persist changes on this Samples object back to the One Codex server along with any changes
-        on its metadata (if it has any).
+        """Send changes on this Samples object to the One Codex server.
+
+        Changes to the metadata object and tags list are passed as well.
         """
         # any newly-created tags should be associated with this sample and saved
         if self.tags:
@@ -144,7 +144,7 @@ class Samples(OneCodexBase, ResourceDownloadMixin):
     def upload(
         cls, files, metadata=None, tags=None, project=None, coerce_ascii=False, progressbar=None
     ):
-        """Uploads a series of files to the One Codex server.
+        """Upload a series of files to the One Codex server.
 
         Parameters
         ----------

--- a/onecodex/scripts/subset_reads.py
+++ b/onecodex/scripts/subset_reads.py
@@ -61,11 +61,11 @@ def get_filtered_filename(file_path):
 
 
 def make_taxonomy_dict(classification, parent=False):
-    """
-    Takes a classification data frame returned by the API and parses it
-    into a dictionary mapping a tax_id to its children (or parent).
-    Restricted to tax_id's that are represented in the classification
-    results.
+    """Parse a Classification object into a `dict` mapping a tax_id to its children or parent.
+
+    Notes
+    -----
+    Restricted to taxonomic IDs that are represented in the classification results.
     """
 
     tax_id_map = {}
@@ -86,15 +86,23 @@ def make_taxonomy_dict(classification, parent=False):
 
 
 def recurse_taxonomy_map(tax_id_map, tax_id, parent=False):
-    """
-    Takes the output dict from make_taxonomy_map and an input tax_id
-    and recurses either up or down through the tree to get /all/ children
-    (or parents) of the given tax_id.
+    """Traverse up or down through a taxonomic tree.
+
+    Finds all children (or parents) of the given tax_id.
+
+    Parameters
+    ----------
+    tax_id_map : `dict`
+        The output of make_taxonomy_map().
+    tax_id : `int`
+        The taxonomic ID of the node to begin the traversal from.
+    parent : `bool`
+        Return parents of the taxonomic node rather than children.
     """
 
     if parent:
         # TODO: allow filtering on tax_id and its parents, too
-        pass
+        raise NotImplementedError
     else:
 
         def _child_recurse(tax_id, visited):

--- a/onecodex/taxonomy.py
+++ b/onecodex/taxonomy.py
@@ -3,8 +3,9 @@ import warnings
 
 class TaxonomyMixin(object):
     def tree_build(self):
-        """Build a tree from the taxonomy data present in this `ClassificationsDataFrame` or
-        `SampleCollection`.
+        """Build a tree from the taxonomy data present in this object.
+
+        This is designed for use with `ClassificationsDataFrame` or `SampleCollection`.
 
         Returns
         -------
@@ -42,7 +43,7 @@ class TaxonomyMixin(object):
         return nodes["1"]
 
     def tree_prune_tax_ids(self, tree, tax_ids):
-        """Prunes a tree back to contain only the tax_ids in the list and their parents.
+        """Prune a tree back to contain only the tax_ids in the list and their parents.
 
         Parameters
         ----------
@@ -68,8 +69,10 @@ class TaxonomyMixin(object):
         return tree
 
     def tree_prune_rank(self, tree, rank="species"):
-        """Takes a TreeNode tree and prunes off any tips not at the specified rank and backwards up
-        until all of the tips are at the specified rank.
+        """Prune tips off a TreeNode tree not at specified rank.
+
+        Takes a TreeNode tree and prunes off any tips below the specified rank, leaving behind all
+        nodes /at/ the specified rank and their parents.
 
         Parameters
         ----------

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -97,9 +97,7 @@ SUPPORTED_EXTENSIONS = [
 
 
 def valid_api_key(ctx, param, value):
-    """
-    Ensures an API has valid length (this is a click callback)
-    """
+    """Ensure an API has valid length (this is a click callback)."""
     if value is not None and len(value) != 32:
         raise click.BadParameter(
             "API Key must be 32 characters long, not {}".format(str(len(value)))
@@ -109,9 +107,7 @@ def valid_api_key(ctx, param, value):
 
 
 def pprint(j, no_pretty):
-    """
-    Prints as formatted JSON
-    """
+    """Print as formatted JSON."""
     if not no_pretty:
         click.echo(
             json.dumps(j, cls=PotionJSONEncoder, sort_keys=True, indent=4, separators=(",", ": "))
@@ -185,9 +181,7 @@ def cli_resource_fetcher(ctx, resource, uris, print_results=True):
 
 
 def is_insecure_platform():
-    """
-    Checks if the current system is missing an SSLContext object
-    """
+    """Check if the current system is missing an SSLContext object."""
     v = sys.version_info
     if v.major == 3:
         return False  # Python 2 issue
@@ -205,10 +199,11 @@ def is_insecure_platform():
 
 
 def warn_if_insecure_platform():
-    """
-    Produces a nice message if SSLContext object is not available.
-    Also returns True -> platform is insecure
-                 False -> platform is secure
+    """Produce a nice message if SSLContext object is not available.
+
+    Returns
+    -------
+    `True` if platform is insecure, `False` if platform is secure.
     """
     m = (
         "\n"
@@ -242,9 +237,7 @@ def get_download_dest(input_path, url):
 
 
 def download_file_helper(url, input_path):
-    """
-    Manages the chunked downloading of a file given an url
-    """
+    """Manage the chunked downloading of a file given an url."""
     r = requests.get(url, stream=True)
     if r.status_code != 200:
         log.error("Failed to download file: %s" % r.json()["message"])
@@ -260,9 +253,7 @@ def download_file_helper(url, input_path):
 
 
 def check_for_allowed_file(f):
-    """
-    Checks a file extension against a list of seq file exts
-    """
+    """Check a file extension against a list of supporting sequence file extensions."""
     for ext in SUPPORTED_EXTENSIONS:
         if f.endswith(ext):
             return True
@@ -271,9 +262,7 @@ def check_for_allowed_file(f):
 
 
 def collapse_user(fp):
-    """
-    Converts a path back to ~/ from expanduser()
-    """
+    """Convert a path back to ~/ from expanduser()."""
     home_dir = os.path.expanduser("~")
     abs_path = os.path.abspath(fp)
     return abs_path.replace(home_dir, "~")
@@ -350,14 +339,20 @@ def get_raven_client(user_context=None, extra_context=None):
 
 
 def telemetry(fn):
-    """
-    Decorator for CLI and other functions that need special Sentry client handling.
-    This function is only required for functions that may exit *before* we set up
-    the ._raven_client object on the Api instance *or* that specifically catch and re-raise
-    exceptions or call sys.exit directly.
+    """Decorate CLI and other functions that need special Sentry client handling.
 
-    Note that this also overwrites verbose Raven logs on exit ("Sentry is waiting to send..."),
-    see https://github.com/getsentry/raven-python/issues/904 for more details.
+    This decorator is only required on functions that:
+        1) May exit *before* we set up a ._raven_client object on the Api() instance.
+        2) Specifically catch and re-raise exceptions.
+        3) Call sys.exit() directly.
+
+    Notes
+    -----
+    This overwrites verbose Raven logs on exit ("Sentry is waiting to send..."). See:
+
+        https://github.com/getsentry/raven-python/issues/904
+
+    for more details.
     """
 
     @wraps(fn)
@@ -393,11 +388,10 @@ def telemetry(fn):
 
 
 def pretty_errors(fn):
-    """
-    Decorator for the CLI for catching errors and then calling sys.exit(1).
+    """Decorate CLI functions, catching errors and then calling sys.exit(1).
 
-    For now, this is intended for use with the CLI and scripts where we only use
-    OneCodexExceptions (incl. ValidationError) and UploadException.
+    This is intended for use with the CLI and scripts where we only use OneCodexException and its
+    subclasses, e.g. ValidationError or UploadException.
     """
 
     @wraps(fn)

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -474,3 +474,47 @@ def atexit_unregister(func, *args, **kwargs):
             if atexit._exithandlers[i] == (func, args, kwargs):
                 atexit._exithandlers[i] = (lambda: None, [], {})
                 break
+
+
+def click_path_autocomplete_helper(ctx, args, incomplete, filename=True, directory=True):
+    """Suggest paths to complete a partially typed filename or directory.
+
+    Parameters
+    ----------
+    ctx : `click.Context`
+    args : `list`
+    incomplete : `str`
+        A partially typed path to a file or directory.
+    filename : `bool`
+        If True, include filenames in the list of suggestions.
+    directory : `bool`
+        If True, include directories in the list of suggestions.
+
+    Returns
+    -------
+    A list of suggestions for completing the path.
+    """
+    dir_name = os.path.dirname(incomplete)
+    file_name = os.path.basename(incomplete)
+
+    if dir_name.startswith("~"):
+        abs_dir_name = os.path.expanduser(dir_name)
+    else:
+        abs_dir_name = os.path.abspath(dir_name)
+
+    if not os.path.exists(abs_dir_name):
+        return []
+
+    suggestions = []
+
+    for item in os.listdir(abs_dir_name):
+        if item.startswith(file_name):
+            abs_item_path = os.path.join(abs_dir_name, item)
+            item_path = os.path.join(dir_name, item)
+
+            if directory and os.path.isdir(abs_item_path):
+                suggestions.append(item_path)
+            elif filename and os.path.isfile(abs_item_path):
+                suggestions.append(item_path)
+
+    return suggestions

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ coverage~=4.5
 codecov
 flake8
 black
+pydocstyle>=3.0.0
 pytest~=4.1
 pytest-cov~=2.6
 responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # base
 boto3>=1.4.2
-click>=6.6
+click>=7.0
 jsonschema>=2.4
 python-dateutil>=2.5.3
 pytz>=2014.1

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
             "coverage~=4.5",
             "codecov~=2.0",
             "flake8",
+            "pydocstyle>=3.0.0",
             "pytest~=4.1",
             "pytest-cov~=2.6",
             "responses",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     packages=find_packages(exclude=["*test*"]),
     install_requires=[
         "boto3>=1.4.2",
-        "click>=6.6",
+        "click>=7.0",
         "jsonschema>=2.4",
         "python-dateutil>=2.5.3",
         "pytz>=2014.1",


### PR DESCRIPTION
This PR:

- #152 Adds automatic linting of docstrings in NumPy format and updates existing docstrings to pass.
- Note that I'm currently ignoring D100-105 which would force us to add docstrings all over the place, and D202 which requires no blank line after docstrings in function definitions. D202 conflicts with `black` linting.
- #298 Catches an exception when trying to cancel an upload that's already succeeded upon Ctrl+C
- Bumps version of Click to 7.0.0 which should fix a bug calculating ETA when `progressbar.pos = 0`
- Enables tab autocompletion of filenames and directories. It's not the greatest since we're kind of limited by Click's API but it's better than nothing IMO.
- Idk how this came to be, but we were re-using the flask-potion session with our API for uploads via proxy. Sets up a separate session for each upload, which should fix any connection pool errors as a side effect.
- Limits concurrent uploads to 8.