### PR TITLE
Add support for multilane file concatenation

### DIFF
--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -27,7 +27,7 @@ from onecodex.utils import (
     warn_if_insecure_platform,
     telemetry,
 )
-from onecodex.input_helpers import auto_detect_pairs, concatenate_multiline_files
+from onecodex.input_helpers import auto_detect_pairs, concatenate_multilane_files
 from onecodex.version import __version__
 
 
@@ -410,7 +410,7 @@ def upload(
 
         files = auto_detect_pairs(files, prompt)
 
-    files = concatenate_multiline_files(files, prompt)
+    files = concatenate_multilane_files(files, prompt)
 
     total_size = sum(
         [

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 
 
-def auto_detect_pairs(files: list, prompt: bool) -> list:
+def auto_detect_pairs(files, prompt):
     """Group paired-end files into tuples in the files list.
 
     Returns the files list with paired-end files represented as tuples on that list.
@@ -61,7 +61,7 @@ def auto_detect_pairs(files: list, prompt: bool) -> list:
         return files
 
 
-def _find_multiline_groups(files) -> list:
+def _find_multiline_groups(files):
     """Find a list of multiline file groups eligible for concatenation.
 
     The files are grouped based on filename (e.g. `Sample_R1_L001.fq`, `Sample_R1_L002.fq`).
@@ -77,14 +77,14 @@ def _find_multiline_groups(files) -> list:
     (for paired-end reads). The files are in proper order, concatenation-ready.
     """
 
-    pattern_multiline = re.compile("[._]L(\d+)[._]")
-    pattern_pair_line_combo = re.compile("([._][rR][12])?[._]L\d+[._]([rR][12])?")
+    pattern_multiline = re.compile(r"[._]L(\d+)[._]")
+    pattern_pair_line_combo = re.compile(r"([._][rR][12])?[._]L\d+[._]([rR][12])?")
 
-    def _group_for(file_path: str) -> str:
+    def _group_for(file_path):
         """Create group names by removing Lx and Rx elements from the filename."""
         return re.sub(pattern_pair_line_combo, '', os.path.basename(file_path))
 
-    def _create_group_map(elem_list: list, paired: bool) -> map:
+    def _create_group_map(elem_list, paired):
         """Create multiline file groups with elements in proper order based on file list."""
         # Create groups for the multiline files
         group_map = {}
@@ -103,7 +103,7 @@ def _find_multiline_groups(files) -> list:
         else:
             return {group: sorted(elems) for group, elems in group_map.items() if len(elems) > 1}
     
-    def _with_gaps_removed(group_map: map, paired: bool) -> map:
+    def _with_gaps_removed(group_map, paired):
         """Return a new map having groups with gaps in elements removed."""
         gapped_groups = []
         for group, elems in group_map.items():
@@ -141,7 +141,7 @@ def _find_multiline_groups(files) -> list:
     return multiline_groups
 
 
-def concatenate_multiline_files(files: list, prompt: bool) -> list:
+def concatenate_multiline_files(files, prompt):
     """Concatenate multiline files before uploading.
 
     The files are grouped based on filename. If `prompt` is set to True, the user 
@@ -154,7 +154,7 @@ def concatenate_multiline_files(files: list, prompt: bool) -> list:
     concatenated file.
     """
 
-    def _concatenate_group(group: list, first_elem: str) -> str:
+    def _concatenate_group(group, first_elem):
         """Concatenate all the files on the list and return the target file path."""
         target_file_name = re.sub(pattern_line_num, r"\1", os.path.basename(first_elem))
         target_path = os.path.join(tempfile.gettempdir(), target_file_name)
@@ -188,7 +188,7 @@ def concatenate_multiline_files(files: list, prompt: bool) -> list:
         return files
 
     files = files[:]
-    pattern_line_num = re.compile("[._]L\d+([._])")
+    pattern_line_num = re.compile(r"[._]L\d+([._])")
 
     for group in groups:
         first_elem = group[0]

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -137,9 +137,6 @@ def _find_multiline_groups(files) -> list:
 
     multiline_groups = list(multiline_singles.values())
     multiline_groups.extend(list(multiline_pairs.values()))
-    # for _, elems in multiline_pairs.items():
-    #     multiline_groups.append([fwd for fwd, _ in elems])
-    #     multiline_groups.append([rev for _, rev in elems])
 
     return multiline_groups
 

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -182,9 +182,7 @@ def concatenate_multilane_files(files, prompt):
     perform_concat = True
     if prompt:
         answer = click.confirm(
-            "It appears there are {n_groups} group(s) of multilane files.\nConcatenate them before upload?".format(
-                n_groups=len(groups)
-            ),
+            "This data appears to have been split across multiple sequencing lanes.\nConcatenate lanes before upload?",
             default="Y",
         )
         if not answer:

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -181,9 +181,8 @@ def concatenate_multiline_files(files, prompt):
     perform_concat = True
     if prompt:
         answer = click.confirm(
-            (
-                f"It appears there are {len(groups)} group(s) of multiline files.\n"
-                "Concatenate them before upload?"
+            "It appears there are {n_groups} group(s) of multiline files.\nConcatenate them before upload?".format(
+                n_groups=len(groups)
             ),
             default="Y",
         )

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -20,20 +20,20 @@ def auto_detect_pairs(files, prompt):
     for filename in files:
         # convert "read 1" filenames into "read 2" and check that they exist; if they do
         # upload the files as a pair, autointerleaving them
-        pair = re.sub(r"([._][Rr])1([._][\w.]+)$", r"\g<1>2\g<2>", filename)
-        pair = re.sub(r"([._])1([._][\D._]+)$", r"\g<1>2\g<2>", pair)
+        paired_filename = re.sub(r"([._][Rr])1([._][\w.]+)$", r"\g<1>2\g<2>", filename)
+        paired_filename = re.sub(r"([._])1([._][\D._]+)$", r"\g<1>2\g<2>", paired_filename)
 
         # we don't necessary need the R2 to have been passed in; we infer it anyways
-        if pair != filename and os.path.exists(pair):
-            if not prompt and pair not in single_files:
+        if paired_filename != filename and os.path.exists(paired_filename):
+            if not prompt and paired_filename not in single_files:
                 # if we're not prompting, don't automatically pull in files
                 # not in the list the user passed in
                 continue
 
-            paired_files.append((filename, pair))
+            paired_files.append((filename, paired_filename))
 
-            if pair in single_files:
-                single_files.remove(pair)
+            if paired_filename in single_files:
+                single_files.remove(paired_filename)
 
             single_files.remove(filename)
 

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -1,0 +1,209 @@
+import click
+import re
+import os
+import shutil
+import tempfile
+
+
+def auto_detect_pairs(files: list, prompt: bool) -> list:
+    """Group paired-end files into tuples in the files list.
+
+    Returns the files list with paired-end files represented as tuples on that list.
+    If `prompt` is set to True, the user is asked whether this should happen first.
+    """
+
+    # "intelligently" find paired files and tuple them
+    paired_files = []
+    single_files = set(files)
+
+    for filename in files:
+        # convert "read 1" filenames into "read 2" and check that they exist; if they do
+        # upload the files as a pair, autointerleaving them
+        pair = re.sub(r"([._][Rr])1([._][\w.]+)$", r"\g<1>2\g<2>", filename)
+        pair = re.sub(r"([._])1([._][\D._]+)$", r"\g<1>2\g<2>", pair)
+
+        # we don't necessary need the R2 to have been passed in; we infer it anyways
+        if pair != filename and os.path.exists(pair):
+            if not prompt and pair not in single_files:
+                # if we're not prompting, don't automatically pull in files
+                # not in the list the user passed in
+                continue
+
+            paired_files.append((filename, pair))
+
+            if pair in single_files:
+                single_files.remove(pair)
+
+            single_files.remove(filename)
+
+    auto_pair = True
+
+    if prompt and len(paired_files) > 0:
+        pair_list = ""
+        for p in paired_files:
+            pair_list += "\n  {}  &  {}".format(os.path.basename(p[0]), os.path.basename(p[1]))
+
+        answer = click.confirm(
+            "It appears there are {n_paired_files} paired files (of {n_files} total):{pair_list}\nInterleave them after upload?".format(
+                n_paired_files=len(paired_files) * 2,
+                n_files=len(paired_files) * 2 + len(single_files),
+                pair_list=pair_list,
+            ),
+            default="Y",
+        )
+
+        if not answer:
+            auto_pair = False
+
+    if auto_pair:
+        return paired_files + list(single_files)
+    else:
+        return files
+
+
+def _find_multiline_groups(files) -> list:
+    """Find a list of multiline file groups eligible for concatenation.
+
+    The files are grouped based on filename (e.g. `Sample_R1_L001.fq`, `Sample_R1_L002.fq`).
+    If there is a gap in the sequence (e.g. [`Sample_R1_L001.fq`, `Sample_R1_L003.fq`]), the group
+    is skipped. If there is a mismatch in forward and reverse file sequence (e.g. 
+    [(`Sample_R1_L001.fq`, `Sample_R2_L001.fq`), `Sample_R2_L002.fq`]), the group is skipped.
+    If the sequence doesn't begin with `L001`, the group is skipped.
+
+    This function assumes that the paired-end file tuples on the list are properly matched.
+    
+    The result is a list of lists, with each nested list representing a single multiline
+    file group concisting of either string filenames (for single read files) or tuples
+    (for paired-end reads). The files are in proper order, concatenation-ready.
+    """
+
+    pattern_multiline = re.compile("[._]L(\d+)[._]")
+    pattern_pair_line_combo = re.compile("([._][rR][12])?[._]L\d+[._]([rR][12])?")
+
+    def _group_for(file_path: str) -> str:
+        """Create group names by removing Lx and Rx elements from the filename."""
+        return re.sub(pattern_pair_line_combo, '', os.path.basename(file_path))
+
+    def _create_group_map(elem_list: list, paired: bool) -> map:
+        """Create multiline file groups with elements in proper order based on file list."""
+        # Create groups for the multiline files
+        group_map = {}
+        for elem in elem_list:
+            search_elem = elem if not paired else elem[0]
+            if pattern_multiline.search(search_elem):
+                group = _group_for(search_elem)
+                if group in group_map:
+                    group_map[group].append(elem)
+                else:
+                    group_map[group] = [elem]
+        
+        # Only multifile groups are returned
+        if paired:
+            return {group: sorted(elems, key=lambda x: x[0]) for group, elems in group_map.items() if len(elems) > 1}
+        else:
+            return {group: sorted(elems) for group, elems in group_map.items() if len(elems) > 1}
+    
+    def _with_gaps_removed(group_map: map, paired: bool) -> map:
+        """Return a new map having groups with gaps in elements removed."""
+        gapped_groups = []
+        for group, elems in group_map.items():
+            search_elems = elems if not paired else [e[0] for e in elems]
+            line_nums = [int(pattern_multiline.search(se).group(1)) for se in search_elems]
+            # Verify we're getting 1, 2, 3, ...
+            for idx, elem in enumerate(line_nums, start=1):
+                if idx != elem:
+                    gapped_groups.append(group)
+                    break
+
+        return {group: elems for group, elems in group_map.items() if group not in gapped_groups}
+
+    single_files = [f for f in files if isinstance(f, str)]
+    paired_files = [f for f in files if isinstance(f, tuple)]
+
+    multiline_pairs = _create_group_map(paired_files, paired=True)
+    multiline_singles = _create_group_map(single_files, paired=False)
+    
+    # Search for unmatched files for paired end multiline files and remove offending groups,
+    # e.g. [(Sample_R1_L001.fq, Sample_R2_L001.fq), Sample_R2_L002.fq]
+    for filename in single_files:
+        if pattern_multiline.search(filename):
+            group = _group_for(filename)
+            if group in multiline_pairs:
+                del multiline_pairs[group]
+    
+    # Remove groups with gaps, e.g. [`Sample_R1_L001.fq`, `Sample_R1_L003.fq`]
+    multiline_pairs = _with_gaps_removed(multiline_pairs, paired=True)
+    multiline_singles = _with_gaps_removed(multiline_singles, paired=False)
+
+    multiline_groups = list(multiline_singles.values())
+    multiline_groups.extend(list(multiline_pairs.values()))
+    # for _, elems in multiline_pairs.items():
+    #     multiline_groups.append([fwd for fwd, _ in elems])
+    #     multiline_groups.append([rev for _, rev in elems])
+
+    return multiline_groups
+
+
+def concatenate_multiline_files(files: list, prompt: bool) -> list:
+    """Concatenate multiline files before uploading.
+
+    The files are grouped based on filename. If `prompt` is set to True, the user 
+    is asked whether this should happen first.
+    
+    The concatenated files replace the matched sequence files. They're put in a temporary
+    directory and overwrite any existing files.
+
+    Returns a new list with multiline groups replaced with a path to the single 
+    concatenated file.
+    """
+
+    def _concatenate_group(group: list, first_elem: str) -> str:
+        """Concatenate all the files on the list and return the target file path."""
+        target_file_name = re.sub(pattern_line_num, r"\1", os.path.basename(first_elem))
+        target_path = os.path.join(tempfile.gettempdir(), target_file_name)
+        
+        # Overwriting all files by default
+        if os.path.exists(target_path):
+            os.remove(target_path)
+        with open(target_path, "wb") as outf:
+            for fname in group:
+                with open(fname, "rb") as inf:
+                    # TODO: check for newline at the end of file first?
+                    shutil.copyfileobj(inf, outf)
+        return target_path
+
+    groups = _find_multiline_groups(files)
+    
+    if not groups:
+        return files
+
+    perform_concat = True
+    if prompt:
+        answer = click.confirm(
+            f"It appears there are {len(groups)} group(s) of multiline files.\n"
+            "Concatenate them before upload?",
+            default="Y",
+        )
+        if not answer:
+            perform_concat = False
+    
+    if not perform_concat:
+        return files
+
+    files = files[:]
+    pattern_line_num = re.compile("[._]L\d+([._])")
+
+    for group in groups:
+        first_elem = group[0]
+        if isinstance(first_elem, tuple):
+            concat_fwd = _concatenate_group([fwd for fwd, _ in group], first_elem[0])
+            concat_rev = _concatenate_group([rev for _, rev in group], first_elem[1])
+            files.append((concat_fwd, concat_rev))
+        elif isinstance(first_elem, str):
+            concat = _concatenate_group(group, first_elem)
+            files.append(concat)
+
+        for elem in group:
+            files.remove(elem)
+    
+    return files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -474,16 +474,33 @@ TTTCCGGGGCACATAATCTTCAGCCGGGCGC
 9C;=;=<9@4868>9:67AA<9>65<=>591"""
 
 
+@contextmanager
+def path_for_filename(tmp_path, runner, filename):
+    path = os.path.join(str(tmp_path), filename)
+    parent_dir = os.path.dirname(path)
+    with runner.isolated_filesystem():
+        if not os.path.exists(parent_dir):
+            os.makedirs(parent_dir)
+        yield path
+
+
 @pytest.fixture
 def generate_fastq(tmp_path, runner):
     def fn(filename):
-        path = os.path.join(str(tmp_path), filename)
-        with runner.isolated_filesystem():
-            parent_dir = os.path.dirname(path)
-            if not os.path.exists(parent_dir):
-                os.makedirs(parent_dir)
+        with path_for_filename(tmp_path, runner, filename) as path:
             with open(path, "w") as fout:
                 fout.write(FASTQ_SEQUENCE)
-        return path
+            return path
+
+    yield fn
+
+
+@pytest.fixture
+def generate_fastq_gz(tmp_path, runner):
+    def fn(filename):
+        with path_for_filename(tmp_path, runner, filename) as path:
+            with gzip.open(path, "w") as fout:
+                fout.write(FASTQ_SEQUENCE.encode("utf-8"))
+            return path
 
     yield fn

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -288,18 +288,20 @@ def test_paired_and_multiline_files(
     assert mock_file_upload.call_count == n_files_uploaded
     assert mock_sample_get.call_count == n_samples_uploaded
     assert result.exit_code == 0
+
+    paired_files_prompt = "It appears there are {} paired files (of {} total)".format(
+        n_paired_files, len(files)
+    )
     if n_paired_files > 0:
-        assert (
-            "It appears there are {} paired files (of {} total)".format(n_paired_files, len(files))
-            in result.output
-        )
+        assert paired_files_prompt in result.output
+    else:
+        assert paired_files_prompt not in result.output
+
+    multilane_prompt = "This data appears to have been split across multiple sequencing lanes.\nConcatenate lanes before upload?"
     if n_multiline_groups > 0:
-        assert (
-            "It appears there are {} group(s) of multilane files.\nConcatenate them before upload?".format(
-                n_multiline_groups
-            )
-            in result.output
-        )
+        assert multilane_prompt in result.output
+    else:
+        assert multilane_prompt not in result.output
 
 
 def test_paired_files_with_forward_and_reverse_args(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -241,21 +241,33 @@ def test_empty_upload(runner, mocked_creds_path, upload_mocks):
 
 
 @pytest.mark.parametrize(
-    "files,n_samples_uploaded",
+    "files,n_samples_uploaded,n_files_uploaded,n_paired_files,n_multiline_groups",
     [
         # 1 files, 1 sample
-        (["test.fq"], 1),
+        (["test.fq"], 1, 1, 0, 0),
         # 2 files, 1 sample
-        (["test_R1.fq", "test_R2.fq"], 1),
-        (["dir_r1_test/test_R1.fq", "dir_r1_test/test_R2.fq"], 1),
-        (["test_1.fq", "test_2.fq"], 1),
-        (["test_1_1.fq", "test_1_2.fq"], 1),
-        (["test_S1_L001_R1_001.fastq.gz", "test_S1_L001_R2_001.fastq.gz"], 1),
+        (["test_R1.fq", "test_R2.fq"], 1, 2, 2, 0),
+        (["test_1.fq", "test_2.fq"], 1, 2, 2, 0),
+        # 2 files, 2 lines each, 1 sample
+        (
+            [
+                "test_S1_L001_R1_001.fastq.gz",
+                "test_S1_L001_R2_001.fastq.gz",
+                "test_S1_L002_R1_001.fastq.gz",
+                "test_S1_L002_R2_001.fastq.gz",
+            ],
+            1,
+            2,
+            4,
+            1,
+        ),
+        (["dir_r1_test/test_R1.fq", "dir_r1_test/test_R2.fq"], 1, 2, 2, 0),
+        (["test_1_1.fq", "test_1_2.fq"], 1, 2, 2, 0),
         # 3 files, 2 samples
-        (["test_R1.fq", "test_R2.fq", "other.fq"], 2),
+        (["test_R1.fq", "test_R2.fq", "other.fq"], 2, 3, 2, 0),
     ],
 )
-def test_paired_files(
+def test_paired_and_multiline_files(
     runner,
     generate_fastq,
     mock_file_upload,
@@ -264,20 +276,27 @@ def test_paired_files(
     upload_mocks,
     files,
     n_samples_uploaded,
+    n_files_uploaded,
+    n_paired_files,
+    n_multiline_groups,
 ):
     files = [generate_fastq(x) for x in files]
-    n_paired_files = (len(files) - n_samples_uploaded) * 2
 
     args = ["--api-key", "01234567890123456789012345678901", "upload"] + files
     # check that 2 uploads are kicked off for the pair of files
     result = runner.invoke(Cli, args, catch_exceptions=False)
-    assert mock_file_upload.call_count == len(files)
+    assert mock_file_upload.call_count == n_files_uploaded
     assert mock_sample_get.call_count == n_samples_uploaded
     assert result.exit_code == 0
     if n_paired_files > 0:
         assert (
             "It appears there are {} paired files (of {} total)".format(n_paired_files, len(files))
             in result.output
+        )
+    if n_multiline_groups > 0:
+        assert (
+            f"It appears there are {n_multiline_groups} group(s) of multiline files.\n"
+            "Concatenate them before upload?" in result.output
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,8 +295,10 @@ def test_paired_and_multiline_files(
         )
     if n_multiline_groups > 0:
         assert (
-            f"It appears there are {n_multiline_groups} group(s) of multiline files.\n"
-            "Concatenate them before upload?" in result.output
+            "It appears there are {} group(s) of multiline files.\nConcatenate them before upload?".format(
+                n_multiline_groups
+            )
+            in result.output
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,7 +295,7 @@ def test_paired_and_multiline_files(
         )
     if n_multiline_groups > 0:
         assert (
-            "It appears there are {} group(s) of multiline files.\nConcatenate them before upload?".format(
+            "It appears there are {} group(s) of multilane files.\nConcatenate them before upload?".format(
                 n_multiline_groups
             )
             in result.output

--- a/tests/test_input_helpers.py
+++ b/tests/test_input_helpers.py
@@ -82,12 +82,12 @@ def test_concatenate_multiline_files(generate_fastq):
         generate_fastq("Sample2_L003.fq"),
     ]
     non_multiline = [("Sample3_R1.fq", "Sample3_R2.fq"), "Sample3.fq"]
-    files = [*pairs, *singles, *non_multiline]
+    files = pairs + singles + non_multiline
 
     concatenated = concatenate_multiline_files(files, prompt=False)
 
     basenames = _get_basenames(concatenated)
-    assert basenames == [*non_multiline, "Sample2.fq", ("Sample1_R1.fq", "Sample1_R2.fq")]
+    assert basenames == non_multiline + ["Sample2.fq", ("Sample1_R1.fq", "Sample1_R2.fq")]
 
     with open(concatenated[len(non_multiline)], "r") as inf:
         assert inf.read() == len(singles) * FASTQ_SEQUENCE

--- a/tests/test_input_helpers.py
+++ b/tests/test_input_helpers.py
@@ -58,7 +58,7 @@ def test_find_multilane_groups():
         "Sample7_L002.fq",
         "Sample7_L003.fq",  # proper single group
         "Sample8_L001A.fq",
-        "Sample8_L002A.fq", # invalid lane number
+        "Sample8_L002A.fq",  # invalid lane number
         "Sample9_L001.fq",
         "Sample9_L002.fq",
         "Sample9_L004.fq",  # sequence gap

--- a/tests/test_input_helpers.py
+++ b/tests/test_input_helpers.py
@@ -2,8 +2,8 @@ import os
 import gzip
 import pytest
 from onecodex.input_helpers import (
-    _find_multiline_groups,
-    concatenate_multiline_files,
+    _find_multilane_groups,
+    concatenate_multilane_files,
     auto_detect_pairs,
 )
 from tests.conftest import FASTQ_SEQUENCE
@@ -40,26 +40,29 @@ def test_auto_detect_pairs(generate_fastq, files, expected_pairing):
     assert basenames == expected_pairing
 
 
-def test_find_multiline_groups():
+# Not parametrizing here in order to test a more complex scenario
+def test_find_multilane_groups():
     files = [
         ("Sample1_L001_R1.fq", "Sample1_L001_R2.fq"),
         ("Sample1_L002_R1.fq", "Sample1_L002_R2.fq"),
         ("Sample1_L003_R1.fq", "Sample1_L003_R2.fq"),
         ("Sample2_L001_R1.fq", "Sample2_L001_R2.fq"),
         ("Sample2_L003_R1.fq", "Sample2_L003_R2.fq"),  # proper paired group
-        ("Sample3_R1.fq", "Sample3_R2.fq"),  # no multiline
+        ("Sample3_R1.fq", "Sample3_R2.fq"),  # no multilane
         ("Sample4_L001_R1.fq", "Sample4_L001_R2.fq"),
         "Sample4_L002_R2.fq",  # mismatch: R2 has more files
-        "Sample5.fq",
-        "Sample6_L001.fq",
-        "Sample6_L002.fq",
-        "Sample6_L003.fq",  # proper single group
+        ("Sample5_L001_R1.fq", "Sample5_L002_R2.fq"),
+        ("Sample5_L002_R1.fq", "Sample5_L001_R2.fq"),  # mismatch during pairing
+        "Sample6.fq",
         "Sample7_L001.fq",
         "Sample7_L002.fq",
-        "Sample7_L004.fq",  # sequence gap
+        "Sample7_L003.fq",  # proper single group
+        "Sample8_L001.fq",
+        "Sample8_L002.fq",
+        "Sample8_L004.fq",  # sequence gap
     ]
     expected_groups = [
-        ["Sample6_L001.fq", "Sample6_L002.fq", "Sample6_L003.fq"],
+        ["Sample7_L001.fq", "Sample7_L002.fq", "Sample7_L003.fq"],
         [
             ("Sample1_L001_R1.fq", "Sample1_L001_R2.fq"),
             ("Sample1_L002_R1.fq", "Sample1_L002_R2.fq"),
@@ -67,11 +70,11 @@ def test_find_multiline_groups():
         ],
     ]
 
-    groups = _find_multiline_groups(files)
+    groups = _find_multilane_groups(files)
     assert groups == expected_groups
 
 
-def test_concatenate_multiline_files(generate_fastq):
+def test_concatenate_multilane_files(generate_fastq):
     pairs = [
         (generate_fastq("Sample1_L001_R1.fq"), generate_fastq("Sample1_L001_R2.fq")),
         (generate_fastq("Sample1_L002_R1.fq"), generate_fastq("Sample1_L002_R2.fq")),
@@ -81,28 +84,28 @@ def test_concatenate_multiline_files(generate_fastq):
         generate_fastq("Sample2_L002.fq"),
         generate_fastq("Sample2_L003.fq"),
     ]
-    non_multiline = [("Sample3_R1.fq", "Sample3_R2.fq"), "Sample3.fq"]
-    files = pairs + singles + non_multiline
+    non_multilane = [("Sample3_R1.fq", "Sample3_R2.fq"), "Sample3.fq"]
+    files = pairs + singles + non_multilane
 
-    concatenated = concatenate_multiline_files(files, prompt=False)
+    concatenated = concatenate_multilane_files(files, prompt=False)
 
     basenames = _get_basenames(concatenated)
-    assert basenames == non_multiline + ["Sample2.fq", ("Sample1_R1.fq", "Sample1_R2.fq")]
+    assert basenames == non_multilane + ["Sample2.fq", ("Sample1_R1.fq", "Sample1_R2.fq")]
 
-    with open(concatenated[len(non_multiline)], "r") as inf:
+    with open(concatenated[len(non_multilane)], "r") as inf:
         assert inf.read() == len(singles) * FASTQ_SEQUENCE
 
-    with open(concatenated[len(non_multiline) + 1][0], "r") as inf:
+    with open(concatenated[len(non_multilane) + 1][0], "r") as inf:
         assert inf.read() == len(pairs) * FASTQ_SEQUENCE
 
 
-def test_concatenate_gzipped_multiline_files(generate_fastq_gz):
+def test_concatenate_gzipped_multilane_files(generate_fastq_gz):
     files = [
-        generate_fastq_gz("Sample2_L001.fq"),
-        generate_fastq_gz("Sample2_L002.fq"),
-        generate_fastq_gz("Sample2_L003.fq"),
+        generate_fastq_gz("Sample2_L001.fq.gz"),
+        generate_fastq_gz("Sample2_L002.fq.gz"),
+        generate_fastq_gz("Sample2_L003.fq.gz"),
     ]
-    concatenated = concatenate_multiline_files(files, prompt=False)
+    concatenated = concatenate_multilane_files(files, prompt=False)
     assert len(concatenated) == 1
     with gzip.open(concatenated[0], "r") as fin:
         assert fin.read() == len(files) * FASTQ_SEQUENCE.encode("utf-8")

--- a/tests/test_input_helpers.py
+++ b/tests/test_input_helpers.py
@@ -57,9 +57,11 @@ def test_find_multilane_groups():
         "Sample7_L001.fq",
         "Sample7_L002.fq",
         "Sample7_L003.fq",  # proper single group
-        "Sample8_L001.fq",
-        "Sample8_L002.fq",
-        "Sample8_L004.fq",  # sequence gap
+        "Sample8_L001A.fq",
+        "Sample8_L002A.fq", # invalid lane number
+        "Sample9_L001.fq",
+        "Sample9_L002.fq",
+        "Sample9_L004.fq",  # sequence gap
     ]
     expected_groups = [
         ["Sample7_L001.fq", "Sample7_L002.fq", "Sample7_L003.fq"],

--- a/tests/test_input_helpers.py
+++ b/tests/test_input_helpers.py
@@ -1,14 +1,20 @@
 import os
 import gzip
 import pytest
-from onecodex.input_helpers import _find_multiline_groups, concatenate_multiline_files, auto_detect_pairs
+from onecodex.input_helpers import (
+    _find_multiline_groups,
+    concatenate_multiline_files,
+    auto_detect_pairs,
+)
 from tests.conftest import FASTQ_SEQUENCE
 
 
 def _get_basenames(elems):
     return [
-        (os.path.basename(elem[0]), os.path.basename(elem[1])) 
-        if isinstance(elem, tuple) else os.path.basename(elem) for elem in elems
+        (os.path.basename(elem[0]), os.path.basename(elem[1]))
+        if isinstance(elem, tuple)
+        else os.path.basename(elem)
+        for elem in elems
     ]
 
 
@@ -17,14 +23,12 @@ def _get_basenames(elems):
     [
         (["test.fq"], ["test.fq"]),
         (["test_R1.fq", "test_R2.fq"], [("test_R1.fq", "test_R2.fq")]),
-        (
-            ["dir_r1_test/test_R1.fq", "dir_r1_test/test_R2.fq"], [("test_R1.fq", "test_R2.fq")]
-        ),
+        (["dir_r1_test/test_R1.fq", "dir_r1_test/test_R2.fq"], [("test_R1.fq", "test_R2.fq")]),
         (["test_1.fq", "test_2.fq"], [("test_1.fq", "test_2.fq")]),
         (["test_1_1.fq", "test_1_2.fq"], [("test_1_1.fq", "test_1_2.fq")]),
         (
-            ["test_S1_L001_R1_001.fastq.gz", "test_S1_L001_R2_001.fastq.gz"], 
-            [("test_S1_L001_R1_001.fastq.gz", "test_S1_L001_R2_001.fastq.gz")]
+            ["test_S1_L001_R1_001.fastq.gz", "test_S1_L001_R2_001.fastq.gz"],
+            [("test_S1_L001_R1_001.fastq.gz", "test_S1_L001_R2_001.fastq.gz")],
         ),
         (["test_R1.fq", "test_R2.fq", "other.fq"], [("test_R1.fq", "test_R2.fq"), "other.fq"]),
     ],
@@ -38,9 +42,9 @@ def test_auto_detect_pairs(generate_fastq, files, expected_pairing):
 
 def test_find_multiline_groups():
     files = [
-        ("Sample1_L001_R1.fq", "Sample1_L001_R2.fq"), 
-        ("Sample1_L002_R1.fq", "Sample1_L002_R2.fq"), 
-        ("Sample1_L003_R1.fq", "Sample1_L003_R2.fq"), 
+        ("Sample1_L001_R1.fq", "Sample1_L001_R2.fq"),
+        ("Sample1_L002_R1.fq", "Sample1_L002_R2.fq"),
+        ("Sample1_L003_R1.fq", "Sample1_L003_R2.fq"),
         ("Sample2_L001_R1.fq", "Sample2_L001_R2.fq"),
         ("Sample2_L003_R1.fq", "Sample2_L003_R2.fq"),  # proper paired group
         ("Sample3_R1.fq", "Sample3_R2.fq"),  # no multiline
@@ -55,10 +59,12 @@ def test_find_multiline_groups():
         "Sample7_L004.fq",  # sequence gap
     ]
     expected_groups = [
-        ['Sample6_L001.fq', 'Sample6_L002.fq', 'Sample6_L003.fq'],
-        [('Sample1_L001_R1.fq', 'Sample1_L001_R2.fq'), 
-        ('Sample1_L002_R1.fq', 'Sample1_L002_R2.fq'), 
-        ('Sample1_L003_R1.fq', 'Sample1_L003_R2.fq')],
+        ["Sample6_L001.fq", "Sample6_L002.fq", "Sample6_L003.fq"],
+        [
+            ("Sample1_L001_R1.fq", "Sample1_L001_R2.fq"),
+            ("Sample1_L002_R1.fq", "Sample1_L002_R2.fq"),
+            ("Sample1_L003_R1.fq", "Sample1_L003_R2.fq"),
+        ],
     ]
 
     groups = _find_multiline_groups(files)
@@ -67,8 +73,8 @@ def test_find_multiline_groups():
 
 def test_concatenate_multiline_files(generate_fastq):
     pairs = [
-        (generate_fastq("Sample1_L001_R1.fq"), generate_fastq("Sample1_L001_R2.fq")), 
-        (generate_fastq("Sample1_L002_R1.fq"), generate_fastq("Sample1_L002_R2.fq"))
+        (generate_fastq("Sample1_L001_R1.fq"), generate_fastq("Sample1_L001_R2.fq")),
+        (generate_fastq("Sample1_L002_R1.fq"), generate_fastq("Sample1_L002_R2.fq")),
     ]
     singles = [
         generate_fastq("Sample2_L001.fq"),
@@ -77,15 +83,15 @@ def test_concatenate_multiline_files(generate_fastq):
     ]
     non_multiline = [("Sample3_R1.fq", "Sample3_R2.fq"), "Sample3.fq"]
     files = [*pairs, *singles, *non_multiline]
-    
+
     concatenated = concatenate_multiline_files(files, prompt=False)
-    
+
     basenames = _get_basenames(concatenated)
     assert basenames == [*non_multiline, "Sample2.fq", ("Sample1_R1.fq", "Sample1_R2.fq")]
 
     with open(concatenated[len(non_multiline)], "r") as inf:
         assert inf.read() == len(singles) * FASTQ_SEQUENCE
-    
+
     with open(concatenated[len(non_multiline) + 1][0], "r") as inf:
         assert inf.read() == len(pairs) * FASTQ_SEQUENCE
 
@@ -99,4 +105,4 @@ def test_concatenate_gzipped_multiline_files(generate_fastq_gz):
     concatenated = concatenate_multiline_files(files, prompt=False)
     assert len(concatenated) == 1
     with gzip.open(concatenated[0], "r") as fin:
-        assert fin.read() == len(files) * FASTQ_SEQUENCE.encode('utf-8')
+        assert fin.read() == len(files) * FASTQ_SEQUENCE.encode("utf-8")

--- a/tests/test_input_helpers.py
+++ b/tests/test_input_helpers.py
@@ -1,0 +1,102 @@
+import os
+import gzip
+import pytest
+from onecodex.input_helpers import _find_multiline_groups, concatenate_multiline_files, auto_detect_pairs
+from tests.conftest import FASTQ_SEQUENCE
+
+
+def _get_basenames(elems):
+    return [
+        (os.path.basename(elem[0]), os.path.basename(elem[1])) 
+        if isinstance(elem, tuple) else os.path.basename(elem) for elem in elems
+    ]
+
+
+@pytest.mark.parametrize(
+    "files,expected_pairing",
+    [
+        (["test.fq"], ["test.fq"]),
+        (["test_R1.fq", "test_R2.fq"], [("test_R1.fq", "test_R2.fq")]),
+        (
+            ["dir_r1_test/test_R1.fq", "dir_r1_test/test_R2.fq"], [("test_R1.fq", "test_R2.fq")]
+        ),
+        (["test_1.fq", "test_2.fq"], [("test_1.fq", "test_2.fq")]),
+        (["test_1_1.fq", "test_1_2.fq"], [("test_1_1.fq", "test_1_2.fq")]),
+        (
+            ["test_S1_L001_R1_001.fastq.gz", "test_S1_L001_R2_001.fastq.gz"], 
+            [("test_S1_L001_R1_001.fastq.gz", "test_S1_L001_R2_001.fastq.gz")]
+        ),
+        (["test_R1.fq", "test_R2.fq", "other.fq"], [("test_R1.fq", "test_R2.fq"), "other.fq"]),
+    ],
+)
+def test_auto_detect_pairs(generate_fastq, files, expected_pairing):
+    files = [generate_fastq(x) for x in files]
+    pairs = auto_detect_pairs(files, prompt=False)
+    basenames = _get_basenames(pairs)
+    assert basenames == expected_pairing
+
+
+def test_find_multiline_groups():
+    files = [
+        ("Sample1_L001_R1.fq", "Sample1_L001_R2.fq"), 
+        ("Sample1_L002_R1.fq", "Sample1_L002_R2.fq"), 
+        ("Sample1_L003_R1.fq", "Sample1_L003_R2.fq"), 
+        ("Sample2_L001_R1.fq", "Sample2_L001_R2.fq"),
+        ("Sample2_L003_R1.fq", "Sample2_L003_R2.fq"),  # proper paired group
+        ("Sample3_R1.fq", "Sample3_R2.fq"),  # no multiline
+        ("Sample4_L001_R1.fq", "Sample4_L001_R2.fq"),
+        "Sample4_L002_R2.fq",  # mismatch: R2 has more files
+        "Sample5.fq",
+        "Sample6_L001.fq",
+        "Sample6_L002.fq",
+        "Sample6_L003.fq",  # proper single group
+        "Sample7_L001.fq",
+        "Sample7_L002.fq",
+        "Sample7_L004.fq",  # sequence gap
+    ]
+    expected_groups = [
+        ['Sample6_L001.fq', 'Sample6_L002.fq', 'Sample6_L003.fq'],
+        [('Sample1_L001_R1.fq', 'Sample1_L001_R2.fq'), 
+        ('Sample1_L002_R1.fq', 'Sample1_L002_R2.fq'), 
+        ('Sample1_L003_R1.fq', 'Sample1_L003_R2.fq')],
+    ]
+
+    groups = _find_multiline_groups(files)
+    assert groups == expected_groups
+
+
+def test_concatenate_multiline_files(generate_fastq):
+    pairs = [
+        (generate_fastq("Sample1_L001_R1.fq"), generate_fastq("Sample1_L001_R2.fq")), 
+        (generate_fastq("Sample1_L002_R1.fq"), generate_fastq("Sample1_L002_R2.fq"))
+    ]
+    singles = [
+        generate_fastq("Sample2_L001.fq"),
+        generate_fastq("Sample2_L002.fq"),
+        generate_fastq("Sample2_L003.fq"),
+    ]
+    non_multiline = [("Sample3_R1.fq", "Sample3_R2.fq"), "Sample3.fq"]
+    files = [*pairs, *singles, *non_multiline]
+    
+    concatenated = concatenate_multiline_files(files, prompt=False)
+    
+    basenames = _get_basenames(concatenated)
+    assert basenames == [*non_multiline, "Sample2.fq", ("Sample1_R1.fq", "Sample1_R2.fq")]
+
+    with open(concatenated[len(non_multiline)], "r") as inf:
+        assert inf.read() == len(singles) * FASTQ_SEQUENCE
+    
+    with open(concatenated[len(non_multiline) + 1][0], "r") as inf:
+        assert inf.read() == len(pairs) * FASTQ_SEQUENCE
+
+
+def test_concatenate_gzipped_multiline_files(generate_fastq_gz):
+    files = [
+        generate_fastq_gz("Sample2_L001.fq"),
+        generate_fastq_gz("Sample2_L002.fq"),
+        generate_fastq_gz("Sample2_L003.fq"),
+    ]
+    concatenated = concatenate_multiline_files(files, prompt=False)
+    assert len(concatenated) == 1
+    with gzip.open(concatenated[0], "r") as fin:
+        assert fin.read() == len(files) * FASTQ_SEQUENCE.encode('utf-8')


### PR DESCRIPTION
Multiline files are detected and concatenated before upload.
The multiline groups are detected based on filenames, specifically based on the `_LXXX` part, e.g. `Sample_R1_L001.fq`, `Sample_R1_L002.fq`.
If there is a gap in the sequence (e.g. [`Sample_R1_L001.fq`, `Sample_R1_L003.fq`]), the group is skipped. 
If there is a mismatch in forward and reverse file sequence (e.g. [`Sample_R1_L001.fq`, `Sample_R2_L001.fq`, `Sample_R2_L002.fq`]), the group is skipped. 
If the sequence doesn't begin with `L001`, the group is skipped.
The concatenated filename is generated by dropping the `LXXX` part of the name, e.g. [`Sample_R1_L001.fq`, `Sample_R1_L002.fq`] &rarr; `Sample_R1.fq`.
The concatenated files are put into a temporary directory.
The concatenated files replace the multiline files on the input list.

Closes DEV-2759.