### PR TITLE
Fixes bug where scikit-bio would fail when plotting Weighted Unifrac distances

### DIFF
--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -121,11 +121,11 @@ class DistanceMixin(TaxonomyMixin):
                 BetaDiversityMetric.WeightedUnifrac,
                 df,
                 df.index,
-                tree=tree,
+                tree=new_tree,
                 otu_ids=tax_ids,
                 normalized=True,
             )
         else:
             return skbio.diversity.beta_diversity(
-                BetaDiversityMetric.UnweightedUnifrac, df, df.index, tree=tree, otu_ids=tax_ids,
+                BetaDiversityMetric.UnweightedUnifrac, df, df.index, tree=new_tree, otu_ids=tax_ids,
             )

--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -102,6 +102,19 @@ class DistanceMixin(TaxonomyMixin):
         tree = self.tree_build()
         tree = self.tree_prune_rank(tree, rank=ocx_rank)
 
+        # `scikit-bio` requires that the tree root has no more than 2
+        # children, otherwise it considers it "unrooted".
+        #
+        # https://github.com/biocore/scikit-bio/blob/f3ae1dcfe8ea88e52e19f6693d79e529d05bda04/skbio/diversity/_util.py#L89
+        #
+        # Our taxonomy root regularly has more than 2 children, so we
+        # add a fake parent of `root` to the tree here.
+        from skbio.tree import TreeNode
+
+        new_tree = TreeNode(name="fake root")
+        new_tree.rank = "no rank"
+        new_tree.append(tree)
+
         # then finally run the calculation and return
         if weighted:
             return skbio.diversity.beta_diversity(

--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -186,9 +186,17 @@ class VizMetadataMixin(object):
                     PlottingWarning,
                 )
 
+            box_size = 45
+            increment = 5
+
+            n_boxes = len(df[magic_fields[haxis]].unique())
+
+            if (n_boxes * (box_size + increment)) > width:
+                box_size = ((width / n_boxes) // increment) * increment - increment
+
             chart = (
                 alt.Chart(df)
-                .mark_boxplot(size=35)
+                .mark_boxplot(size=box_size)
                 .encode(
                     x=alt.X(magic_fields[haxis], axis=alt.Axis(title=xlabel)),
                     y=alt.Y(magic_fields[vaxis], axis=alt.Axis(title=ylabel)),


### PR DESCRIPTION
There was a bug introduced in `v0.8.0` where I had removed some code that was required to workaround a limitation in `scikit-bio`. This PR re-implements that workaround.