### PR TITLE
Improve error message for importing samples

### DIFF
--- a/onecodex/models/helpers.py
+++ b/onecodex/models/helpers.py
@@ -136,6 +136,9 @@ class ResourceDownloadMixin(object):
         from requests.adapters import HTTPAdapter
         from requests.packages.urllib3.util.retry import Retry
 
+        if self._resource.visibility == "awaiting data":
+            raise OneCodexException("Sample has not finished processing. Please try again later.")
+
         if path and file_obj:
             raise OneCodexException("Please specify only one of: path, file_obj")
 

--- a/onecodex/models/helpers.py
+++ b/onecodex/models/helpers.py
@@ -136,7 +136,7 @@ class ResourceDownloadMixin(object):
         from requests.adapters import HTTPAdapter
         from requests.packages.urllib3.util.retry import Retry
 
-        if self._resource.visibility == "awaiting data":
+        if hasattr(self._resource, "visibility") and self._resource.visibility == "awaiting data":
             raise OneCodexException("Sample has not finished processing. Please try again later.")
 
         if path and file_obj:

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -58,6 +58,14 @@ def test_sample_download(runner, ocx, api_data):
         sample.download()
 
 
+def test_sample_download_awaiting_data(runner, ocx, api_data):
+    with runner.isolated_filesystem():
+        sample = ocx.Samples.get("761bc54b97f64980")
+        sample.visibility = "awaiting data"
+        with pytest.raises(OneCodexException):
+            sample.download()
+
+
 def test_document_download(runner, ocx, api_data):
     with runner.isolated_filesystem():
         doc = ocx.Documents.get("a4f6727a840a4df0")


### PR DESCRIPTION
Improves error message when attempting to download a sample that hasn't finished importing.