### PR TITLE
Improve input validation in plotting methods

### DIFF
--- a/onecodex/exceptions.py
+++ b/onecodex/exceptions.py
@@ -36,6 +36,18 @@ class RetryableUploadException(UploadException):
     pass
 
 
+class PlottingException(OneCodexException):
+    """User-facing plotting error for cases when the user may take action to resolve the issue."""
+
+    pass
+
+
+class PlottingWarning(UserWarning):
+    """User-facing plotting warning for cases when the user may take action to resolve the issue."""
+
+    pass
+
+
 def raise_api_error(resp, state=None):
     """Raise an exception with a pretty message in various states of upload."""
     # TODO: Refactor into an Exception class

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -1,4 +1,4 @@
-from onecodex.exceptions import OneCodexException
+from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.lib.enums import AbundanceMetric, Rank, Metric
 from onecodex.viz._primitives import sort_helper, prepare_props
 
@@ -80,6 +80,12 @@ class VizBargraphMixin(object):
 
         if not (threshold or top_n):
             raise OneCodexException("Please specify at least one of: threshold, top_n")
+
+        if len(self._results) < 1:
+            raise PlottingException(
+                "There are too few samples for bargraph plots after filtering. Please select 1 or "
+                "more samples to plot."
+            )
 
         if top_n == "auto" and threshold == "auto":
             top_n = 10

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -3,7 +3,7 @@ from itertools import chain
 import warnings
 
 from onecodex.lib.enums import BetaDiversityMetric, Rank, Linkage, OrdinationMethod
-from onecodex.exceptions import OneCodexException
+from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.distance import DistanceMixin
 from onecodex.viz._primitives import prepare_props
 
@@ -125,8 +125,9 @@ class VizDistanceMixin(DistanceMixin):
         from onecodex.viz import dendrogram
 
         if len(self._results) < 2:
-            raise OneCodexException(
-                "`plot_distance` requires 2 or more valid classification results."
+            raise PlottingException(
+                "There are too few samples for distance matrix plots after filtering. Please "
+                "select 2 or more samples to plot."
             )
 
         # this will be passed to the heatmap chart as a dataframe eventually
@@ -289,8 +290,11 @@ class VizDistanceMixin(DistanceMixin):
         from sklearn import manifold
         from sklearn.metrics.pairwise import euclidean_distances
 
-        if len(self._results) < 2:
-            raise OneCodexException("`plot_mds` requires 2 or more valid classification results.")
+        if len(self._results) < 3:
+            raise PlottingException(
+                "There are too few samples for MDS/PCoA after filtering. Please select 3 or more "
+                "samples to plot."
+            )
 
         dists = self._compute_distance(rank, metric).to_data_frame()
 

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -1,5 +1,5 @@
 from onecodex.lib.enums import Rank, Linkage
-from onecodex.exceptions import OneCodexException
+from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.viz._primitives import prepare_props, sort_helper
 
 
@@ -89,8 +89,9 @@ class VizHeatmapMixin(object):
             raise OneCodexException("Please specify at least one of: threshold, top_n")
 
         if len(self._results) < 2:
-            raise OneCodexException(
-                "`plot_heatmap` requires 2 or more valid classification results."
+            raise PlottingException(
+                "There are too few samples for heatmap plots after filtering. Please select 2 or "
+                "more samples to plot."
             )
 
         if top_n == "auto" and threshold == "auto":
@@ -104,6 +105,12 @@ class VizHeatmapMixin(object):
         df = self.to_df(
             rank=rank, normalize=normalize, top_n=top_n, threshold=threshold, table_format="long"
         )
+
+        if len(df["tax_id"].unique()) < 2:
+            raise PlottingException(
+                "There are too few taxa for heatmap clustering after filtering. Please select a "
+                "rank or threshold that includes at least 2 taxa."
+            )
 
         if legend == "auto":
             legend = df.ocx.metric

--- a/onecodex/viz/_pca.py
+++ b/onecodex/viz/_pca.py
@@ -1,6 +1,6 @@
 from onecodex.lib.enums import Rank
 from onecodex.viz._primitives import prepare_props
-from onecodex.exceptions import OneCodexException
+from onecodex.exceptions import OneCodexException, PlottingException
 
 
 class VizPCAMixin(object):
@@ -83,13 +83,19 @@ class VizPCAMixin(object):
         if rank is None:
             raise OneCodexException("Please specify a rank or 'auto' to choose automatically")
 
-        if len(self._results) < 2:
-            raise OneCodexException("`plot_pca` requires 2 or more valid classification results.")
+        if len(self._results) < 3:
+            raise PlottingException(
+                "There are too few samples for PCA after filtering. Please select 3 or more "
+                "samples to plot."
+            )
 
         df = self.to_df(rank=rank, normalize=normalize)
 
         if len(df.columns) < 2:
-            raise OneCodexException("Too few taxa in results. Need at least 2 for PCA.")
+            raise PlottingException(
+                "There are too few taxa for PCA after filtering. Please select a rank that "
+                "includes at least 2 taxa."
+            )
 
         if tooltip:
             if not isinstance(tooltip, list):


### PR DESCRIPTION
Improved input validation for the various `plot_*` methods in the `onecodex.viz` subpackage:

- Added `onecodex.exceptions.PlottingException` for reporting user-facing plotting errors (e.g. for the plot builder). This exception type is a subclass of `OneCodexException`.

- Added `onecodex.exceptions.PlottingWarning` for reporting user-facing plotting warnings (e.g. for the plot builder). This warning type is a subclass of `UserWarning`.

- Methods now require that the minimum number of samples and/or taxa are present for a given plot type. This number varies by type, and is usally a minimum of 1, 2, or 3 samples or taxa.

- `plot_metadata` now raises a `PlottingWarning` if any boxplot groups of size 1 are detected (groups of size 1 are not displayed by Altair, and the plot builder may wish to catch and display this warning to users).

@clausmith and @lynchde, please let me know if there are any additional checks you'd like me to add. Thanks!