### PR TITLE
add better error messaging for saving tags directly

### DIFF
--- a/onecodex/models/misc.py
+++ b/onecodex/models/misc.py
@@ -1,6 +1,6 @@
 import warnings
 
-from onecodex.exceptions import OneCodexException
+from onecodex.exceptions import OneCodexException, MethodNotSupported
 from onecodex.lib.upload import upload_document
 from onecodex.models import OneCodexBase
 from onecodex.models.helpers import truncate_string, ResourceDownloadMixin
@@ -30,6 +30,12 @@ class Tags(OneCodexBase):
 
     def __hash__(self):
         return hash(self.name)
+
+    def save(self):
+        # Tags cannot be saved directly this way; instruct user to save via a sample
+        raise MethodNotSupported(
+            "Tags cannot be saved directly. Instead, append a newly created tag to a sample and save the sample."
+        )
 
 
 class Users(OneCodexBase):

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import datetime
 import io
 import pytest
+import mock
 import responses
 import sys
 
@@ -253,6 +254,16 @@ def test_sample_saving(ocx, api_data):
     sample.visibility = "private" if visibility == "public" else "public"
     sample.save()
     assert sample.visibility is not visibility
+
+
+def test_tag_saving_raises_exception(ocx, api_data):
+    with mock.patch("onecodex.models.misc.Tags.where", return_value=[]):
+        new_tag = ocx.Tags(name="new ta2")
+
+    with pytest.raises(MethodNotSupported) as e:
+        new_tag.save()
+
+    assert "Tags cannot be saved directly" in str(e)
 
 
 def test_metadata_saving(ocx, api_data):


### PR DESCRIPTION
Saving tags directly is not supported. Add better error handling/messaging:

Before: 
```
HTTPError: 500 Server Error: INTERNAL SERVER ERROR for url: http://localhost:5000/api/v1/tags
```

After
```
MethodNotSupported: Tags cannot be saved directly. Instead, append a newly created tag to a sample and save the sample.
```