### PR TITLE
PCA/MDS/PCoA coloring bug fixes

### DIFF
--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -500,3 +500,7 @@ def is_continuous(series):
         or pd.api.types.is_categorical_dtype(series)  # noqa
         or pd.api.types.is_object_dtype(series)  # noqa
     )
+
+
+def has_missing_values(dataframe_or_series):
+    return dataframe_or_series.isnull().values.any()

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -6,7 +6,7 @@ from onecodex.lib.enums import BetaDiversityMetric, Rank, Linkage, OrdinationMet
 from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.distance import DistanceMixin
 from onecodex.viz._primitives import interleave_palette, prepare_props, get_base_classification_url
-from onecodex.utils import is_continuous
+from onecodex.utils import is_continuous, has_missing_values
 
 
 class VizDistanceMixin(DistanceMixin):
@@ -388,11 +388,12 @@ class VizDistanceMixin(DistanceMixin):
 
         # only add these parameters if they are in use
         if color:
-            domain = magic_metadata[color].values
             color_kwargs = {
                 "legend": alt.Legend(title=magic_fields[color]),
             }
-            if not is_continuous(domain):
+            if not is_continuous(plot_data[color]) or has_missing_values(plot_data[color]):
+                plot_data[color] = plot_data[color].fillna("N/A").astype(str)
+                domain = plot_data[color].values
                 color_range = interleave_palette(domain)
                 color_kwargs["scale"] = alt.Scale(domain=domain, range=color_range)
 

--- a/onecodex/viz/_pca.py
+++ b/onecodex/viz/_pca.py
@@ -1,7 +1,7 @@
 from onecodex.lib.enums import Rank
 from onecodex.viz._primitives import interleave_palette, prepare_props, get_base_classification_url
 from onecodex.exceptions import OneCodexException, PlottingException
-from onecodex.utils import is_continuous
+from onecodex.utils import is_continuous, has_missing_values
 
 
 class VizPCAMixin(object):
@@ -140,11 +140,12 @@ class VizPCAMixin(object):
 
         # only add these parameters if they are in use
         if color:
-            domain = magic_metadata[color].values
             color_kwargs = {
                 "legend": alt.Legend(title=magic_fields[color]),
             }
-            if not is_continuous(domain):
+            if not is_continuous(plot_data[color]) or has_missing_values(plot_data[color]):
+                plot_data[color] = plot_data[color].fillna("N/A").astype(str)
+                domain = plot_data[color].values
                 color_range = interleave_palette(domain)
                 color_kwargs["scale"] = alt.Scale(domain=domain, range=color_range)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import pytest
 from click import BadParameter
 
 from onecodex.api import Api
-from onecodex.utils import snake_case, check_for_allowed_file, valid_api_key
+from onecodex.utils import snake_case, check_for_allowed_file, valid_api_key, has_missing_values
 
 
 def test_check_allowed_file():
@@ -69,3 +69,18 @@ def test_custom_ca_bundle(runner, api_data):
         classifications = ocx.Classifications.all()
         assert merge_env.call_count >= 1
         assert len(classifications) >= 1
+
+
+def test_has_missing_values():
+    pytest.importorskip("numpy")
+    pytest.importorskip("pandas")
+
+    import numpy as np
+    import pandas as pd
+
+    assert has_missing_values(pd.Series([1, np.nan, 2]))
+    assert has_missing_values(pd.Series([np.nan, np.nan]))
+    assert not has_missing_values(pd.Series([1, 2, 3]))
+
+    assert has_missing_values(pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", None]}))
+    assert not has_missing_values(pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]}))

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from onecodex.exceptions import OneCodexException, PlottingException, PlottingWarning
 from onecodex.models.collection import SampleCollection
+from onecodex.utils import has_missing_values
 
 
 def test_altair_ocx_theme(ocx, api_data):
@@ -152,6 +153,34 @@ def test_plot_pca(ocx, api_data):
     assert vectors.data["x"].sum().round(6) == 0.145172
     assert vectors.data["y"].sum().round(6) == 0.039944
     assert vectors.data["o"].tolist() == [0, 1, 0, 1, 0, 1]
+
+
+def test_plot_pca_color_by_bool_field(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    assert samples.metadata["wheat"].dtype == bool
+
+    chart = samples.plot_pca(color="wheat", return_chart=True)
+    color = chart.encoding.color
+
+    assert color.shorthand == "wheat"
+    assert color.legend.title == "wheat"
+    assert color.scale.domain.dtype == object
+    assert len(color.scale.domain) == 3
+    assert len(color.scale.range) == 2
+
+
+def test_plot_pca_color_by_field_with_nans(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    assert has_missing_values(samples.metadata["name"])
+
+    chart = samples.plot_pca(color="name", return_chart=True)
+    color = chart.encoding.color
+
+    assert color.shorthand == "name"
+    assert color.legend.title == "name"
+    assert color.scale.domain.dtype == object
+    assert len(color.scale.domain) == 3
+    assert len(color.scale.range) == 1
 
 
 def test_plot_pca_exceptions(ocx, api_data):
@@ -325,6 +354,34 @@ def test_plot_mds(ocx, api_data, metric, dissimilarity_metric, smacof):
         method="smacof", rank="species", metric=dissimilarity_metric, return_chart=True
     )
     assert (chart.data["MDS1"] * chart.data["MDS2"]).sum().round(4) == smacof
+
+
+def test_plot_mds_color_by_bool_field(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    assert samples.metadata["wheat"].dtype == bool
+
+    chart = samples.plot_mds(color="wheat", return_chart=True)
+    color = chart.encoding.color
+
+    assert color.shorthand == "wheat"
+    assert color.legend.title == "wheat"
+    assert color.scale.domain.dtype == object
+    assert len(color.scale.domain) == 3
+    assert len(color.scale.range) == 2
+
+
+def test_plot_mds_color_by_field_with_nans(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    assert has_missing_values(samples.metadata["name"])
+
+    chart = samples.plot_mds(color="name", return_chart=True)
+    color = chart.encoding.color
+
+    assert color.shorthand == "name"
+    assert color.legend.title == "name"
+    assert color.scale.domain.dtype == object
+    assert len(color.scale.domain) == 3
+    assert len(color.scale.range) == 1
 
 
 def test_plot_pcoa(ocx, api_data):


### PR DESCRIPTION
Fixed the following bugs with the `color` parameter in PCA/MDS/PCoA plots:

- Coloring by a boolean field no longer raises an error.
- Coloring by a field with mixed types (e.g. strings and numbers) is treated as categorical data. Previously, non-numeric data was filtered out and the legend scale was incorrect.
- Coloring by a field with missing values is treated as categorical data (and missing values display as "N/A"). Previously, data with missing color values was filtered out (without regenerating the ordination, which isn't generally desirable behavior).

Closes DEV-4452
Closes DEV-4799