### PR TITLE
Support `width=None` and `width="container"` in plot_metadata

### DIFF
--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -191,7 +191,7 @@ class VizMetadataMixin(object):
 
             n_boxes = len(df[magic_fields[haxis]].unique())
 
-            if (n_boxes * (box_size + increment)) > width:
+            if width and width != "container" and (n_boxes * (box_size + increment)) > width:
                 box_size = ((width / n_boxes) // increment) * increment - increment
 
             chart = (


### PR DESCRIPTION
This change is necessary for [DEV-4017](https://linear.app/onecodex/issue/DEV-4017/make-plots-responsive-by-default).