### PR TITLE
Faster imports for `viz` and `analyses` subpackages

### DIFF
--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from onecodex.exceptions import OneCodexException
 from onecodex.taxonomy import TaxonomyMixin
 from onecodex.lib.enums import AlphaDiversityMetric, BetaDiversityMetric, Rank
@@ -20,6 +18,7 @@ class DistanceMixin(TaxonomyMixin):
         -------
         pandas.DataFrame, a distance matrix.
         """
+        import pandas as pd
         import skbio.diversity
 
         if not AlphaDiversityMetric.has_value(metric):

--- a/onecodex/viz/__init__.py
+++ b/onecodex/viz/__init__.py
@@ -1,4 +1,5 @@
-import altair as alt
+import imp
+import sys
 
 from onecodex.viz._heatmap import VizHeatmapMixin
 from onecodex.viz._pca import VizPCAMixin
@@ -46,23 +47,49 @@ def onecodex_theme():
     }
 
 
-alt.themes.register("onecodex", onecodex_theme)
-alt.themes.enable("onecodex")
+# Define an import hook to configure Altair's theme and renderer the first time
+# it is imported. Directly importing and configuring Altair in this subpackage
+# can slow down the API and CLI. An import hook avoids this performance hit by
+# configuring Altair during deferred import in visualization code.
+#
+# Note: this code is currently Python 2/3 compatible by using the `imp`
+# package, which is deprecated in Python 3. Consider using `importlib` if this
+# subpackage doesn't need to support Python 2.
+#
+# Based on: https://stackoverflow.com/a/60352956/3776794
+class _AltairImportHook(object):
+    def find_module(self, fullname, path=None):
+        if fullname != "altair":
+            return None
+        self.module_info = imp.find_module(fullname, path)
+        return self
+
+    def load_module(self, fullname):
+        """Load Altair module and configure its theme and renderer."""
+        previously_loaded = fullname in sys.modules
+        altair = imp.load_module(fullname, *self.module_info)
+
+        if not previously_loaded:
+            self._configure_altair(altair)
+        return altair
+
+    def _configure_altair(self, altair):
+        altair.themes.register("onecodex", onecodex_theme)
+        altair.themes.enable("onecodex")
+
+        # Render using `altair_saver` if installed (report environment only, requires node deps)
+        if "altair_saver" in altair.renderers.names():
+            altair.renderers.enable(
+                "altair_saver",
+                fmts=["html", "svg"],
+                embed_options=VEGAEMBED_OPTIONS,
+                vega_cli_options=["--loglevel", "error"],
+            )
+        else:
+            altair.renderers.enable("html", embed_options=VEGAEMBED_OPTIONS)
 
 
-# Render using `altair_saver` if installed (report environment only, requires node deps)
-try:
-    import altair_saver  # noqa
-
-    alt.renderers.enable(
-        "altair_saver",
-        fmts=["html", "svg"],
-        embed_options=VEGAEMBED_OPTIONS,
-        vega_cli_options=["--loglevel", "error"],
-    )
-except ImportError:
-    alt.renderers.enable("html", embed_options=VEGAEMBED_OPTIONS)
-
+sys.meta_path = [_AltairImportHook()] + sys.meta_path
 
 __all__ = [
     "VizPCAMixin",

--- a/onecodex/viz/_primitives.py
+++ b/onecodex/viz/_primitives.py
@@ -1,6 +1,3 @@
-import altair as alt
-import pandas as pd
-
 from onecodex.exceptions import OneCodexException
 
 
@@ -49,6 +46,10 @@ def dendrogram(tree):
     -------
     `altair.Chart`
     """
+    # Deferred imports
+    import altair as alt
+    import pandas as pd
+
     plot_data = {
         "x": [],
         "y": [],

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -22,16 +22,16 @@ import pytest
             "from onecodex.viz import VizPCAMixin",
             {
                 "onecodex": 0.25,
-                "onecodex.viz": 1.00,  # TODO: Get this time down
+                "onecodex.viz": 0.20,
                 "onecodex.viz._pca": 0.01,
                 "onecodex.viz._distance": 0.01,
             },
-            1.00,
+            0.25,
         ),
         (
             "from onecodex.analyses import AnalysisMixin",
-            {"onecodex": 0.25, "onecodex.analyses": 1.00},
-            1.00,
+            {"onecodex": 0.25, "onecodex.analyses": 0.20},
+            0.25,
         ),
     ],
 )

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -5,6 +5,18 @@ pytest.importorskip("pandas")  # noqa
 from onecodex.exceptions import OneCodexException
 
 
+def test_altair_ocx_theme(ocx, api_data):
+    import altair as alt
+
+    assert alt.themes.active == "onecodex"
+
+
+def test_altair_renderer(ocx, api_data):
+    import altair as alt
+
+    assert alt.renderers.active in {"altair_saver", "html"}
+
+
 def test_plot_metadata(ocx, api_data):
     samples = ocx.Samples.where(project="4b53797444f846c4")
 


### PR DESCRIPTION
## Description

This PR replaces #352.

Sped up import times for `onecodex.viz` and `onecodex.analyses` subpackages. Testing locally on a macOS laptop, the previous import times for both packages were ~670ms, and the new import times are ~170ms.

Faster imports are achieved by defining an import hook to configure Altair's theme and renderer the first time it is imported. Directly importing and configuring Altair in the `onecodex.viz` subpackage was the primary cause of the slow imports. An import hook avoids this performance hit by configuring Altair during deferred import in visualization code.

I also deferred a few more imports in the `viz` subpackage, and added a couple of unit tests to ensure Altair is being configured as expected.

Addresses part of #248.

## TODO

The import hook code is Python 2/3 compatible by using the `imp` package, which is deprecated in Python 3. I spent some time today attempting to update the code to use Python 3's `importlib` package but wasn't able to get it to work. I'm happy to continue working on this but likely won't have it ready for the `v0.8.0` release today. @boydgreenfield, please feel free to push additional commits if you have time to work on the `importlib` issue in the meantime. Thanks!