### PR TITLE
Add an additional creds filelock guard; clean up on logout

### DIFF
--- a/onecodex/api.py
+++ b/onecodex/api.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from datetime import datetime
 import errno
+import filelock
 import json
 import logging
 import os
@@ -73,7 +74,8 @@ class Api(object):
                 warnings.warn("Check permissions on {}".format(collapse_user(creds_file)))
             else:
                 try:
-                    api_key = json.load(open(creds_file, "r"))["api_key"]
+                    with filelock.FileLock("{}.lock".format(creds_file)):
+                        api_key = json.load(open(creds_file, "r"))["api_key"]
                 except KeyError:
                     # lacking an api_key doesn't mean the file is corrupt--it can just be that the
                     # schema was cached after logging in anonymously

--- a/onecodex/auth.py
+++ b/onecodex/auth.py
@@ -160,7 +160,7 @@ def _remove_creds(creds_file=None):
 
     try:
         os.remove("{}.lock".format(creds_file))
-    except OSError:
+    except (IOError, OSError):
         pass
 
     return True

--- a/onecodex/auth.py
+++ b/onecodex/auth.py
@@ -158,6 +158,11 @@ def _remove_creds(creds_file=None):
         else:
             raise
 
+    try:
+        os.remove("{}.lock".format(creds_file))
+    except FileNotFoundError:
+        pass
+
     return True
 
 

--- a/onecodex/auth.py
+++ b/onecodex/auth.py
@@ -160,7 +160,7 @@ def _remove_creds(creds_file=None):
 
     try:
         os.remove("{}.lock".format(creds_file))
-    except FileNotFoundError:
+    except OSError:
         pass
 
     return True


### PR DESCRIPTION
There was one place we were missing a `filelock` guard. This also tries to cleanup `.lock` file on `onecodex logout` (I _think_ it could get left there if the process gets `SIGKILL`ed).