### PR TITLE
Changes to viz plotters

### DIFF
--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -63,17 +63,16 @@ class DistanceMixin(TaxonomyMixin):
                 "For beta diversity, metric must be one of: jaccard, braycurtis, cityblock"
             )
 
-        # needs read counts, not relative abundances
-        if self._guess_normalized():
-            raise OneCodexException("Beta diversity requires unnormalized read counts.")
-
-        df = self.to_df(rank=rank, normalize=False)
+        df = self.to_df(rank=rank, normalize=self._guess_normalized())
 
         counts = []
         for c_id in df.index:
             counts.append(df.loc[c_id].tolist())
 
-        return skbio.diversity.beta_diversity(metric, counts, df.index.tolist())
+        # NOTE: see #291 for a discussion on using these metrics with normalized read counts. we are
+        # explicitly disabling skbio's check for a counts matrix to allow normalized data to make
+        # its way into this function.
+        return skbio.diversity.beta_diversity(metric, counts, df.index.tolist(), validate=False)
 
     def unifrac(self, weighted=True, rank="auto"):
         """Calculate the UniFrac beta diversity metric.

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -160,6 +160,22 @@ class SampleCollection(ResourceList, AnalysisMixin):
 
             new_classifications.append(c)
 
+        # warn if some of the classifications in this collection are not alike
+        job_names_to_ids = {}
+
+        for obj in new_classifications:
+            try:
+                job_names_to_ids[obj.job.name].append(obj.job.id)
+            except KeyError:
+                job_names_to_ids[obj.job.name] = [obj.job.id]
+
+        if len(job_names_to_ids) > 1:
+            warnings.warn(
+                "SampleCollection contains multiple analysis types: {}".format(
+                    ", ".join(job_names_to_ids.keys())
+                )
+            )
+
         self._cached["classifications"] = new_classifications
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -247,6 +247,13 @@ API_DATA = {
     "POST::api/v1/documents/a4f6727a840a4df0/download_uri": {
         "download_uri": "http://localhost:3000/mock/download/url"
     },
+    "GET::api/v1/jobs/cc1d331e1ee54bac": {
+        "$uri": "/api/v1/jobs/cc1d331e1ee54bac",
+        "analysis_type": "classification",
+        "created_at": "2016-05-05T17:27:02.116480+00:00",
+        "name": "One Codex Database (2017)",
+        "public": True,
+    },
 }
 
 # explicitly load classification results for testing subset_reads

--- a/tests/test_analyses.py
+++ b/tests/test_analyses.py
@@ -150,11 +150,11 @@ def test_results_filtering_other(ocx, api_data):
 
     # remove columns where every value is zero
     results = samples.to_df(rank=None, normalize=False, remove_zeros=False)
-    assert len(results.columns) == 3157
+    assert len(results.columns) == 3156
     results["1279"] = 0
     results["1280"] = 0
     results = results.ocx.to_df(rank=None, normalize=False, remove_zeros=True)
-    assert len(results.columns) == 3155
+    assert len(results.columns) == 3154
 
     # return only taxa with at least 100 reads in one or more samples
     assert (

--- a/tests/test_analyses.py
+++ b/tests/test_analyses.py
@@ -73,10 +73,10 @@ def test_metadata_fetch(ocx, api_data):
 
     # label is a metadata field or callable
     df, fields = samples._metadata_fetch(["Label"], label="eggs")
-    assert df["Label"].tolist() == [True, True, True]
+    assert df["Label"].tolist() == ["True (1)", "True (2)", "True (3)"]
 
     df, fields = samples._metadata_fetch(["Label"], label=lambda x: str(x["eggs"]) + "_foo")
-    assert df["Label"].tolist() == ["True_foo", "True_foo", "True_foo"]
+    assert df["Label"].tolist() == ["True_foo (1)", "True_foo (2)", "True_foo (3)"]
 
     # label must be a string or callable
     with pytest.raises(OneCodexException) as e:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -127,7 +127,7 @@ def test_collate_results(ocx, api_data):
 
     assert (
         sha256(string_to_hash.encode()).hexdigest()
-        == "5353e7ada1db22624db3604f80e3d6b2c15ca476c9d47881d0e8123b7e6c009d"
+        == "dbe3adf601ca9584a49b1b5fcb1873dec5ea33986afa3f614e96609f9320c8ba"
     )
 
     # check contents of taxonomy df

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -53,11 +53,6 @@ def test_beta_diversity(ocx, api_data, metric, value, kwargs):
 def test_beta_diversity_exceptions(ocx, api_data):
     samples = ocx.Samples.where(project="4b53797444f846c4")
 
-    # should fail if data has been normalized
-    with pytest.raises(OneCodexException) as e:
-        samples.to_df(normalize=True).ocx.beta_diversity("braycurtis")
-    assert "requires unnormalized" in str(e.value)
-
     # must be a metric that exists
     with pytest.raises(OneCodexException) as e:
         samples.beta_diversity("does_not_exist")


### PR DESCRIPTION
This PR addresses:

- mainline/#3229 Changes duplicate labels in plotters, appending an incremented number to the end of each duplicate to avoid collisions in Altair. For example, two samples named `Sample` will become `Sample (1)` and `Sample (2)`
- #285 Drop host reads from `Classifications` results on a per-classification basis. For example, a sample with a human host will lose its human reads, and a sample with a pig host will lose its pig reads.
- Warn user if trying to create a `SampleCollection` containing multiple jobs. For example, a food database job and a One Codex Database job. This should warn users when analyses with multiple different hosts are mixed.
- #291 Enable jaccard, cityblock, and Bray-Curtis beta diversity metrics on normalized read counts. Users must now be careful or they will obtain bad results