### PR TITLE
Support zero abundance samples in normalization calculations

### DIFF
--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -306,7 +306,8 @@ class AnalysisMixin(
 
         if normalize is True or (normalize == "auto" and rank):
             if not self._guess_normalized():
-                df = df.div(df.sum(axis=1), axis=0)
+                # Replace nans with zeros for samples that have a total abundance of zero.
+                df = df.div(df.sum(axis=1), axis=0).fillna(0.0)
 
         # remove columns (tax_ids) with no values that are > 0
         if remove_zeros:

--- a/tests/test_analyses.py
+++ b/tests/test_analyses.py
@@ -54,6 +54,17 @@ def test_guess_normalization(ocx, api_data):
     assert unnorm_results.ocx._guess_normalized() is False
 
 
+def test_normalization_with_zero_abundance_samples(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    samples._collate_results(metric="readcount_w_children")
+    samples._results.iloc[:2, :] = 0
+    assert not samples._guess_normalized()
+
+    df = samples.to_df(normalize=True)
+
+    assert list(df.sum(axis=1, skipna=False).round(6)) == [0.0, 0.0, 1.0]
+
+
 def test_metadata_fetch(ocx, api_data):
     samples = ocx.Samples.where(project="4b53797444f846c4")
 


### PR DESCRIPTION
Samples with a total abundance of zero are now supported in `to_df` normalization calculations. Previously, the normalized abundances were NaN, now they are 0.0.

Closes DEV-4937