### PR TITLE
fix signature of fn and add error messaging on sample save

### DIFF
--- a/onecodex/models/sample.py
+++ b/onecodex/models/sample.py
@@ -32,7 +32,8 @@ def get_project(project):
 
         if isinstance(project_search, list):
             return project_search[0]
-    return project
+
+    return project_search
 
 
 class Samples(OneCodexBase, ResourceDownloadMixin):
@@ -194,6 +195,12 @@ class Samples(OneCodexBase, ResourceDownloadMixin):
                 if tag.id is None:
                     tag._resource.__dict__["_Reference__properties"]["sample"] = self._resource
                     tag._resource.save()
+
+        if self.project and not isinstance(self.project, Projects):
+            try:
+                self.project = get_project(self.project)
+            except OneCodexException as e:
+                raise OneCodexException(f"Error saving sample: {e}")
 
         super(Samples, self).save()
 


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
• Add better error messaging for trying to save a sample with an invalid project
• Look up project and use project object in sample's `save` method, if found.
• Fix function signature and return `Project` instance instead of whatever was passed in if project was found and is not a list

```
In [9]: p
Out[9]: <Projects eda5c7eb9d3c49ef>

In [10]: p.id
Out[10]: 'eda5c7eb9d3c49ef'

In [11]: s.project = p.id

In [12]: s.save()

In [13]: s.project
Out[13]: <Projects eda5c7eb9d3c49ef>
```
## Related PRs
- [x] This PR is independent

