### PR TITLE
Add faceting to metadata plots

### DIFF
--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -61,6 +61,26 @@ def test_plot_metadata(ocx, api_data):
     assert chart.mark == "circle"
 
 
+def test_plot_metadata_facet_by_scatter(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+
+    chart = samples.plot_metadata(vaxis="shannon", facet_by="geo_loc_name", return_chart=True)
+
+    assert chart.mark == "circle"
+    assert chart.encoding.x.axis.title == ""
+
+
+def test_plot_metadata_facet_by_boxplot(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+
+    chart = samples.plot_metadata(
+        vaxis="shannon", haxis="starred", facet_by="geo_loc_name", return_chart=True
+    )
+
+    assert chart.mark.type == "boxplot"
+    assert chart.encoding.x.axis.title == ""
+
+
 def test_plot_metadata_alpha_diversity_with_nans(ocx, api_data):
     samples = ocx.Samples.where(project="4b53797444f846c4")
 


### PR DESCRIPTION
Added `facet_by` parameter to `plot_metadata` for creating faceted plots. This option works with both scatter and boxplot types.

Closes DEV-4890

### Scatter plot:

<img width="548" alt="Screen Shot 2020-12-18 at 2 17 16 PM" src="https://user-images.githubusercontent.com/1847232/102663845-d9a24400-413e-11eb-8f19-cc98f1c3650b.png">

### Boxplot:

<img width="544" alt="Screen Shot 2020-12-18 at 2 18 25 PM" src="https://user-images.githubusercontent.com/1847232/102663850-dad37100-413e-11eb-96f3-2ea03fcaca1d.png">

