### PR TITLE
Fix beta diversity distance heatmap layout issues

### DIFF
--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -203,7 +203,7 @@ class VizDistanceMixin(DistanceMixin):
             .encode(**alt_kwargs)
         )
 
-        chart = chart.properties(**prepare_props(title=title, height=height, width=width))
+        chart = chart.properties(**prepare_props(height=height, width=width))
 
         dendro_chart = dendrogram(clust["scipy_tree"])
 
@@ -211,10 +211,14 @@ class VizDistanceMixin(DistanceMixin):
             cell_height = height / len(clust["dist_matrix"].index)
             dendro_chart = dendro_chart.properties(height=height - cell_height / 2)
 
+        title_kwargs = prepare_props(title=title)
+        concat_chart = alt.hconcat(dendro_chart, chart, spacing=0, **title_kwargs).configure_view(
+            strokeWidth=0
+        )
         if return_chart:
-            return dendro_chart | chart
+            return concat_chart
         else:
-            (dendro_chart | chart).display()
+            concat_chart.display()
 
     def plot_pcoa(self, *args, **kwargs):
         return self.plot_mds(*args, method=OrdinationMethod.Pcoa, **kwargs)


### PR DESCRIPTION
Fixed the following layout issues with beta diversity distance heatmaps:

- Removed border from subplots
- Removed spacing between subplots
- Added plot title to composite plot instead of heatmap subplot (this caused spacing issues between subplots)

Closes DEV-4781

<img width="807" alt="Screen Shot 2020-11-04 at 1 01 27 PM" src="https://user-images.githubusercontent.com/1847232/98162962-5636d700-1e9f-11eb-9a6c-9515b362130d.png">
