### PR TITLE
Display facet field name and values below x-axis (taxa barplot and heatmap)

### DIFF
--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -169,7 +169,9 @@ class VizBargraphMixin(object):
         kwargs = {}
 
         if haxis:
-            kwargs["column"] = haxis
+            kwargs["column"] = alt.Column(
+                haxis, header=alt.Header(titleOrient="bottom", labelOrient="bottom")
+            )
 
         domain = sorted(df["tax_name"].unique())
 

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -218,7 +218,9 @@ class VizHeatmapMixin(object):
         )
 
         if haxis:
-            alt_kwargs["column"] = haxis
+            alt_kwargs["column"] = alt.Column(
+                haxis, header=alt.Header(titleOrient="bottom", labelOrient="bottom")
+            )
 
         chart = (
             alt.Chart(df)


### PR DESCRIPTION
Closes [DEV-4028](https://linear.app/onecodex/issue/DEV-4028/remove-redundant-x-axis-titles-in-faceted-plots) (see this issue for before & after screenshots)