### PR TITLE
Minor bugfixes for a v0.8.1 release

### DIFF
--- a/notebook_examples/notebooks_demo.ipynb
+++ b/notebook_examples/notebooks_demo.ipynb
@@ -120,7 +120,7 @@
     "    label=lambda metadata: str(metadata[\"host_age\"]),\n",
     "    title=\"Subject P014839 Over Time\",\n",
     "    xlabel=\"Host Age at Sampling Time (days)\",\n",
-    "    ylabel=\"Normalized Read Count\",\n",
+    "    ylabel=\"Relative Abundance\",\n",
     "    legend=\"Genus\",\n",
     ")"
    ]
@@ -138,7 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_rel[:30].ocx.plot_heatmap(legend=\"Normalized Read Count\", tooltip=\"geo_loc_name\")"
+    "df_rel[:30].ocx.plot_heatmap(legend=\"Relative Abundance\", tooltip=\"geo_loc_name\")"
    ]
   },
   {

--- a/onecodex/notebooks/exporters.py
+++ b/onecodex/notebooks/exporters.py
@@ -12,6 +12,7 @@ from traitlets import default
 
 from onecodex.exceptions import UploadException
 from onecodex.notebooks import report
+from onecodex.utils import get_raven_client
 
 
 ASSETS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "assets"))
@@ -209,12 +210,14 @@ class OneCodexDocumentExporter(OneCodexPDFExporter):
 
         try:
             document_id = _upload_document_fileobj(
-                BytesIO(output), file_name, ocx._client.session, ocx.Documents._resource
+                BytesIO(output), file_name, ocx.Documents._resource
             )
         except UploadException as exc:
             resp = json.dumps({"status": 500, "message": str(exc)})
             return resp, resources
-        except Exception:
+        except Exception as exc:
+            client = get_raven_client()
+            client.captureException(exc)
             resp = json.dumps(
                 {
                     "status": 500,


### PR DESCRIPTION
This PR includes 2 principal bug fixes/enhancements:

1. Adds better retry logic for the upload confirmation request. If this request failed for any reason, it cancels the rest of the uploads. Now it retries with a conservative backoff.

2. Fixes a bug with the "Export to One Codex" upload flow.

The objective is to push a `v0.8.1` release. 

Fixes DEV-3915, fixes DEV-3921, fixes DEV-2703.