### PR TITLE
remove abundances method

### DIFF
--- a/onecodex/models/analysis.py
+++ b/onecodex/models/analysis.py
@@ -136,19 +136,6 @@ class Classifications(Analyses):
         """
         return self.results(json=False)
 
-    def abundances(self, ids=None):
-        """Query the results table to get abundance data for all or some tax ids."""
-        # TODO: Consider removing this method... since it's kind of trivial
-        #       May want to replace with something that actually gets genome-size adjusted
-        #       abundances from the results table
-        if ids is None:
-            # get the data frame
-            return self.table()
-
-        else:
-            res = self.table()
-            return res[res["tax_id"].isin(ids)]
-
     @classmethod
     def where(cls, *filters, **keyword_filters):
         from onecodex.models.collection import SampleCollection


### PR DESCRIPTION
Since the `abundances` method doesn't return actual abundances data, we should remove so that it's not confusing.

Before:
![image](https://user-images.githubusercontent.com/7769529/135177368-d57a6941-f302-4e5a-8d11-6588c3038b1a.png)

After:
![image](https://user-images.githubusercontent.com/7769529/135177374-612eeb77-5bee-447a-89a8-e7ab5a688f9a.png)
