### PR TITLE
Support empty domain in `interleave_palette`

### DIFF
--- a/onecodex/viz/_primitives.py
+++ b/onecodex/viz/_primitives.py
@@ -52,6 +52,8 @@ def interleave_palette(domain, palette="ocx"):
         raise OneCodexException("A valid palette name or list of colors must be passed")
 
     n_rows = len(set(domain))
+    if n_rows == 0:
+        return []
 
     # We do some shuffling to optimize the range of colours with our own palette
     if palette == "ocx":

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -9,6 +9,7 @@ import numpy as np
 from onecodex.exceptions import OneCodexException, PlottingException, PlottingWarning
 from onecodex.models.collection import SampleCollection
 from onecodex.utils import has_missing_values
+from onecodex.viz._primitives import interleave_palette
 
 
 def test_altair_ocx_theme(ocx, api_data):
@@ -509,3 +510,7 @@ def test_plot_bargraph_chart_result(ocx, api_data, metric, rank, label):
     assert chart.encoding.x.axis.title == "Exemplary Samples"
     assert chart.encoding.y.shorthand == label
     assert chart.encoding.y.axis.title == "Glorious Abundances"
+
+
+def test_interleave_palette_empty_domain():
+    assert interleave_palette([]) == []


### PR DESCRIPTION
An empty `domain` is now supported in `interleave_palette`. Previously, a `ZeroDivisionError` was raised.

This allows us to plot bargraphs composed of samples that only have taxa labelled as "Other" or "No {rank}".

Closes DEV-5128