### PR TITLE
Fix edge case in subset_reads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -q -U pip
-            pip install --progress-bar=off numpy tuna
+            pip install --progress-bar=off numpy tuna==0.3.3
             pip install --progress-bar=off .[all,testing]
       - run:
           name: Run tests

--- a/onecodex/lib/auth.py
+++ b/onecodex/lib/auth.py
@@ -56,7 +56,7 @@ def check_version(version, server):
     """
 
     def version_inadequate(client_version, server_version):
-        """Simple, fast check for version inequality.
+        """Check for version inequality.
 
         Could use python package `semver` if we need more precise checks in edge cases, but this
         generally works for now.

--- a/onecodex/scripts/subset_reads.py
+++ b/onecodex/scripts/subset_reads.py
@@ -277,6 +277,9 @@ def cli(
         save_msg += " and {}".format(rev_filtered_filename)
     click.echo(save_msg, err=True)
 
+    # see mainline/#3513. we must set idx=0 here for cases where the fastx file is empty
+    idx = 0
+
     with click.progressbar(length=tsv_row_count) as bar, gzip.open(readlevel_path, "rt") as tsv:
         reader = csv.DictReader(tsv, delimiter="\t")
 

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -153,7 +153,11 @@ class VizBargraphMixin(object):
             dfs_to_plot.append(blank_df)
 
             for md_val in magic_metadata[magic_fields[haxis]].unique():
-                plot_df = df.where(df[magic_fields[haxis]] == md_val).dropna()
+                # special case where the metadata value is None: must use isnull()
+                if md_val is None:
+                    plot_df = df.where(df[magic_fields[haxis]].isnull()).dropna(how="all")
+                else:
+                    plot_df = df.where(df[magic_fields[haxis]] == md_val).dropna(how="all")
 
                 # preserve booleans
                 if magic_metadata[magic_fields[haxis]].dtype == "bool":

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -170,7 +170,7 @@ def test_upload_lots_of_files(files, n_uploads, fxi_calls, fxp_calls):
         sz = "os.path.getsize"
 
         with patch(uso) as upload_sequence_fileobj, patch(fxi) as paired, patch(fxp) as passthru:
-            with patch(sz, size_effect=fake_size) as _:
+            with patch(sz, size_effect=fake_size):
                 upload_sequence(files, FakeSamplesResource())
 
                 assert upload_sequence_fileobj.call_count == n_uploads
@@ -181,7 +181,7 @@ def test_upload_lots_of_files(files, n_uploads, fxi_calls, fxp_calls):
         with patch(udo) as upload_document_fileobj, patch(
             "onecodex.lib.upload.FilePassthru"
         ) as passthru:
-            with patch(sz, size_effect=fake_size) as _:
+            with patch(sz, size_effect=fake_size):
                 files = files[0] if isinstance(files, tuple) else files
                 upload_document(files, FakeDocumentsResource())
 


### PR DESCRIPTION
This closes mainline/#3513 where an exception is improperly handled by `subset_reads` if the target FASTX file is empty.