### PR TITLE
Remove bash completion to fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,28 +15,6 @@ Links
 
 """
 from setuptools import setup, find_packages
-from setuptools.command.install import install
-
-
-class PostInstallCommand(install):
-    def run(self):
-        install.run(self)
-
-        # try to enable bash completion, if possible
-        import os
-
-        paths_to_try = ["/etc/bash_completion.d", "/usr/local/etc/bash_completion.d"]
-
-        for path in paths_to_try:
-            if os.access(path, os.W_OK):
-                try:
-                    with open(os.path.join(path, "onecodex"), "w") as f:
-                        f.write('eval "$(_ONECODEX_COMPLETE=source onecodex)"')
-                    print("Enabled bash auto-completion for onecodex")
-                    return
-                except Exception:
-                    print("Unable to enable bash auto-completion for onecodex")
-
 
 with open("onecodex/version.py") as import_file:
     exec(import_file.read())
@@ -100,7 +78,6 @@ setup(
     },
     author="One Codex",
     author_email="opensource@onecodex.com",
-    cmdclass={"install": PostInstallCommand},
     description="One Codex API client and Python library",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

The way bash completion is being installed somehow causes setuptools to quietly not install all dependencies. Removing the post-install hook fixes the issue.

```bash
python setup.py install
echo $? # we get an exit status of 0
onecodex --help
# ...
# ModuleNotFoundError: No module named 'filelock'

# (delete post command hook)

python setup.py install
onecodex --help # works
```

## Related PRs

- [x] This PR is independent

## TODOs

NA
