### PR TITLE
Adds aitchison distance and supports cityblock-manhattan interchangea…

### DIFF
--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -48,8 +48,9 @@ class DistanceMixin(TaxonomyMixin):
 
         Parameters
         ----------
-        metric : {'jaccard', 'braycurtis', 'cityblock'}
+        metric : {'jaccard', 'braycurtis', 'cityblock', 'manhattan', 'aitchison'}
             The distance metric to calculate.
+            Note that 'cityblock' and 'manhattan' are interchangeable metrics.
         rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
             Analysis will be restricted to abundances of taxa at the specified level.
 
@@ -74,11 +75,14 @@ class DistanceMixin(TaxonomyMixin):
             return self.unifrac(weighted=False, rank=rank)
         elif metric == BetaDiversityMetric.Jaccard:
             df = df > 0  # Jaccard requires a boolean matrix, otherwise it throws a warning
+        elif metric == BetaDiversityMetric.Aitchison:
+            return self.aitchison_distance(rank=rank)
 
         # NOTE: see #291 for a discussion on using these metrics with normalized read counts. we are
         # explicitly disabling skbio's check for a counts matrix to allow normalized data to make
         # its way into this function.
-        return skbio.diversity.beta_diversity(metric, df.values, df.index, validate=False)
+        skbio_metric = "cityblock" if metric == "manhattan" else metric
+        return skbio.diversity.beta_diversity(skbio_metric, df.values, df.index, validate=False)
 
     def unifrac(self, weighted=True, rank=Rank.Auto):
         """Calculate the UniFrac beta diversity metric.
@@ -138,3 +142,41 @@ class DistanceMixin(TaxonomyMixin):
             return skbio.diversity.beta_diversity(
                 BetaDiversityMetric.UnweightedUnifrac, df, df.index, tree=new_tree, otu_ids=tax_ids,
             )
+
+    def aitchison_distance(self, rank=Rank.Auto):
+        """Calculate the Aitchison distance between samples.
+
+        Aitchison distance is the Euclidean distance between centre logratio-normalized samples (abundances).
+        As this requires log-transforms, we first need to 'estimate' zeros in the data;
+        i.e. replace zeros with small, positive values, while maintaining a constant sum to 1.
+
+        Parameters
+        ----------
+        rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
+            Analysis will be restricted to abundances of taxa at the specified level.
+
+        Returns
+        -------
+        skbio.stats.distance.DistanceMatrix, a distance matrix.
+        """
+        import numpy as np
+        from skbio.stats.composition import multiplicative_replacement, clr
+        from sklearn.metrics.pairwise import euclidean_distances
+        from skbio.stats.distance import DistanceMatrix
+
+        df = self.to_df(
+            rank=rank, normalize=self._guess_normalized()
+        )  # get a dataframe of abundances
+        df_n0 = multiplicative_replacement(df)  # replace 0s with positive small numbers
+        df_n0_clr = clr(df_n0)  # clr-normalize
+        aitchison_array = euclidean_distances(df_n0_clr, df_n0_clr)  # get the euclidean distances
+
+        # Due to rounding differences, we must force mirroring on the matrix
+        aitchison_dm = np.zeros(aitchison_array.shape)
+        aitchison_dm[np.triu_indices(aitchison_array.shape[0], k=0)] = aitchison_array[
+            np.triu_indices(aitchison_array.shape[0], k=0)
+        ]
+        aitchison_dm = aitchison_dm + aitchison_dm.T - np.diag(np.diag(aitchison_dm))
+        aitchison_dm = DistanceMatrix(aitchison_dm, df.index)
+
+        return aitchison_dm

--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -50,7 +50,7 @@ class DistanceMixin(TaxonomyMixin):
         ----------
         metric : {'jaccard', 'braycurtis', 'cityblock', 'manhattan', 'aitchison'}
             The distance metric to calculate.
-            Note that 'cityblock' and 'manhattan' are interchangeable metrics.
+            Note that 'cityblock' and 'manhattan' are equivalent metrics.
         rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
             Analysis will be restricted to abundances of taxa at the specified level.
 

--- a/onecodex/lib/enums.py
+++ b/onecodex/lib/enums.py
@@ -37,8 +37,10 @@ class BetaDiversityMetric(BaseEnum):
     Jaccard = "jaccard"
     BrayCurtis = "braycurtis"
     CityBlock = "cityblock"
+    Manhattan = "manhattan"
     WeightedUnifrac = "weighted_unifrac"
     UnweightedUnifrac = "unweighted_unifrac"
+    Aitchison = "aitchison"
 
 
 class NormalizedRank(BaseEnum):

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -99,7 +99,7 @@ class VizDistanceMixin(DistanceMixin):
             Analysis will be restricted to abundances of taxa at the specified level.
         metric : {'braycurtis', 'cityblock', 'manhattan', 'jaccard', 'unifrac', 'unweighted_unifrac', 'aitchison'}, optional
             Function to use when calculating the distance between two samples.
-            Note that 'cityblock' and 'manhattan' are interchangeable metrics.
+            Note that 'cityblock' and 'manhattan' are equivalent metrics.
         linkage : {'average', 'single', 'complete', 'weighted', 'centroid', 'median'}
             The type of linkage to use when clustering axes.
         title : `string`, optional
@@ -244,7 +244,7 @@ class VizDistanceMixin(DistanceMixin):
             Analysis will be restricted to abundances of taxa at the specified level.
         metric : {'braycurtis', 'cityblock', 'manhattan', 'jaccard', 'unifrac', 'unweighted_unifrac', 'aitchison'}, optional
             Function to use when calculating the distance between two samples.
-            Note that 'cityblock' and 'manhattan' are interchangeable metrics.
+            Note that 'cityblock' and 'manhattan' are equivalent metrics.
         method : {'pcoa', 'smacof'}
             Algorithm to use for ordination. PCoA uses eigenvalue decomposition and is not well
             suited to non-euclidean distance functions. SMACOF is an iterative optimization strategy

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -27,6 +27,8 @@ class VizDistanceMixin(DistanceMixin):
             distances = self.unifrac(weighted=True, rank=rank)
         elif metric == BetaDiversityMetric.UnweightedUnifrac:
             distances = self.unifrac(weighted=False, rank=rank)
+        elif metric == BetaDiversityMetric.Aitchison:
+            distances = self.beta_diversity(metric=BetaDiversityMetric.Aitchison, rank=rank)
         else:
             raise OneCodexException(
                 "Metric must be one of: {}".format(", ".join(BetaDiversityMetric.values()))
@@ -95,8 +97,9 @@ class VizDistanceMixin(DistanceMixin):
         ----------
         rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
             Analysis will be restricted to abundances of taxa at the specified level.
-        metric : {'braycurtis', 'manhattan', 'jaccard', 'unifrac', 'unweighted_unifrac}, optional
+        metric : {'braycurtis', 'cityblock', 'manhattan', 'jaccard', 'unifrac', 'unweighted_unifrac', 'aitchison'}, optional
             Function to use when calculating the distance between two samples.
+            Note that 'cityblock' and 'manhattan' are interchangeable metrics.
         linkage : {'average', 'single', 'complete', 'weighted', 'centroid', 'median'}
             The type of linkage to use when clustering axes.
         title : `string`, optional
@@ -239,8 +242,9 @@ class VizDistanceMixin(DistanceMixin):
         ----------
         rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
             Analysis will be restricted to abundances of taxa at the specified level.
-        metric : {'braycurtis', 'manhattan', 'jaccard', 'unifrac', 'unweighted_unifrac}, optional
+        metric : {'braycurtis', 'cityblock', 'manhattan', 'jaccard', 'unifrac', 'unweighted_unifrac', 'aitchison'}, optional
             Function to use when calculating the distance between two samples.
+            Note that 'cityblock' and 'manhattan' are interchangeable metrics.
         method : {'pcoa', 'smacof'}
             Algorithm to use for ordination. PCoA uses eigenvalue decomposition and is not well
             suited to non-euclidean distance functions. SMACOF is an iterative optimization strategy

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -42,7 +42,7 @@ class VizHeatmapMixin(object):
             samples together. Each group of samples will be clustered independently.
         metric : {'euclidean', 'braycurtis', 'cityblock', 'manhattan', 'jaccard', 'unifrac', 'unweighted_unifrac', 'aitchison'}, optional
             Function to use when calculating the distance between two samples.
-            Note that 'cityblock' and 'manhattan' are interchangeable metrics.
+            Note that 'cityblock' and 'manhattan' are equivalent metrics.
         linkage : {'average', 'single', 'complete', 'weighted', 'centroid', 'median'}
             The type of linkage to use when clustering axes.
         top_n : `int`, optional

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -40,8 +40,9 @@ class VizHeatmapMixin(object):
         haxis : `string`, optional
             The metadata field (or tuple containing multiple categorical fields) used to group
             samples together. Each group of samples will be clustered independently.
-        metric : {'euclidean', 'braycurtis', 'manhattan', 'jaccard', 'unifrac', 'unweighted_unifrac}, optional
+        metric : {'euclidean', 'braycurtis', 'cityblock', 'manhattan', 'jaccard', 'unifrac', 'unweighted_unifrac', 'aitchison'}, optional
             Function to use when calculating the distance between two samples.
+            Note that 'cityblock' and 'manhattan' are interchangeable metrics.
         linkage : {'average', 'single', 'complete', 'weighted', 'centroid', 'median'}
             The type of linkage to use when clustering axes.
         top_n : `int`, optional

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -42,9 +42,11 @@ def test_alpha_diversity_warnings(ocx, api_data):
     [
         ("braycurtis", [0.886014, 0.84694, 0.905716], {}),
         ("cityblock", [1.772028, 1.693879, 1.811432], {}),
+        ("manhattan", [1.772028, 1.693879, 1.811432], {}),
         ("jaccard", [0.742616, 0.697561, 0.752632], {}),
         ("unweighted_unifrac", [0.6, 0.547486, 0.591304], {}),
         ("weighted_unifrac", [0.503168, 0.403155, 0.605155], {}),
+        ("aitchison", [59.800677, 51.913911, 52.693709], {}),
     ],
 )
 def test_beta_diversity(ocx, api_data, metric, value, kwargs):


### PR DESCRIPTION
This will allow users to calculate Aitchison distance (beta_diversity) between samples.
It also allows users to call either 'cityblock' or 'manhattan' as a beta diversity metric, as these names are synonyms.
Closes DEV-2947 and DEV-3990