### PR TITLE
Faster imports for `viz` and `analyses` subpackages

### DIFF
--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from onecodex.exceptions import OneCodexException
 from onecodex.taxonomy import TaxonomyMixin
 
@@ -19,6 +17,7 @@ class DistanceMixin(TaxonomyMixin):
         -------
         pandas.DataFrame, a distance matrix.
         """
+        import pandas as pd
         import skbio.diversity
 
         if metric not in ("simpson", "chao1", "shannon"):

--- a/onecodex/models/__init__.py
+++ b/onecodex/models/__init__.py
@@ -372,7 +372,7 @@ class OneCodexBase(object):
         # FIXME: this doesn't actually work though, because potion creates these routes for all
         # items :/
         method_links = cls._resource._schema["links"]
-        return any(True for l in method_links if l["rel"] == method_name)
+        return any(True for link in method_links if link["rel"] == method_name)
 
     @classmethod
     def all(cls, sort=None, limit=None):
@@ -427,7 +427,9 @@ class OneCodexBase(object):
             "_instances", "instances" if not public else "instances_public"
         )
 
-        schema = next(l for l in cls._resource._schema["links"] if l["rel"] == instances_route)
+        schema = next(
+            link for link in cls._resource._schema["links"] if link["rel"] == instances_route
+        )
         sort_schema = schema["schema"]["properties"]["sort"]["properties"]
         where_schema = schema["schema"]["properties"]["where"]["properties"]
 

--- a/onecodex/models/sample.py
+++ b/onecodex/models/sample.py
@@ -123,7 +123,9 @@ class Samples(OneCodexBase, ResourceDownloadMixin):
         md_search_keywords = {}
         if not public and not organization:
             md_schema = next(
-                l for l in Metadata._resource._schema["links"] if l["rel"] == instances_route
+                link
+                for link in Metadata._resource._schema["links"]
+                if link["rel"] == instances_route
             )
 
             md_where_schema = md_schema["schema"]["properties"]["where"]["properties"]

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -164,7 +164,7 @@ def cli_resource_fetcher(ctx, resource, uris, print_results=True):
                         )
                 except requests.exceptions.HTTPError as e:
                     log.error(
-                        "Could not find %s %s (%d status code)".format(
+                        "Could not find {} {} ({} status code)".format(
                             resource_name, uri, e.response.status_code
                         )
                     )

--- a/onecodex/viz/__init__.py
+++ b/onecodex/viz/__init__.py
@@ -1,4 +1,5 @@
-import altair as alt
+import imp
+import sys
 
 from onecodex.viz._heatmap import VizHeatmapMixin
 from onecodex.viz._pca import VizPCAMixin
@@ -46,23 +47,49 @@ def onecodex_theme():
     }
 
 
-alt.themes.register("onecodex", onecodex_theme)
-alt.themes.enable("onecodex")
+# Define an import hook to configure Altair's theme and renderer the first time
+# it is imported. Directly importing and configuring Altair in this subpackage
+# can slow down the API and CLI. An import hook avoids this performance hit by
+# configuring Altair during deferred import in visualization code.
+#
+# Note: this code is currently Python 2/3 compatible by using the `imp`
+# package, which is deprecated in Python 3. Consider using `importlib` if this
+# subpackage doesn't need to support Python 2.
+#
+# Based on: https://stackoverflow.com/a/60352956/3776794
+class _AltairImportHook(object):
+    def find_module(self, fullname, path=None):
+        if fullname != "altair":
+            return None
+        self.module_info = imp.find_module(fullname, path)
+        return self
+
+    def load_module(self, fullname):
+        """Load Altair module and configure its theme and renderer."""
+        previously_loaded = fullname in sys.modules
+        altair = imp.load_module(fullname, *self.module_info)
+
+        if not previously_loaded:
+            self._configure_altair(altair)
+        return altair
+
+    def _configure_altair(self, altair):
+        altair.themes.register("onecodex", onecodex_theme)
+        altair.themes.enable("onecodex")
+
+        # Render using `altair_saver` if installed (report environment only, requires node deps)
+        if "altair_saver" in altair.renderers.names():
+            altair.renderers.enable(
+                "altair_saver",
+                fmts=["html", "svg"],
+                embed_options=VEGAEMBED_OPTIONS,
+                vega_cli_options=["--loglevel", "error"],
+            )
+        else:
+            altair.renderers.enable("html", embed_options=VEGAEMBED_OPTIONS)
 
 
-# Render using `altair_saver` if installed (report environment only, requires node deps)
-try:
-    import altair_saver  # noqa
-
-    alt.renderers.enable(
-        "altair_saver",
-        fmts=["html", "svg"],
-        embed_options=VEGAEMBED_OPTIONS,
-        vega_cli_options=["--loglevel", "error"],
-    )
-except ImportError:
-    alt.renderers.enable("html", embed_options=VEGAEMBED_OPTIONS)
-
+sys.meta_path = [_AltairImportHook()] + sys.meta_path
 
 __all__ = [
     "VizPCAMixin",

--- a/onecodex/viz/_primitives.py
+++ b/onecodex/viz/_primitives.py
@@ -1,6 +1,3 @@
-import altair as alt
-import pandas as pd
-
 from onecodex.exceptions import OneCodexException
 
 
@@ -28,6 +25,9 @@ def boxplot(df, category, quantity, category_type="N", title=None, xlabel=None, 
     -------
     `altair.Chart`
     """
