### PR TITLE
pinning jupyter-client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ ALL_DEPS = [
     "pandas>=1.0.3",
     "scikit-bio>=0.5.0",
     "scikit-learn>=0.19.0",
+    "jupyter-client==6.1.12",
 ]
 REPORT_DEPS = ALL_DEPS + ["notebook==6.0.3", "nbconvert<6", "WeasyPrint==51", "altair_saver==0.5.0"]
 


### PR DESCRIPTION
pin `jupyter-client` to version `6.1.12` to fix tests
(Thanks @audy !)

