### PR TITLE
add support for FunctionalProfiles

### DIFF
--- a/onecodex/models/__init__.py
+++ b/onecodex/models/__init__.py
@@ -562,7 +562,7 @@ class OneCodexBase(object):
                 raise e
 
 
-from onecodex.models.analysis import Analyses, Classifications, Alignments, Panels  # noqa
+from onecodex.models.analysis import Analyses, Classifications, Alignments, Panels, FunctionalProfiles  # noqa
 from onecodex.models.collection import SampleCollection  # noqa
 from onecodex.models.misc import Jobs, Projects, Tags, Users, Documents  # noqa
 from onecodex.models.sample import Samples, Metadata  # noqa
@@ -575,6 +575,7 @@ __all__ = [
     "Jobs",
     "Metadata",
     "Panels",
+    "FunctionalProfiles",
     "Projects",
     "Samples",
     "SampleCollection",

--- a/onecodex/models/__init__.py
+++ b/onecodex/models/__init__.py
@@ -598,7 +598,7 @@ class OneCodexBase(object):
                 raise e
 
 
-from onecodex.models.analysis import ( # noqa
+from onecodex.models.analysis import (  # noqa
     Analyses,
     Classifications,
     Alignments,
@@ -626,7 +626,7 @@ __all__ = [
 ]
 
 # import and expose experimental models
-from onecodex.models.experimental import ( # noqa
+from onecodex.models.experimental import (  # noqa
     AnnotationSets,
     Assemblies,
     Genomes,

--- a/onecodex/models/__init__.py
+++ b/onecodex/models/__init__.py
@@ -73,9 +73,7 @@ class ResourceList(object):
 
             if len(set(self_ids + other_ids)) != len(self_ids + other_ids):
                 raise OneCodexException(
-                    "{} cannot contain duplicate objects".format(
-                        self.__class__.__name__
-                    )
+                    "{} cannot contain duplicate objects".format(self.__class__.__name__)
                 )
 
     def __init__(self, _resource, oc_model, **kwargs):
@@ -203,9 +201,7 @@ class OneCodexBase(object):
         # non-None) if we have a class.resource?
         if _resource is not None:
             if not isinstance(_resource, Resource):
-                raise TypeError(
-                    "Use the .get() method to fetch an individual resource."
-                )
+                raise TypeError("Use the .get() method to fetch an individual resource.")
             self._resource = _resource
         elif hasattr(self.__class__, "_resource"):
             for key, val in kwargs.items():
@@ -226,8 +222,7 @@ class OneCodexBase(object):
         # this won't appear when you call, e.g. dir(ocx.Samples)
 
         fields = [
-            str(f) if f != "$uri" else "id"
-            for f in self.__class__._resource._schema["properties"]
+            str(f) if f != "$uri" else "id" for f in self.__class__._resource._schema["properties"]
         ]
 
         # this might be a little too clever, but we mask out class methods/fxns from the instances
@@ -253,9 +248,7 @@ class OneCodexBase(object):
                 elif isinstance(value, list):
                     if schema["items"]["type"] == "object":
                         # convert lists of potion resources into wrapped ones
-                        compiled_re = re.compile(
-                            schema["items"]["properties"]["$ref"]["pattern"]
-                        )
+                        compiled_re = re.compile(schema["items"]["properties"]["$ref"]["pattern"])
 
                         # if the list we're returning is empty, we can't just infer what type of
                         # object belongs in this list from its contents. to account for this, we'll
@@ -339,9 +332,7 @@ class OneCodexBase(object):
 
     def __delattr__(self, key):
         if not self.__class__._has_schema_method("update"):
-            raise MethodNotSupported(
-                "{} do not support editing.".format(self.__class__.__name__)
-            )
+            raise MethodNotSupported("{} do not support editing.".format(self.__class__.__name__))
 
         if hasattr(self, "_resource") and key in self._resource.keys():
             # changes on this model also change the potion resource
@@ -442,16 +433,12 @@ class OneCodexBase(object):
         )
 
         schema = next(
-            link
-            for link in cls._resource._schema["links"]
-            if link["rel"] == instances_route
+            link for link in cls._resource._schema["links"] if link["rel"] == instances_route
         )
         sort_schema = schema["schema"]["properties"]["sort"]["properties"]
         where_schema = schema["schema"]["properties"]["where"]["properties"]
 
-        sort = generate_potion_sort_clause(
-            keyword_filters.pop("sort", None), sort_schema
-        )
+        sort = generate_potion_sort_clause(keyword_filters.pop("sort", None), sort_schema)
         limit = keyword_filters.pop("limit", None if not public else 1000)
         where = {}
 
@@ -464,19 +451,13 @@ class OneCodexBase(object):
                 where = {"$uri": {"$in": [cls._convert_id_to_uri(f) for f in filters]}}
             else:
                 # we're doing some more advanced filtering
-                raise NotImplementedError(
-                    "Advanced filtering hasn't been implemented yet"
-                )
+                raise NotImplementedError("Advanced filtering hasn't been implemented yet")
 
         # we're filtering by keyword arguments (like SQLAlchemy's filter_by)
         if len(keyword_filters) > 0:
-            for k, v in generate_potion_keyword_where(
-                keyword_filters, where_schema, cls
-            ).items():
+            for k, v in generate_potion_keyword_where(keyword_filters, where_schema, cls).items():
                 if k in where:
-                    raise AttributeError(
-                        "Multiple definitions for same field {}".format(k)
-                    )
+                    raise AttributeError("Multiple definitions for same field {}".format(k))
                 where[k] = v
 
         # the potion-client method returns an iterator (which lazily fetchs the records
@@ -496,9 +477,7 @@ class OneCodexBase(object):
                 wrapped = [obj for obj in wrapped if filter_func(obj) is True]
             else:
                 raise OneCodexException(
-                    "Expected callable for filter, got: {}".format(
-                        type(filter_func).__name__
-                    )
+                    "Expected callable for filter, got: {}".format(type(filter_func).__name__)
                 )
 
         return wrapped
@@ -548,13 +527,9 @@ class OneCodexBase(object):
         """Delete this object from the One Codex server."""
         check_bind(self)
         if self.id is None:
-            raise ServerError(
-                "{} object does not exist yet".format(self.__class__.name)
-            )
+            raise ServerError("{} object does not exist yet".format(self.__class__.name))
         elif not self.__class__._has_schema_method("destroy"):
-            raise MethodNotSupported(
-                "{} do not support deletion.".format(self.__class__.__name__)
-            )
+            raise MethodNotSupported("{} do not support deletion.".format(self.__class__.__name__))
 
         try:
             self._resource.delete()
@@ -570,13 +545,9 @@ class OneCodexBase(object):
 
         creating = self.id is None
         if creating and not self.__class__._has_schema_method("create"):
-            raise MethodNotSupported(
-                "{} do not support creating.".format(self.__class__.__name__)
-            )
+            raise MethodNotSupported("{} do not support creating.".format(self.__class__.__name__))
         if not creating and not self.__class__._has_schema_method("update"):
-            raise MethodNotSupported(
-                "{} do not support updating.".format(self.__class__.__name__)
-            )
+            raise MethodNotSupported("{} do not support updating.".format(self.__class__.__name__))
 
         try:
             self._resource.save()
@@ -591,9 +562,7 @@ class OneCodexBase(object):
                     "{} do not support {}.".format(self.__class__.__name__, action)
                 )
             elif e.response.status_code == 409:
-                raise ServerError(
-                    "This {} object already exists".format(self.__class__.__name__)
-                )
+                raise ServerError("This {} object already exists".format(self.__class__.__name__))
             else:
                 raise e
 

--- a/onecodex/models/analysis.py
+++ b/onecodex/models/analysis.py
@@ -170,7 +170,6 @@ class Panels(Analyses):
 class FunctionalProfiles(Analyses):
     _resource_path = "/api/v1/functional_profiles"
 
-
     def results(self, json=True):
         """Return the complete results table for a functional analysis.
 

--- a/onecodex/models/analysis.py
+++ b/onecodex/models/analysis.py
@@ -165,3 +165,38 @@ class Panels(Analyses):
             return self._results()
         else:
             raise NotImplementedError("Panel results only available as JSON at this time.")
+
+
+class FunctionalProfiles(Analyses):
+    _resource_path = "/api/v1/functional_profiles"
+
+
+    def results(self, json=True):
+        """Return the complete results table for a functional analysis.
+
+        Parameters
+        ----------
+        json : `bool`, optional
+            Return result as JSON? Default True.
+
+        Returns
+        -------
+        table : `dict` or `pd.DataFrame`
+            Return a JSON object with the functional analysis results or a `pd.DataFrame` if json=False.
+        """
+        if json is True:
+            return self._results()
+        else:
+            return self.table()
+
+    def table(self):
+        """Return the complete results table for the functional analysis.
+
+        Returns
+        -------
+        table : `pd.DataFrame`
+            A Pandas DataFrame of the functional results.
+        """
+        import pandas as pd
+
+        return pd.DataFrame(self._results()["table"])

--- a/tests/api_data/functional_profiles.json
+++ b/tests/api_data/functional_profiles.json
@@ -1,0 +1,15 @@
+[
+    {
+        "$uri": "/api/v1/functional_profiles/45a573fb7833449b",
+        "complete": true,
+        "created_at": "2015-09-26T06:16:39.794227-07:00",
+        "error_msg": "",
+        "job": {
+            "$ref": "/api/v1/jobs/c4f763556452402c"
+        },
+        "sample": {
+            "$ref": "/api/v1/samples/002f55a11aae4b8f"
+        },
+        "success": true
+    }
+]

--- a/tests/api_data/schema.json
+++ b/tests/api_data/schema.json
@@ -20,6 +20,12 @@
         "documents": {
             "$ref": "/api/v1/documents/schema#"
         },
+        "events": {
+            "$ref": "/api/v1/events/schema#"
+        },
+        "functional_profiles": {
+            "$ref": "/api/v1/functional_profiles/schema#"
+        },
         "jobs": {
             "$ref": "/api/v1/jobs/schema#"
         },
@@ -43,11 +49,14 @@
         },
         "users": {
             "$ref": "/api/v1/users/schema#"
+        },
+        "webhooks": {
+            "$ref": "/api/v1/webhooks/schema#"
         }
     },
     "title": "One Codex API (v1)",
     "version_info": {
         "api_version": "v1",
-        "cli_version": "0.5.5"
+        "cli_version": "v0.5.5"
     }
 }

--- a/tests/api_data/schema_all.json
+++ b/tests/api_data/schema_all.json
@@ -11703,6 +11703,1566 @@
             },
             "type": "object"
         },
+        "functional_profiles":
+        {
+    "$schema": "http://json-schema.org/draft-04/hyper-schema#",
+    "links": [
+        {
+            "href": "/api/v1/functional_profiles/schema",
+            "method": "GET",
+            "rel": "describedBy"
+        },
+        {
+            "href": "/api/v1/functional_profiles/{id}/files",
+            "method": "GET",
+            "rel": "files",
+            "targetSchema": {
+                "type": "string"
+            }
+        },
+        {
+            "href": "/api/v1/functional_profiles",
+            "method": "GET",
+            "rel": "instances",
+            "schema": {
+                "additionalProperties": true,
+                "properties": {
+                    "page": {
+                        "default": 1,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "per_page": {
+                        "default": 20,
+                        "maximum": 1000,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "sort": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "$uri": {
+                                "description": "Sort by $uri in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "complete": {
+                                "description": "Sort by complete in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "created_at": {
+                                "description": "Sort by created_at in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "error_msg": {
+                                "description": "Sort by error_msg in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "job": {
+                                "description": "Sort by job in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "sample": {
+                                "description": "Sort by sample in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "success": {
+                                "description": "Sort by success in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "where": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "$uri": {
+                                "anyOf": [
+                                    {
+                                        "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                                    "type": "string"
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "complete": {
+                                "anyOf": [
+                                    {
+                                        "default": false,
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "default": false,
+                                                    "type": "boolean"
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "created_at": {
+                                "anyOf": [
+                                    {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$lt": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$lt"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$lte": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$lte"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$gt": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$gt"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$gte": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$gte"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$between": {
+                                                "default": [],
+                                                "items": {
+                                                    "format": "date-time",
+                                                    "type": "string"
+                                                },
+                                                "maxItems": 2,
+                                                "minItems": 2,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "$between"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "error_msg": {
+                                "anyOf": [
+                                    {
+                                        "maxLength": 255,
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "maxLength": 255,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "maxLength": 255,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$contains": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$contains"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$icontains": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$icontains"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$startswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$startswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$istartswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$istartswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$endswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$endswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$iendswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$iendswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "maxLength": 255,
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "job": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "$ref": {
+                                                        "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            {
+                                                "maxLength": 16,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "$ref": {
+                                                                    "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "maxLength": 16,
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "sample": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "$ref": {
+                                                        "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            {
+                                                "maxLength": 16,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "$ref": {
+                                                                    "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "maxLength": 16,
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "success": {
+                                "anyOf": [
+                                    {
+                                        "default": false,
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "default": false,
+                                                    "type": "boolean"
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "targetSchema": {
+                "items": {
+                    "$ref": "#"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "href": "/api/v1/functional_profiles/public",
+            "method": "GET",
+            "rel": "instances_public",
+            "schema": {
+                "additionalProperties": true,
+                "properties": {
+                    "page": {
+                        "default": 1,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "per_page": {
+                        "default": 20,
+                        "maximum": 1000,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "sort": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "$uri": {
+                                "description": "Sort by $uri in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "complete": {
+                                "description": "Sort by complete in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "created_at": {
+                                "description": "Sort by created_at in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "error_msg": {
+                                "description": "Sort by error_msg in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "job": {
+                                "description": "Sort by job in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "sample": {
+                                "description": "Sort by sample in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "success": {
+                                "description": "Sort by success in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "where": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "$uri": {
+                                "anyOf": [
+                                    {
+                                        "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                                    "type": "string"
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "complete": {
+                                "anyOf": [
+                                    {
+                                        "default": false,
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "default": false,
+                                                    "type": "boolean"
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "created_at": {
+                                "anyOf": [
+                                    {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$lt": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$lt"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$lte": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$lte"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$gt": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$gt"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$gte": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$gte"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$between": {
+                                                "default": [],
+                                                "items": {
+                                                    "format": "date-time",
+                                                    "type": "string"
+                                                },
+                                                "maxItems": 2,
+                                                "minItems": 2,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "$between"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "error_msg": {
+                                "anyOf": [
+                                    {
+                                        "maxLength": 255,
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "maxLength": 255,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "maxLength": 255,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$contains": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$contains"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$icontains": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$icontains"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$startswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$startswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$istartswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$istartswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$endswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$endswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$iendswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$iendswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "maxLength": 255,
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "job": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "$ref": {
+                                                        "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            {
+                                                "maxLength": 16,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "$ref": {
+                                                                    "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "maxLength": 16,
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "sample": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "$ref": {
+                                                        "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            {
+                                                "maxLength": 16,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "$ref": {
+                                                                    "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "maxLength": 16,
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "success": {
+                                "anyOf": [
+                                    {
+                                        "default": false,
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "default": false,
+                                                    "type": "boolean"
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "targetSchema": {
+                "items": {
+                    "$ref": "#"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "href": "/api/v1/functional_profiles/{id}/results",
+            "method": "GET",
+            "rel": "results",
+            "targetSchema": {
+                "additionalProperties": false,
+                "properties": {
+                    "table": {
+                        "default": [],
+                        "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "clade": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "cpm": {
+                                    "type": "number"
+                                },
+                                "group": {
+                                    "type": "string"
+                                },
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "rpk": {
+                                    "type": "number"
+                                },
+                                "tax_id": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        {
+            "href": "/api/v1/functional_profiles/{id}",
+            "method": "GET",
+            "rel": "self",
+            "targetSchema": {
+                "$ref": "#"
+            }
+        }
+    ],
+    "properties": {
+        "$uri": {
+            "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+            "readOnly": true,
+            "type": "string"
+        },
+        "complete": {
+            "default": false,
+            "type": "boolean"
+        },
+        "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+        },
+        "error_msg": {
+            "maxLength": 255,
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "job": {
+            "additionalProperties": false,
+            "properties": {
+                "$ref": {
+                    "pattern": "^/api/v1/jobs\\/[^/]+$",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "sample": {
+            "additionalProperties": false,
+            "properties": {
+                "$ref": {
+                    "pattern": "^/api/v1/samples\\/[^/]+$",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "success": {
+            "default": false,
+            "type": "boolean"
+        }
+    },
+    "type": "object"
+    },
         "panels": {
             "$schema": "http://json-schema.org/draft-04/hyper-schema#",
             "links": [
@@ -22691,5 +24251,1565 @@
     "version_info": {
         "api_version": "v1",
         "cli_version": "v0.5.5"
-    }
+    },
+    "functional_profiles":
+    {
+    "$schema": "http://json-schema.org/draft-04/hyper-schema#",
+    "links": [
+        {
+            "href": "/api/v1/functional_profiles/schema",
+            "method": "GET",
+            "rel": "describedBy"
+        },
+        {
+            "href": "/api/v1/functional_profiles/{id}/files",
+            "method": "GET",
+            "rel": "files",
+            "targetSchema": {
+                "type": "string"
+            }
+        },
+        {
+            "href": "/api/v1/functional_profiles",
+            "method": "GET",
+            "rel": "instances",
+            "schema": {
+                "additionalProperties": true,
+                "properties": {
+                    "page": {
+                        "default": 1,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "per_page": {
+                        "default": 20,
+                        "maximum": 1000,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "sort": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "$uri": {
+                                "description": "Sort by $uri in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "complete": {
+                                "description": "Sort by complete in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "created_at": {
+                                "description": "Sort by created_at in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "error_msg": {
+                                "description": "Sort by error_msg in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "job": {
+                                "description": "Sort by job in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "sample": {
+                                "description": "Sort by sample in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "success": {
+                                "description": "Sort by success in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "where": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "$uri": {
+                                "anyOf": [
+                                    {
+                                        "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                                    "type": "string"
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "complete": {
+                                "anyOf": [
+                                    {
+                                        "default": false,
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "default": false,
+                                                    "type": "boolean"
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "created_at": {
+                                "anyOf": [
+                                    {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$lt": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$lt"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$lte": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$lte"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$gt": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$gt"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$gte": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$gte"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$between": {
+                                                "default": [],
+                                                "items": {
+                                                    "format": "date-time",
+                                                    "type": "string"
+                                                },
+                                                "maxItems": 2,
+                                                "minItems": 2,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "$between"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "error_msg": {
+                                "anyOf": [
+                                    {
+                                        "maxLength": 255,
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "maxLength": 255,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "maxLength": 255,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$contains": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$contains"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$icontains": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$icontains"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$startswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$startswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$istartswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$istartswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$endswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$endswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$iendswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$iendswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "maxLength": 255,
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "job": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "$ref": {
+                                                        "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            {
+                                                "maxLength": 16,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "$ref": {
+                                                                    "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "maxLength": 16,
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "sample": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "$ref": {
+                                                        "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            {
+                                                "maxLength": 16,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "$ref": {
+                                                                    "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "maxLength": 16,
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "success": {
+                                "anyOf": [
+                                    {
+                                        "default": false,
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "default": false,
+                                                    "type": "boolean"
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "targetSchema": {
+                "items": {
+                    "$ref": "#"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "href": "/api/v1/functional_profiles/public",
+            "method": "GET",
+            "rel": "instances_public",
+            "schema": {
+                "additionalProperties": true,
+                "properties": {
+                    "page": {
+                        "default": 1,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "per_page": {
+                        "default": 20,
+                        "maximum": 1000,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "sort": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "$uri": {
+                                "description": "Sort by $uri in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "complete": {
+                                "description": "Sort by complete in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "created_at": {
+                                "description": "Sort by created_at in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "error_msg": {
+                                "description": "Sort by error_msg in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "job": {
+                                "description": "Sort by job in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "sample": {
+                                "description": "Sort by sample in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            },
+                            "success": {
+                                "description": "Sort by success in descending order if 'true', ascending order if 'false'.",
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "where": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "$uri": {
+                                "anyOf": [
+                                    {
+                                        "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+                                                    "type": "string"
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "complete": {
+                                "anyOf": [
+                                    {
+                                        "default": false,
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "default": false,
+                                                    "type": "boolean"
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "created_at": {
+                                "anyOf": [
+                                    {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$lt": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$lt"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$lte": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$lte"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$gt": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$gt"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$gte": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$gte"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$between": {
+                                                "default": [],
+                                                "items": {
+                                                    "format": "date-time",
+                                                    "type": "string"
+                                                },
+                                                "maxItems": 2,
+                                                "minItems": 2,
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "$between"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "error_msg": {
+                                "anyOf": [
+                                    {
+                                        "maxLength": 255,
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "maxLength": 255,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "maxLength": 255,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$contains": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$contains"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$icontains": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$icontains"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$startswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$startswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$istartswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$istartswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$endswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$endswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$iendswith": {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$iendswith"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "maxLength": 255,
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "job": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "$ref": {
+                                                        "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            {
+                                                "maxLength": 16,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "$ref": {
+                                                                    "pattern": "^/api/v1/jobs\\/[^/]+$",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "maxLength": 16,
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "sample": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "$ref": {
+                                                        "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            {
+                                                "maxLength": 16,
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "anyOf": [
+                                                    {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "$ref": {
+                                                                "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "maxLength": 16,
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "$ref": {
+                                                                    "pattern": "^/api/v1/samples\\/[^/]+$",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "maxLength": 16,
+                                                            "type": [
+                                                                "string",
+                                                                "null"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "success": {
+                                "anyOf": [
+                                    {
+                                        "default": false,
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$eq": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$eq"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$ne": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "$ne"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "$in": {
+                                                "default": [],
+                                                "items": {
+                                                    "default": false,
+                                                    "type": "boolean"
+                                                },
+                                                "minItems": 0,
+                                                "type": "array",
+                                                "uniqueItems": true
+                                            }
+                                        },
+                                        "required": [
+                                            "$in"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "targetSchema": {
+                "items": {
+                    "$ref": "#"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "href": "/api/v1/functional_profiles/{id}/results",
+            "method": "GET",
+            "rel": "results",
+            "targetSchema": {
+                "additionalProperties": false,
+                "properties": {
+                    "table": {
+                        "default": [],
+                        "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "clade": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "cpm": {
+                                    "type": "number"
+                                },
+                                "group": {
+                                    "type": "string"
+                                },
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "rpk": {
+                                    "type": "number"
+                                },
+                                "tax_id": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        {
+            "href": "/api/v1/functional_profiles/{id}",
+            "method": "GET",
+            "rel": "self",
+            "targetSchema": {
+                "$ref": "#"
+            }
+        }
+    ],
+    "properties": {
+        "$uri": {
+            "pattern": "^/api/v1/functional_profiles\\/[^/]+$",
+            "readOnly": true,
+            "type": "string"
+        },
+        "complete": {
+            "default": false,
+            "type": "boolean"
+        },
+        "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+        },
+        "error_msg": {
+            "maxLength": 255,
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "job": {
+            "additionalProperties": false,
+            "properties": {
+                "$ref": {
+                    "pattern": "^/api/v1/jobs\\/[^/]+$",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "sample": {
+            "additionalProperties": false,
+            "properties": {
+                "$ref": {
+                    "pattern": "^/api/v1/samples\\/[^/]+$",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "success": {
+            "default": false,
+            "type": "boolean"
+        }
+    },
+    "type": "object"
+}
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,28 @@ API_DATA = {
             "success": True,
         }
     ],
+    "GET::api/v1/functional_profiles/45a573fb7833449b/results": {
+        "table": [
+            {
+                "clade": None,
+                "cpm": 789654.0,
+                "group": "gene_family",
+                "id": "UNMAPPED",
+                "name": None,
+                "rpk": 2524097.0,
+                "tax_id": None,
+            },
+            {
+                "clade": "unclassified",
+                "cpm": 0.47229099999999996,
+                "group": "gene_family",
+                "id": "UniRef90_A0A010JCS2",
+                "name": None,
+                "rpk": 1.5096607033000002,
+                "tax_id": "unclassified",
+            },
+        ]
+    },
     "GET::api/v1/classifications/45a573fb7833449a/results": {
         "table": [
             {

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -5,6 +5,8 @@ import pytest
 import responses
 import sys
 
+pytest.importorskip("pandas")  # noqa
+
 try:
     from urllib.parse import unquote_plus  # Py3
 except ImportError:
@@ -293,11 +295,14 @@ def test_classification_methods(ocx, api_data):
 
 
 def test_functional_profiles_methods(ocx, api_data):
+    import pandas as pd
+
     functional_profile = ocx.FunctionalProfiles.get("45a573fb7833449b")
     assert isinstance(functional_profile, onecodex.models.analysis.FunctionalProfiles)
 
     expected_results_keys = set(["clade", "cpm", "group", "id", "name", "rpk", "tax_id"])
     assert set(functional_profile.results()["table"][0].keys()) == expected_results_keys
+    assert type(functional_profile.table()) == pd.DataFrame
 
 
 # Sorting and where clauses

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -293,14 +293,11 @@ def test_classification_methods(ocx, api_data):
 
 
 def test_functional_profiles_methods(ocx, api_data):
-    import pandas as pd
-
     functional_profile = ocx.FunctionalProfiles.get("45a573fb7833449b")
     assert isinstance(functional_profile, onecodex.models.analysis.FunctionalProfiles)
 
     expected_results_keys = set(["clade", "cpm", "group", "id", "name", "rpk", "tax_id"])
     assert set(functional_profile.results()["table"][0].keys()) == expected_results_keys
-    assert type(functional_profile.table()) == pd.DataFrame
 
 
 # Sorting and where clauses

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -292,6 +292,17 @@ def test_classification_methods(ocx, api_data):
     assert isinstance(classification, onecodex.models.analysis.Classifications)
 
 
+def test_functional_profiles_methods(ocx, api_data):
+    import pandas as pd
+
+    functional_profile = ocx.FunctionalProfiles.get("45a573fb7833449b")
+    assert isinstance(functional_profile, onecodex.models.analysis.FunctionalProfiles)
+
+    expected_results_keys = set(["clade", "cpm", "group", "id", "name", "rpk", "tax_id"])
+    assert set(functional_profile.results()["table"][0].keys()) == expected_results_keys
+    assert type(functional_profile.table()) == pd.DataFrame
+
+
 # Sorting and where clauses
 @pytest.mark.parametrize(
     "where_args,where_kwargs,queries",

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -5,8 +5,6 @@ import pytest
 import responses
 import sys
 
-pytest.importorskip("pandas")  # noqa
-
 try:
     from urllib.parse import unquote_plus  # Py3
 except ImportError:
@@ -295,6 +293,7 @@ def test_classification_methods(ocx, api_data):
 
 
 def test_functional_profiles_methods(ocx, api_data):
+    pytest.importorskip("pandas")  # noqa
     import pandas as pd
 
     functional_profile = ocx.FunctionalProfiles.get("45a573fb7833449b")


### PR DESCRIPTION
Adding support for `/api/v1/functional_profiles` endpoint:

• Add `FunctionalProfiles` class with `results` and `table` methods

![image](https://user-images.githubusercontent.com/7769529/133168699-70ab268d-ef7e-4b46-87fe-6a014206272c.png)


![image](https://user-images.githubusercontent.com/7769529/133168557-c03ccbe1-5ecf-4160-a9f6-ba94157818d2.png)
