### PR TITLE
Improve missing value coercion in SampleCollection._collate_results

### DIFF
--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -344,7 +344,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
                 if not include_host and d_tax_id in host_tax_ids:
                     continue
 
-                data[c_idx, tax_id_to_idx[d_tax_id]] = d[metric]
+                data[c_idx, tax_id_to_idx[d_tax_id]] = d[metric] or 0
 
         df = pd.DataFrame(
             data,
@@ -352,7 +352,6 @@ class SampleCollection(ResourceList, AnalysisMixin):
             columns=tax_info.index,
             copy=False,
         )
-        df.fillna(0, inplace=True)
 
         self._cached["results"] = df
         self._cached["taxonomy"] = tax_info


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Falsey values are now explicitly set to zero in `SampleCollection._collate_results()` instead of relying on numpy + pandas to handle it. This wasn't actually an issue because `None` converts to `np.nan` in a float dtype array, which was then converted to zero. An error would have been raised if there were missing values for an int dtype metric though. The new code handles both cases.

## Related PRs
- [x] This PR is independent