### PR TITLE
Support more paired file scenarios during upload

### DIFF
--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -416,7 +416,8 @@ def upload(
         for filename in files:
             # convert "read 1" filenames into "read 2" and check that they exist; if they do
             # upload the files as a pair, autointerleaving them
-            pair = re.sub("[._][Rr]1[._]", lambda x: x.group().replace("1", "2"), filename)
+            pair = re.sub("([._][Rr])1([._][\w.]+)$", r"\g<1>2\g<2>", filename)
+            pair = re.sub("([._])1([._][\D._]+)$", r"\g<1>2\g<2>", pair)
 
             # we don't necessary need the R2 to have been passed in; we infer it anyways
             if pair != filename and os.path.exists(pair):

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -416,8 +416,8 @@ def upload(
         for filename in files:
             # convert "read 1" filenames into "read 2" and check that they exist; if they do
             # upload the files as a pair, autointerleaving them
-            pair = re.sub("([._][Rr])1([._][\w.]+)$", r"\g<1>2\g<2>", filename)
-            pair = re.sub("([._])1([._][\D._]+)$", r"\g<1>2\g<2>", pair)
+            pair = re.sub(r"([._][Rr])1([._][\w.]+)$", r"\g<1>2\g<2>", filename)
+            pair = re.sub(r"([._])1([._][\D._]+)$", r"\g<1>2\g<2>", pair)
 
             # we don't necessary need the R2 to have been passed in; we infer it anyways
             if pair != filename and os.path.exists(pair):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -477,7 +477,7 @@ TTTCCGGGGCACATAATCTTCAGCCGGGCGC
 @pytest.fixture
 def generate_fastq(tmp_path, runner):
     def fn(filename):
-        path = os.path.join(tmp_path, filename)
+        path = os.path.join(str(tmp_path), filename)
         with runner.isolated_filesystem():
             parent_dir = os.path.dirname(path)
             if not os.path.exists(parent_dir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -477,8 +477,11 @@ TTTCCGGGGCACATAATCTTCAGCCGGGCGC
 @pytest.fixture
 def generate_fastq(tmp_path, runner):
     def fn(filename):
-        path = str(tmp_path / filename)
+        path = os.path.join(tmp_path, filename)
         with runner.isolated_filesystem():
+            parent_dir = os.path.dirname(path)
+            if not os.path.exists(parent_dir):
+                os.makedirs(parent_dir)
             with open(path, "w") as fout:
                 fout.write(FASTQ_SEQUENCE)
         return path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -247,6 +247,7 @@ def test_empty_upload(runner, mocked_creds_path, upload_mocks):
         (["test.fq"], 1),
         # 2 files, 1 sample
         (["test_R1.fq", "test_R2.fq"], 1),
+        (["dir_r1_test/test_R1.fq", "dir_r1_test/test_R2.fq"], 1),
         (["test_1.fq", "test_2.fq"], 1),
         (["test_1_1.fq", "test_1_2.fq"], 1),
         (["test_S1_L001_R1_001.fastq.gz", "test_S1_L001_R2_001.fastq.gz"], 1),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -247,6 +247,9 @@ def test_empty_upload(runner, mocked_creds_path, upload_mocks):
         (["test.fq"], 1),
         # 2 files, 1 sample
         (["test_R1.fq", "test_R2.fq"], 1),
+        (["test_1.fq", "test_2.fq"], 1),
+        (["test_1_1.fq", "test_1_2.fq"], 1),
+        (["test_S1_L001_R1_001.fastq.gz", "test_S1_L001_R2_001.fastq.gz"], 1),
         # 3 files, 2 samples
         (["test_R1.fq", "test_R2.fq", "other.fq"], 2),
     ],


### PR DESCRIPTION
Some paired end file cases were not supported (e.g. files ending with `_1` and `_2`), but also some cases could have been handled in an invalid manner (e.g. having `_R1_` somewhere in the file path outside the name) during sample upload.

This PR fixes those scenarios and introduces some more tests to make sure they're covered.