### PR TITLE
Filter out NaNs from alpha diversity plots

### DIFF
--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -97,6 +97,7 @@ class VizMetadataMixin(object):
         if AlphaDiversityMetric.has_value(vaxis):
             df.loc[:, vaxis] = self.alpha_diversity(vaxis, rank=rank)
             magic_fields[vaxis] = vaxis
+            df.dropna(subset=[magic_fields[vaxis]], inplace=True)
         else:
             # if it's not alpha diversity, vertical axis can also be magically mapped
             vert_df, vert_magic_fields = self._metadata_fetch([vaxis])


### PR DESCRIPTION
Samples that have `NaN` as an alpha diversity value are now filtered out before plotting. This works in a similar manner to how `NaNs` are filtered when plotting numeric metadata on the y-axis.

Closes [DEV-4752](https://linear.app/onecodex/issue/DEV-4752/plot-builder-diversity-y-axis-displaying-as-factor-and-not-numeric)