+    # Deferred imports
+    import altair as alt
+
     # must be one of Nominal, Ordinal, Time per altair
     if category_type not in ("N", "O", "T"):
         raise OneCodexException("If specifying category_type, must be N, O, or T")
@@ -85,6 +85,10 @@ def dendrogram(tree):
     -------
     `altair.Chart`
     """
+    # Deferred imports
+    import altair as alt
+    import pandas as pd
+
     plot_data = {
         "x": [],
         "y": [],

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [aliases]
 test=tox
+
+[flake8]
+per-file-ignores=tests/test_*.py: E402

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -22,16 +22,16 @@ import pytest
             "from onecodex.viz import VizPCAMixin",
             {
                 "onecodex": 0.25,
-                "onecodex.viz": 1.00,  # TODO: Get this time down
+                "onecodex.viz": 0.20,
                 "onecodex.viz._pca": 0.01,
                 "onecodex.viz._distance": 0.01,
             },
-            1.00,
+            0.25,
         ),
         (
             "from onecodex.analyses import AnalysisMixin",
-            {"onecodex": 0.25, "onecodex.analyses": 1.00},
-            1.00,
+            {"onecodex": 0.25, "onecodex.analyses": 0.20},
+            0.25,
         ),
     ],
 )

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -5,6 +5,18 @@ pytest.importorskip("pandas")  # noqa
 from onecodex.exceptions import OneCodexException
 
 
+def test_altair_ocx_theme(ocx, api_data):
+    import altair as alt
+
+    assert alt.themes.active == "onecodex"
+
+
+def test_altair_renderer(ocx, api_data):
+    import altair as alt
+
+    assert alt.renderers.active in {"altair_saver", "html"}
+
+
 def test_plot_metadata(ocx, api_data):
     samples = ocx.Samples.where(project="4b53797444f846c4")
 


### PR DESCRIPTION
## Description

Sped up import times for `onecodex.viz` and `onecodex.analyses` subpackages. Testing locally on a macOS laptop, the previous import time for each package was ~670ms, and the new import time is ~170ms.

Faster imports are achieved by defining an import hook to configure Altair's theme and renderer the first time it is imported. Directly importing and configuring Altair in the `onecodex.viz` subpackage was the primary cause of the slow imports. An import hook avoids this performance hit by configuring Altair during deferred import in visualization code.

I also deferred a few more imports in the `viz` subpackage, and added a couple of unit tests to ensure Altair is being configured as expected.

Addresses part of #248.

## Question for reviewers

The import hook code is Python 2/3 compatible by using the `imp` package, which is deprecated in Python 3. Do we want to use the current implementation, or is it preferable to drop support for Python 2 and use the `importlib` package?