### PR TITLE
Relax filelock dependency version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         "requests_toolbelt>=0.7.0",
         "six>=1.10.0",
         "unidecode==1.0.23",
-        "filelock==3.0.12",
+        "filelock>=3.0.12,<4",
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
`filelock` was previously pinned at 3.0.12. Changed this to `>=3.0.12,<4` because some of our dependencies (pre-commit->virtualenv) require a newer version of filelock.

## Related PRs
- [x] This PR is independent