### PR TITLE
Cleans up plot_distance signatures and improves project error handling

### DIFF
--- a/onecodex/models/sample.py
+++ b/onecodex/models/sample.py
@@ -25,7 +25,7 @@ def get_project(project):
             except HTTPError:
                 project_search = None
         if not project_search:
-            raise OneCodexException("{} is not a valid project UUID".format(project))
+            raise OneCodexException("Project {} does not exist. Please create the project in One Codex then try again.".format(project))
 
         if isinstance(project_search, list):
             return project_search[0]

--- a/onecodex/models/sample.py
+++ b/onecodex/models/sample.py
@@ -25,7 +25,11 @@ def get_project(project):
             except HTTPError:
                 project_search = None
         if not project_search:
-            raise OneCodexException("Project {} does not exist. Please create the project in One Codex then try again.".format(project))
+            raise OneCodexException(
+                "Project {} does not exist. Please create the project in One Codex then try again.".format(
+                    project
+                )
+            )
 
         if isinstance(project_search, list):
             return project_search[0]

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -167,9 +167,7 @@ class VizDistanceMixin(DistanceMixin):
         # obtained from scipy
         alt_kwargs = dict(
             x=alt.X("1) Label:N", axis=alt.Axis(title=label), sort=labels_in_order),
-            y=alt.Y(
-                "2) Label:N", axis=alt.Axis(title=label, orient="right"), sort=labels_in_order
-            ),
+            y=alt.Y("2) Label:N", axis=alt.Axis(title=label, orient="right"), sort=labels_in_order),
             color="Distance:Q",
             tooltip=list(chain.from_iterable(formatted_fields)) + ["Distance:Q"],
             href="url:N",

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -76,8 +76,6 @@ class VizDistanceMixin(DistanceMixin):
         rank="auto",
         metric="braycurtis",
         title=None,
-        xlabel=None,
-        ylabel=None,
         tooltip=None,
         return_chart=False,
         linkage="average",
@@ -95,10 +93,6 @@ class VizDistanceMixin(DistanceMixin):
             The type of linkage to use when clustering axes.
         title : `string`, optional
             Text label at the top of the plot.
-        xlabel : `string`, optional
-            Text label along the horizontal axis.
-        ylabel : `string`, optional
-            Text label along the vertical axis.
         tooltip : `string` or `list`, optional
             A string or list containing strings representing metadata fields. When a point in the
             plot is hovered over, the value of the metadata associated with that sample will be
@@ -172,9 +166,9 @@ class VizDistanceMixin(DistanceMixin):
         # it's important to tell altair to order the cells in the heatmap according to the clustering
         # obtained from scipy
         alt_kwargs = dict(
-            x=alt.X("1) Label:N", axis=alt.Axis(title=xlabel), sort=labels_in_order),
+            x=alt.X("1) Label:N", axis=alt.Axis(title=label), sort=labels_in_order),
             y=alt.Y(
-                "2) Label:N", axis=alt.Axis(title=ylabel, orient="right"), sort=labels_in_order
+                "2) Label:N", axis=alt.Axis(title=label, orient="right"), sort=labels_in_order
             ),
             color="Distance:Q",
             tooltip=list(chain.from_iterable(formatted_fields)) + ["Distance:Q"],

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -180,19 +180,12 @@ def test_plot_distance(ocx, api_data):
     samples = ocx.Samples.where(project="4b53797444f846c4")
 
     chart = samples.plot_distance(
-        metric="unifrac",
-        xlabel="my xlabel",
-        ylabel="my ylabel",
-        title="my title",
-        tooltip="vegetables",
-        return_chart=True,
+        metric="unifrac", title="my title", tooltip="vegetables", return_chart=True
     )
     assert len(chart.hconcat) == 2
 
     mainplot = chart.hconcat[1]
     assert mainplot.mark == "rect"
-    assert mainplot.encoding.x.axis.title == "my xlabel"
-    assert mainplot.encoding.y.axis.title == "my ylabel"
     assert sorted([x.shorthand for x in mainplot.encoding.tooltip]) == [
         "1) Label",
         "1) vegetables",
@@ -218,9 +211,7 @@ def test_plot_distance_exceptions(ocx, api_data):
 
     # need more than one analysis
     with pytest.raises(OneCodexException) as e:
-        samples[:1].plot_distance(
-            metric="jaccard", xlabel="my xlabel", ylabel="my ylabel", title="my title"
-        )
+        samples[:1].plot_distance(metric="jaccard", title="my title")
     assert "requires 2 or more" in str(e.value)
 
     # tooltip with invalid metadata fields or taxids


### PR DESCRIPTION
This PR addresses:

- #304: We previously supported a separate `xlabel` and `ylabel` in our `plot_distance` helper. Since this plot is symmetric, I simplified this to just use the `label` as both axis titles (since we don't support using different fields for the different axes anyway)
- #317: I just adjusted a misleading error message for when a user tries to upload a sample into a project that doesn't exist from the CLI.