### PR TITLE
Change minimum required sentry-sdk version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         "jsonschema>=2.4",
         "python-dateutil>=2.5.3",
         "pytz>=2014.1",
-        "sentry-sdk>=0.16.3",
+        "sentry-sdk>=0.10.2",
         "requests>=2.9",
         "requests_toolbelt>=0.7.0",
         "six>=1.10.0",


### PR DESCRIPTION
Changed to `>=0.10.2` for compatibility with mainline.

Closes DEV-4783