### PR TITLE
Fix broken taxa bargraph links

### DIFF
--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -1,6 +1,11 @@
 from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.lib.enums import AbundanceMetric, Rank, Metric
-from onecodex.viz._primitives import interleave_palette, prepare_props, sort_helper
+from onecodex.viz._primitives import (
+    interleave_palette,
+    prepare_props,
+    sort_helper,
+    get_base_classification_url,
+)
 
 
 class VizBargraphMixin(object):
@@ -202,6 +207,7 @@ class VizBargraphMixin(object):
 
         chart = (
             alt.Chart(df)
+            .transform_calculate(url=get_base_classification_url() + alt.datum.classification_id)
             .mark_bar()
             .encode(
                 x=alt.X("Label", axis=alt.Axis(title=xlabel), sort=sort_order),

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -5,7 +5,7 @@ import warnings
 from onecodex.lib.enums import BetaDiversityMetric, Rank, Linkage, OrdinationMethod
 from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.distance import DistanceMixin
-from onecodex.viz._primitives import interleave_palette, prepare_props
+from onecodex.viz._primitives import interleave_palette, prepare_props, get_base_classification_url
 from onecodex.utils import is_continuous
 
 
@@ -189,7 +189,7 @@ class VizDistanceMixin(DistanceMixin):
             color="Distance:Q",
             tooltip=list(chain.from_iterable(formatted_fields)) + ["Distance:Q"],
             href="url:N",
-            url="https://app.onecodex.com/classification/" + alt.datum.classification_id,
+            url=get_base_classification_url() + alt.datum.classification_id,
         )
 
         chart = (
@@ -383,7 +383,7 @@ class VizDistanceMixin(DistanceMixin):
             y=alt.Y(y_field, axis=alt.Axis(title=ylabel)),
             tooltip=[magic_fields[t] for t in tooltip],
             href="url:N",
-            url="https://app.onecodex.com/classification/" + alt.datum.classification_id,
+            url=get_base_classification_url() + alt.datum.classification_id,
         )
 
         # only add these parameters if they are in use

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -1,6 +1,6 @@
 from onecodex.lib.enums import Rank, Linkage
 from onecodex.exceptions import OneCodexException, PlottingException
-from onecodex.viz._primitives import prepare_props, sort_helper
+from onecodex.viz._primitives import prepare_props, sort_helper, get_base_classification_url
 
 
 class VizHeatmapMixin(object):
@@ -214,7 +214,7 @@ class VizHeatmapMixin(object):
             color=alt.Color("{}:Q".format(df.ocx.metric), legend=alt.Legend(title=legend)),
             tooltip=tooltip_for_altair,
             href="url:N",
-            url="https://app.onecodex.com/classification/" + alt.datum.classification_id,
+            url=get_base_classification_url() + alt.datum.classification_id,
         )
 
         if haxis:

--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -2,7 +2,7 @@ import warnings
 
 from onecodex.lib.enums import AlphaDiversityMetric, Rank, BaseEnum
 from onecodex.exceptions import OneCodexException, PlottingException, PlottingWarning
-from onecodex.viz._primitives import prepare_props, sort_helper
+from onecodex.viz._primitives import prepare_props, sort_helper, get_base_classification_url
 
 
 class PlotType(BaseEnum):
@@ -164,7 +164,7 @@ class VizMetadataMixin(object):
                 y=alt.Y(magic_fields[vaxis], axis=alt.Axis(title=ylabel)),
                 tooltip=["Label", "{}:Q".format(magic_fields[vaxis])],
                 href="url:N",
-                url="https://app.onecodex.com/classification/" + alt.datum.classification_id,
+                url=get_base_classification_url() + alt.datum.classification_id,
             )
 
             chart = (

--- a/onecodex/viz/_pca.py
+++ b/onecodex/viz/_pca.py
@@ -1,5 +1,5 @@
 from onecodex.lib.enums import Rank
-from onecodex.viz._primitives import interleave_palette, prepare_props
+from onecodex.viz._primitives import interleave_palette, prepare_props, get_base_classification_url
 from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.utils import is_continuous
 
@@ -135,7 +135,7 @@ class VizPCAMixin(object):
             y=alt.Y("PC2", axis=alt.Axis(title=ylabel)),
             tooltip=[magic_fields[t] for t in tooltip],
             href="url:N",
-            url="https://app.onecodex.com/classification/" + alt.datum.classification_id,
+            url=get_base_classification_url() + alt.datum.classification_id,
         )
 
         # only add these parameters if they are in use

--- a/onecodex/viz/_primitives.py
+++ b/onecodex/viz/_primitives.py
@@ -1,7 +1,12 @@
+import os
 from itertools import chain
 from math import ceil
 
 from onecodex.exceptions import OneCodexException
+
+
+def get_base_classification_url():
+    return os.environ.get("ONE_CODEX_API_BASE", "https://app.onecodex.com") + "/classification/"
 
 
 def sort_helper(sort, values):


### PR DESCRIPTION
Clicking on a bar in a taxa bargraph now takes the user to the correct classification results page.

Also refactored all plot types to allow users to specify a different `ONE_CODEX_API_BASE` for the generated links.

Closes DEV-4775