### PR TITLE
Improves handling of custom corporate CA bundles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,32 @@
 exclude: "^(onecodex/vendored|tests/api_data|tests/data)"
 repos:
   - repo: https://github.com/ambv/black
-    rev: stable
+    rev: 20.8b1
     hooks:
-    - id: black
-      language_version: python3
-      args: ["-l 100"]
+      - id: black
+        language_version: python3
+        args: ["-l 100"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0  # Use the ref you want to point at
+    rev: v3.2.0 # Use the ref you want to point at
     hooks:
-    - id: trailing-whitespace
-    - id: flake8
-    - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 5.0.2
+    rev: 5.1.0
     hooks:
-    - id: pydocstyle
-      exclude: "^(onecodex/vendored|tests/|setup.py)"
-      args:
-      - --convention=numpy
-      - --add-ignore=D100,D101,D102,D103,D104,D105,D202
-      - --match-dir='[^vendored].*'
-      - onecodex/
+      - id: pydocstyle
+        exclude: "^(onecodex/vendored|tests/|setup.py)"
+        args:
+          - --convention=numpy
+          - --add-ignore=D100,D101,D102,D103,D104,D105,D202
+          - --match-dir='[^vendored].*'
+          - onecodex/
   - repo: https://github.com/kynan/nbstripout
-    rev: master
+    rev: 0.3.9
     hooks:
       - id: nbstripout
         files: ".ipynb"

--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -140,7 +140,11 @@ class DistanceMixin(TaxonomyMixin):
             )
         else:
             return skbio.diversity.beta_diversity(
-                BetaDiversityMetric.UnweightedUnifrac, df, df.index, tree=new_tree, otu_ids=tax_ids,
+                BetaDiversityMetric.UnweightedUnifrac,
+                df,
+                df.index,
+                tree=new_tree,
+                otu_ids=tax_ids,
             )
 
     def aitchison_distance(self, rank=Rank.Auto):

--- a/onecodex/vendored/potion_client/links.py
+++ b/onecodex/vendored/potion_client/links.py
@@ -93,7 +93,14 @@ class LinkBinding(object):
         req = self.request_factory(data, params)
         prepared_request = self.owner._client.session.prepare_request(req)
 
-        response = self.owner._client.session.send(prepared_request)
+        # Update cilent session so that it will properly load from env vars
+        # See https://requests.readthedocs.io/en/master/user/advanced/#prepared-requests
+        # for more details
+        settings = self.owner._client.session.merge_environment_settings(
+            url=prepared_request.url, proxies={}, stream=None, verify=None, cert=None
+        )
+
+        response = self.owner._client.session.send(prepared_request, **settings)
 
         # return error for some error conditions
         self.raise_for_status(response)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -417,8 +417,7 @@ def ocx_schemas():
 
 @pytest.fixture(scope="session")
 def ocx():
-    """Instantiated API client
-    """
+    """Instantiated API client"""
     with mock_requests(SCHEMA_ROUTES):
         return Api(
             api_key="1eab4217d30d42849dbde0cd1bb94e39",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -202,7 +202,7 @@ def test_standard_uploads(
     runner, mocked_creds_path, caplog, generate_fastq, upload_mocks, files, threads
 ):
     """Test single and multi file uploads, with and without threads
-       (but not files >5GB)
+    (but not files >5GB)
     """
     with runner.isolated_filesystem(), mock.patch(
         "onecodex.models.Projects.get", side_effect=lambda _: None

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -66,7 +66,8 @@ def test_beta_diversity_exceptions(ocx, api_data):
 
 
 @pytest.mark.parametrize(
-    "weighted,value", [(False, [0.6, 0.547486, 0.591304]), (True, [0.503168, 0.403155, 0.605155])],
+    "weighted,value",
+    [(False, [0.6, 0.547486, 0.591304]), (True, [0.503168, 0.403155, 0.605155])],
 )
 def test_unifrac(ocx, api_data, value, weighted):
     samples = ocx.Samples.where(project="4b53797444f846c4")

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -85,8 +85,7 @@ def test_import_speed(import_command, package_max_import_times, total_time_secs)
 
 
 def test_cli_speed(runner, api_data, mocked_creds_file):
-    """Test that loading the CLI is fast, i.e., it doesn't load all the extensions
-    """
+    """Test that loading the CLI is fast, i.e., it doesn't load all the extensions"""
     start_time = time.time()
     result = runner.invoke(Cli, ["analyses"])
     elapsed = time.time() - start_time

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,11 @@
-from click import BadParameter
 from functools import partial
+
+import mock
 import pytest
 
+from click import BadParameter
+
+from onecodex.api import Api
 from onecodex.utils import snake_case, check_for_allowed_file, valid_api_key
 
 
@@ -56,3 +60,12 @@ def test_snake_case():
     test_cases = ["SnakeCase", "snakeCase", "SNAKE_CASE"]
     for test_case in test_cases:
         assert snake_case(test_case) == "snake_case"
+
+
+def test_custom_ca_bundle(runner, api_data):
+    """Tests that we're properly merging settings into our prepared requests."""
+    with mock.patch("requests.Session.merge_environment_settings") as merge_env:
+        ocx = Api(base_url="http://localhost:3000", cache_schema=True)
+        classifications = ocx.Classifications.all()
+        assert merge_env.call_count >= 1
+        assert len(classifications) >= 1


### PR DESCRIPTION
This PR modifies the behaviour of the underlying `potion_client` to respect environment settings for prepared requests. The goal is to provide a fix to SSL verification issues encountered in certain corporate networks that are using custom CA bundles.

From the `requests` docs (https://requests.readthedocs.io/en/master/user/advanced/#prepared-requests):

> When you are using the prepared request flow, keep in mind that it does not take into account the environment. This can cause problems if you are using environment variables to change the behaviour of requests. For example: Self-signed SSL certificates specified in REQUESTS_CA_BUNDLE will not be taken into account. As a result an SSL: CERTIFICATE_VERIFY_FAILED is thrown. You can get around this behaviour by explicitly merging the environment settings into your session.

Specifically, it uses the `merge_environment_settings` function in `requests` to respect `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` env vars for prepared requests.

