### PR TITLE
Add support for downloading batches of samples

### DIFF
--- a/onecodex/auth.py
+++ b/onecodex/auth.py
@@ -22,7 +22,7 @@ API_KEY_LEN = 32
 
 def login_uname_pwd(server, api_key=None):
     """Prompts user for username and password, gets API key from server if not provided."""
-    username = click.prompt("Please enter your One Codex (email)")
+    username = click.prompt("Please enter your One Codex email")
     if api_key is not None:
         return username, api_key
 

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -333,11 +333,18 @@ def download_group():
 @click.option(
     "-t", "--tags", multiple=True, help="Filter to samples that include *any* of these tag names."
 )
+@click.option(
+    "--prompt/--no-prompt",
+    is_flag=True,
+    default=True,
+    help="Prompt for confirmation before downloading a large number of samples. Setting --no-prompt "
+    "will allow running without any user intervention, e.g. in a script.",
+)
 @click.pass_context
 @pretty_errors
 @telemetry
 @login_required
-def download_samples_command(ctx, outdir, project, tags):
+def download_samples_command(ctx, outdir, project, tags, prompt):
     """Download FASTA/Q files from One Codex.
 
     Samples may optionally be filtered by project and/or tags. By default, all samples in your
@@ -349,7 +356,12 @@ def download_samples_command(ctx, outdir, project, tags):
     from onecodex.lib.download import download_samples
 
     download_samples(
-        ctx.obj["API"], outdir, project_name_or_id=project, tag_names=tags, progressbar=True
+        ctx.obj["API"],
+        outdir,
+        project_name_or_id=project,
+        tag_names=tags,
+        prompt=prompt,
+        progressbar=True,
     )
 
 

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -314,7 +314,7 @@ def samples(ctx, samples):
     cli_resource_fetcher(ctx, "samples", samples)
 
 
-# utilites
+# utilities
 @onecodex.group("download", help="Download data from One Codex.")
 def download_group():
     pass

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -315,6 +315,44 @@ def samples(ctx, samples):
 
 
 # utilites
+@onecodex.group("download", help="Download data from One Codex.")
+def download_group():
+    pass
+
+
+@download_group.command("samples")
+@click.argument(
+    "outdir",
+    type=click.Path(file_okay=False, dir_okay=True, writable=True),
+    nargs=1,
+    required=True,
+)
+@click.option(
+    "--project", help="Filter to samples in a given project. Can be project name or UUID."
+)
+@click.option(
+    "-t", "--tags", multiple=True, help="Filter to samples that include *any* of these tag names."
+)
+@click.pass_context
+@pretty_errors
+@telemetry
+@login_required
+def download_samples_command(ctx, outdir, project, tags):
+    """Download FASTA/Q files from One Codex.
+
+    Samples may optionally be filtered by project and/or tags. By default, all samples in your
+    account will be downloaded.
+
+    OUTDIR is the name of the output directory where downloaded files will be saved.
+
+    """
+    from onecodex.lib.download import download_samples
+
+    download_samples(
+        ctx.obj["API"], outdir, project_name_or_id=project, tag_names=tags, progressbar=True
+    )
+
+
 @onecodex.command("upload")
 @click.argument(
     "files",

--- a/onecodex/exceptions.py
+++ b/onecodex/exceptions.py
@@ -102,5 +102,5 @@ def raise_connectivity_error(file_name):
         "The command line client is experiencing connectivity issues and "
         "cannot complete the upload of {} at this time. Please try again "
         "later. If the problem persists, contact us at support@onecodex.com "
-        "or assistance.".format(file_name)
+        "for assistance.".format(file_name)
     )

--- a/onecodex/lib/download.py
+++ b/onecodex/lib/download.py
@@ -1,0 +1,75 @@
+import logging
+import os
+import os.path
+import warnings
+
+import click
+
+from onecodex.utils import FakeProgressBar
+from onecodex.exceptions import OneCodexException
+
+log = logging.getLogger("onecodex")
+
+
+def get_samples_from_project(ocx, project_name_or_id):
+    project = ocx.Projects.get(project_name_or_id)
+
+    if not project:
+        try:
+            project = ocx.Projects.where(name=project_name_or_id)[0]
+        except IndexError:
+            raise OneCodexException(
+                "No project exists with name or ID '{}'.".format(project_name_or_id)
+            )
+
+    return ocx.Samples.where(project=project)
+
+
+def filter_samples_by_tags(ocx, samples, tag_names):
+    tags = set()
+    for tag_name in tag_names:
+        log.info("Filtering samples by tag '{}'...".format(tag_name))
+        try:
+            tag = ocx.Tags.where(name=tag_name)[0]
+        except IndexError:
+            warnings.warn("No tag found: '{}'.".format(tag_name))
+            continue
+        tags.add(tag)
+
+    if tags:
+        # Filter for samples with any of the tags above (union)
+        return [sample for sample in samples if len(set(sample.tags) & tags)]
+    return samples
+
+
+def download_samples(ocx, outdir, project_name_or_id=None, tag_names=None, progressbar=False):
+    if project_name_or_id:
+        log.info("Fetching samples in project '{}'...".format(project_name_or_id))
+        samples = get_samples_from_project(ocx, project_name_or_id)
+    else:
+        log.info("Fetching all samples in your account...")
+        samples = ocx.Samples.all()
+
+    if tag_names:
+        samples = filter_samples_by_tags(ocx, samples, tag_names)
+
+    if not len(samples):
+        log.info("No samples match the filter criteria; nothing to download.")
+        return []
+
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+
+    if progressbar:
+        label = "Downloading {} sample{}...".format(len(samples), "" if len(samples) == 1 else "s")
+        progressbar = click.progressbar(length=len(samples), label=label)
+    else:
+        progressbar = FakeProgressBar()
+
+    filepaths = []
+    with progressbar as bar:
+        for sample in samples:
+            filepath = os.path.join(outdir, sample.filename)
+            filepaths.append(sample.download(path=filepath, progressbar=False))
+            bar.update(1)
+    return filepaths

--- a/onecodex/lib/download.py
+++ b/onecodex/lib/download.py
@@ -11,9 +11,8 @@ from onecodex.exceptions import OneCodexException
 log = logging.getLogger("onecodex")
 
 
-def get_samples_from_project(ocx, project_name_or_id):
+def get_project(ocx, project_name_or_id):
     project = ocx.Projects.get(project_name_or_id)
-
     if not project:
         try:
             project = ocx.Projects.where(name=project_name_or_id)[0]
@@ -21,8 +20,7 @@ def get_samples_from_project(ocx, project_name_or_id):
             raise OneCodexException(
                 "No project exists with name or ID '{}'.".format(project_name_or_id)
             )
-
-    return ocx.Samples.where(project=project)
+    return project
 
 
 def filter_samples_by_tags(ocx, samples, tag_names):
@@ -45,7 +43,8 @@ def filter_samples_by_tags(ocx, samples, tag_names):
 def download_samples(ocx, outdir, project_name_or_id=None, tag_names=None, progressbar=False):
     if project_name_or_id:
         log.info("Fetching samples in project '{}'...".format(project_name_or_id))
-        samples = get_samples_from_project(ocx, project_name_or_id)
+        project = get_project(ocx, project_name_or_id)
+        samples = ocx.Samples.where(project=project)
     else:
         log.info("Fetching all samples in your account...")
         samples = ocx.Samples.all()

--- a/onecodex/lib/download.py
+++ b/onecodex/lib/download.py
@@ -70,6 +70,11 @@ def download_samples(ocx, outdir, project_name_or_id=None, tag_names=None, progr
     with progressbar as bar:
         for sample in samples:
             filepath = os.path.join(outdir, sample.filename)
-            filepaths.append(sample.download(path=filepath, progressbar=False))
+            try:
+                filepaths.append(sample.download(path=filepath, progressbar=False))
+            except OneCodexException as e:
+                warnings.warn(
+                    "Skipping download of sample {} to {}: {}".format(sample.id, filepath, str(e))
+                )
             bar.update(1)
     return filepaths

--- a/onecodex/lib/upload.py
+++ b/onecodex/lib/upload.py
@@ -7,7 +7,7 @@ import requests
 import six
 
 from onecodex.exceptions import OneCodexException, raise_connectivity_error, raise_api_error
-from onecodex.utils import atexit_register, atexit_unregister, snake_case
+from onecodex.utils import atexit_register, atexit_unregister, snake_case, FakeProgressBar
 from onecodex.lib.files import FilePassthru, get_file_wrapper
 
 from requests.adapters import HTTPAdapter
@@ -59,28 +59,6 @@ def _choose_boto3_chunksize(file_obj):
         multipart_chunksize = 25 * 1024 ** 2
 
     return multipart_chunksize
-
-
-# this lets us turn off the click progressbar context manager and is python2 compatible
-# https://stackoverflow.com/questions/45187286/how-do-i-write-a-null-no-op-contextmanager-in-python
-class FakeProgressBar(object):
-    pct = 0
-    label = ""
-
-    def __init__(self):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        pass
-
-    def finish(self):
-        pass
-
-    def update(self, size):
-        pass
 
 
 def build_upload_dict(metadata, tags, project):

--- a/onecodex/models/helpers.py
+++ b/onecodex/models/helpers.py
@@ -1,6 +1,7 @@
 import click
 import inspect
 import os
+import os.path
 import requests
 
 from onecodex.exceptions import OneCodexException, UnboundObject
@@ -191,7 +192,7 @@ class ResourceDownloadMixin(object):
                     for data in resp.iter_content(chunk_size=1024):
                         f_out.write(data)
         except KeyboardInterrupt:
-            if path:
+            if path and os.path.exists(path):
                 os.remove(path)
             raise
         except requests.exceptions.HTTPError as exc:

--- a/onecodex/models/helpers.py
+++ b/onecodex/models/helpers.py
@@ -156,7 +156,7 @@ class ResourceDownloadMixin(object):
                 path = os.path.join(os.getcwd(), _filename)
 
             if path and os.path.exists(path):
-                raise OneCodexException("{} already exists! Will not overwrite.".format(path))
+                raise OneCodexException("{} already exists. Will not overwrite.".format(path))
 
             if use_potion_session:
                 session = self._resource._client.session
@@ -200,7 +200,8 @@ class ResourceDownloadMixin(object):
             elif exc.response.status_code == 402:
                 raise OneCodexException(
                     "You must either have a premium platform account or be in "
-                    "a notebook environment to download files."
+                    "a notebook environment to download files. Please feel free to contact us "
+                    "about your subscription at support@onecodex.com."
                 )
             elif exc.response.status_code == 403:
                 raise OneCodexException("You are not authorized to download this file.")

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -427,6 +427,28 @@ def progressbar(*args, **kwargs):
     return bar
 
 
+# this lets us turn off the click progressbar context manager and is python2 compatible
+# https://stackoverflow.com/questions/45187286/how-do-i-write-a-null-no-op-contextmanager-in-python
+class FakeProgressBar(object):
+    pct = 0
+    label = ""
+
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def finish(self):
+        pass
+
+    def update(self, size):
+        pass
+
+
 def atexit_register(func, *args, **kwargs):
     atexit.register(func, *args, **kwargs)
 

--- a/tests/api_data/samples.json
+++ b/tests/api_data/samples.json
@@ -1179,7 +1179,7 @@
   {
     "$uri": "/api/v1/samples/0111111111111110",
     "created_at": "2015-09-25T17:40:13.224821-07:00",
-    "filename": "SRR2352223.fastq.gz",
+    "filename": "0111111111111110.fastq.gz",
     "visibility": "private"
   },
   {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,7 +239,7 @@ API_DATA = {
     },
     "PATCH::api/v1/samples/761bc54b97f64980": {},
     "PATCH::api/v1/metadata/4fe05e748b5a4f0e": update_metadata_callback,
-    "POST::api/v1/samples/761bc54b97f64980/download_uri": {
+    "POST::api/v1/samples/.*/download_uri": {
         "download_uri": "http://localhost:3000/mock/download/url"
     },
     "GET::mock/download/url": "1234567890",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 import mock
 import os
+import os.path
 import pytest
 from testfixtures import Replace
 
@@ -353,8 +354,22 @@ def test_paired_files_with_forward_and_reverse_args(
     assert result.exit_code != 0
 
 
-def test_download_samples(runner, api_data, mocked_creds_file):
+def test_download_samples_without_prompt(runner, api_data, mocked_creds_file):
     with runner.isolated_filesystem():
-        result = runner.invoke(Cli, ["download", "samples", "output"])
+        result = runner.invoke(Cli, ["download", "samples", "output", "--no-prompt"])
         assert result.exit_code == 0
         assert len(os.listdir("output")) > 0
+
+
+def test_download_samples_with_prompt_confirmation(runner, api_data, mocked_creds_file):
+    with runner.isolated_filesystem():
+        result = runner.invoke(Cli, ["download", "samples", "output", "--prompt"], input="y\n")
+        assert result.exit_code == 0
+        assert len(os.listdir("output")) > 0
+
+
+def test_download_samples_with_prompt_abort(runner, api_data, mocked_creds_file):
+    with runner.isolated_filesystem():
+        result = runner.invoke(Cli, ["download", "samples", "output", "--prompt"], input="n\n")
+        assert result.exit_code == 0
+        assert not os.path.exists("output")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -351,3 +351,10 @@ def test_paired_files_with_forward_and_reverse_args(
     result = runner.invoke(Cli, args)
     assert "You may not pass a FILES argument" in result.output
     assert result.exit_code != 0
+
+
+def test_download_samples(runner, api_data, mocked_creds_file):
+    with runner.isolated_filesystem():
+        result = runner.invoke(Cli, ["download", "samples", "output"])
+        assert result.exit_code == 0
+        assert len(os.listdir("output")) > 0

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,35 @@
+import os
+import os.path
+
+import pytest
+
+from onecodex.exceptions import OneCodexException
+from onecodex.lib.download import download_samples
+
+
+def test_download_samples(runner, ocx, api_data):
+    with runner.isolated_filesystem():
+        filepaths = download_samples(ocx, "output")
+        for filepath in filepaths:
+            assert os.path.exists(filepath)
+
+
+def test_download_samples_with_progressbar(runner, ocx, api_data):
+    with runner.isolated_filesystem():
+        filepaths = download_samples(ocx, "output", progressbar=True)
+        for filepath in filepaths:
+            assert os.path.exists(filepath)
+
+
+def test_download_samples_does_not_overwrite_existing_files(runner, ocx, api_data):
+    with runner.isolated_filesystem():
+        download_samples(ocx, "output")
+
+        with pytest.raises(OneCodexException):
+            download_samples(ocx, "output")
+
+
+def test_download_samples_outdir_exists(runner, ocx, api_data):
+    with runner.isolated_filesystem():
+        os.mkdir("output")
+        download_samples(ocx, "output")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3,7 +3,6 @@ import os.path
 
 import pytest
 
-from onecodex.exceptions import OneCodexException
 from onecodex.lib.download import download_samples
 
 
@@ -21,12 +20,14 @@ def test_download_samples_with_progressbar(runner, ocx, api_data):
             assert os.path.exists(filepath)
 
 
+@pytest.mark.filterwarnings("ignore:Skipping download of sample.*")
 def test_download_samples_does_not_overwrite_existing_files(runner, ocx, api_data):
     with runner.isolated_filesystem():
-        download_samples(ocx, "output")
+        filepaths1 = download_samples(ocx, "output")
+        assert len(filepaths1) > 0
 
-        with pytest.raises(OneCodexException):
-            download_samples(ocx, "output")
+        filepaths2 = download_samples(ocx, "output")
+        assert len(filepaths2) == 0
 
 
 def test_download_samples_outdir_exists(runner, ocx, api_data):

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -25,7 +25,7 @@ from onecodex import Cli
             "from onecodex.viz import VizPCAMixin",
             {
                 "onecodex": 0.25,
-                "onecodex.viz": 0.20,
+                "onecodex.viz": 0.25,
                 "onecodex.viz._pca": 0.01,
                 "onecodex.viz._distance": 0.01,
             },


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Added `download_samples()` function and `onecodex download samples` CLI command for downloading batches of samples as FASTA/Q files:
- All samples in your account
- Samples optionally filtered by project name or ID
- Samples optionally filtered by tag names

The code was ported from: https://gist.github.com/clausmith/c5da3145412265014151cfcad5493180

Closes DEV-6563

## Related PRs
- [x] This PR is independent