### PR TITLE
Add download retries to ResourceDownloadMixin

### DIFF
--- a/onecodex/api.py
+++ b/onecodex/api.py
@@ -49,7 +49,7 @@ class Api(object):
         if kwargs.get("experimental", False):
             warnings.warn(
                 "Experimental API mode enabled. Features of the experimental API are subject to "
-                "change without notice and should not be relied upon in a production enviroment."
+                "change without notice and should not be relied upon in a production environment."
             )
             schema_path = "/api/v1_experimental/schema"
             cache_schema = False

--- a/onecodex/models/experimental.py
+++ b/onecodex/models/experimental.py
@@ -79,6 +79,40 @@ class AnnotationSets(OneCodexBase, ResourceDownloadMixin):
 class Assemblies(OneCodexBase, ResourceDownloadMixin):
     _resource_path = "/api/v1_experimental/assemblies"
 
+    def download(self, path=None, file_obj=None, progressbar=False):
+        """Download an Assembly in FASTA format.
+
+        Parameters
+        ----------
+        path : `string`, optional
+            Full path to save the file to. If omitted, the file will be saved in the current working
+            directory. The filename will include the taxon name (if available), followed by the
+            genome name (if available), followed by the genome UUID. If this assembly is not
+            associated with a genome, the filename will be ``assembly_<UUID>.fasta``.
+        file_obj : file-like object, optional
+            Rather than save the file to a path, write it to this file-like object.
+        progressbar : `bool`
+            Display a progress bar using Click for the download?
+
+        Returns
+        -------
+        `string`
+            The path the file was downloaded to, if applicable. Otherwise, None.
+
+        Notes
+        -----
+        Existing paths will not be overwritten.
+        """
+        return self._download(
+            "download_uri",
+            # Set `_filename` to `None` to use the filename provided by the server.
+            _filename=None,
+            use_potion_session=False,
+            path=path,
+            file_obj=file_obj,
+            progressbar=progressbar,
+        )
+
 
 class Genomes(OneCodexBase):
     _resource_path = "/api/v1_experimental/genomes"

--- a/onecodex/models/helpers.py
+++ b/onecodex/models/helpers.py
@@ -140,15 +140,15 @@ class ResourceDownloadMixin(object):
 
         try:
             method_to_call = getattr(self._resource, _resource_method)
-            download_info = method_to_call()
+            download_link_info = method_to_call()
 
             if path is None and file_obj is None:
                 if _filename is None:
-                    if "filename" not in download_info:
+                    if "save_as_filename" not in download_link_info:
                         raise OneCodexException(
                             "Please specify `path`, `file_obj`, or `_filename`."
                         )
-                    _filename = download_info["filename"]
+                    _filename = download_link_info["save_as_filename"]
                 path = os.path.join(os.getcwd(), _filename)
 
             if path and os.path.exists(path):
@@ -159,7 +159,7 @@ class ResourceDownloadMixin(object):
             else:
                 session = requests.Session()
 
-            link = download_info["download_uri"]
+            link = download_link_info["download_uri"]
 
             # Retry up to 5 times with backoff timing of 2s, 4s, 8s, 16s, and 32s (applies to all
             # HTTP methods). 404 is included for cases where the file is being asynchronously

--- a/onecodex/models/helpers.py
+++ b/onecodex/models/helpers.py
@@ -2,8 +2,6 @@ import click
 import inspect
 import os
 import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 
 from onecodex.exceptions import OneCodexException, UnboundObject
 
@@ -135,6 +133,9 @@ class ResourceDownloadMixin(object):
         file_obj=None,
         progressbar=False,
     ):
+        from requests.adapters import HTTPAdapter
+        from requests.packages.urllib3.util.retry import Retry
+
         if path and file_obj:
             raise OneCodexException("Please specify only one of: path, file_obj")
 
@@ -178,7 +179,8 @@ class ResourceDownloadMixin(object):
 
             with (open(path, "wb") if path else file_obj) as f_out:
                 if progressbar:
-                    with click.progressbar(length=self.size, label=self.id) as bar:
+                    progress_label = os.path.basename(path) if path else self.filename
+                    with click.progressbar(length=self.size, label=progress_label) as bar:
                         for data in resp.iter_content(chunk_size=1024):
                             bar.update(len(data))
                             f_out.write(data)

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import datetime
+import io
 import pytest
 import responses
 import sys
@@ -87,9 +88,13 @@ def test_download_use_potion_session(runner, ocx, api_data):
 
 
 def test_download_with_progressbar(runner, ocx, api_data):
+    doc = ocx.Documents.get("a4f6727a840a4df0")
+
     with runner.isolated_filesystem():
-        doc = ocx.Documents.get("a4f6727a840a4df0")
         doc.download(progressbar=True)
+
+    file_obj = io.BytesIO()
+    doc.download(file_obj=file_obj, progressbar=True)
 
 
 def test_resourcelist(ocx, api_data):

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -63,6 +63,35 @@ def test_document_download(runner, ocx, api_data):
         doc.download()
 
 
+def test_download_without_filename(runner, ocx, api_data):
+    with runner.isolated_filesystem():
+        doc = ocx.Documents.get("a4f6727a840a4df0")
+
+        with pytest.raises(OneCodexException, match="specify `path`, `file_obj`, or `_filename`"):
+            doc._download("download_uri", _filename=None)
+
+
+def test_download_path_exists(runner, ocx, api_data):
+    with runner.isolated_filesystem():
+        doc = ocx.Documents.get("a4f6727a840a4df0")
+        doc.download()
+
+        with pytest.raises(OneCodexException, match="already exists"):
+            doc.download()
+
+
+def test_download_use_potion_session(runner, ocx, api_data):
+    with runner.isolated_filesystem():
+        doc = ocx.Documents.get("a4f6727a840a4df0")
+        doc._download("download_uri", doc.filename, use_potion_session=True)
+
+
+def test_download_with_progressbar(runner, ocx, api_data):
+    with runner.isolated_filesystem():
+        doc = ocx.Documents.get("a4f6727a840a4df0")
+        doc.download(progressbar=True)
+
+
 def test_resourcelist(ocx, api_data):
     sample = ocx.Samples.get("761bc54b97f64980")
     tags1 = onecodex.models.ResourceList(sample.tags._resource, onecodex.models.misc.Tags)


### PR DESCRIPTION
Added retries to `ResourceDownloadMixin` to support downloading files that may not be immediately available (e.g. downloading an `Assembly` FASTA file that is exported and uploaded to S3 asynchronously).

Also added support for using the server's suggested "save as" filename if the user doesn't provide a path or file object. Currently, only the `Assemblies` resource uses this new feature.

This change is necessary to support https://github.com/onecodex/mainline/pull/4057