### PR TITLE
Display sample filenames if an upload is canceled

### DIFF
--- a/onecodex/lib/upload.py
+++ b/onecodex/lib/upload.py
@@ -231,7 +231,13 @@ def upload_sequence(
         def cancel_atexit():
             bar.canceled = True
             bar.update(1)
-            log.info("Canceled upload for sample: {}".format(fields["sample_id"]))
+
+            if is_paired:
+                filename = "{} and {}".format(fobj.r1.filename, fobj.r2.filename)
+            else:
+                filename = fobj.filename
+
+            log.info("Canceled upload for {} as sample {}".format(filename, fields["sample_id"]))
 
             try:
                 samples_resource.cancel_upload({"sample_id": fields["sample_id"]})


### PR DESCRIPTION
## Description

The API and CLI now log a sample's filename(s) if an upload is canceled.

For example, the following is logged for single and paired-end samples, respectively:

```
Canceled upload for sample1.fasta as sample 35617d7d0a8646ba
Canceled upload for sample_R1.fastq and sample_R2.fastq as sample 53d50ac9c1474de6
```

## Questions

1. Would you like me to add a unit test for canceling an upload?
2. Is a changelog entry necessary, or does that happen at release time?