### PR TITLE
Fix `metric` parameter behavior in SampleCollection constructor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 test:
 	py.test -W ignore::DeprecationWarning --ignore tests/test_speed.py --ignore tests/test_reports.py tests/
-	@echo "Successfully passed all tests (one environment only, use tox to full suite)."
+	@echo "Successfully passed all tests (one environment only, use tox to test full suite)."
 
 lint:
 	pre-commit run --all-files

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -61,6 +61,19 @@ class SampleCollection(ResourceList, AnalysisMixin):
         To provide access to the list-like API of `ResourceList`, must also accept a list of
         unwrapped potion resources and a One Codex model.
         """
+        if "field" in kwargs and "metric" in kwargs:
+            raise OneCodexException(
+                "Cannot provide both `field` and `metric`. `field` has been deprecated in favor of "
+                "`metric`."
+            )
+        if "field" in kwargs:
+            warnings.warn(
+                "The `field` parameter has been renamed to `metric`. Passing `field` to a "
+                "SampleCollection is deprecated and will be removed in a future release.",
+                DeprecationWarning,
+            )
+            kwargs["metric"] = kwargs.pop("field")
+
         if len(args) == 2 and isinstance(args[0], list) and issubclass(args[1], OneCodexBase):
             self._resource_list_constructor(*args, **kwargs)
         else:
@@ -71,7 +84,6 @@ class SampleCollection(ResourceList, AnalysisMixin):
         _resource,
         oc_model,
         skip_missing=True,
-        field="auto",
         metric="auto",
         include_host=False,
         job=None,
@@ -85,15 +97,8 @@ class SampleCollection(ResourceList, AnalysisMixin):
         super(SampleCollection, self).__init__(_resource, oc_model, **self._kwargs)
 
     def _sample_collection_constructor(
-        self, objects, skip_missing=True, field="auto", metric="auto", include_host=False, job=None
+        self, objects, skip_missing=True, metric="auto", include_host=False, job=None
     ):
-        if field:
-            warnings.warn(
-                "The `field` parameter has been renamed to `metric`. Passing `field` to a SampleCollection is deprecated and will be removed in a future release.",
-                DeprecationWarning,
-            )
-            metric = field
-
         # are they all wrapped potion resources?
         if not all([hasattr(obj, "_resource") for obj in objects]):
             raise OneCodexException(

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -26,12 +26,20 @@ def test_sample_collection_pandas(ocx, api_data):
 def test_collection_constructor(ocx, api_data):
     samples = ocx.Samples.where(project="45a573fb7833449a")
 
+    col = SampleCollection(samples)
+    assert col._kwargs["metric"] == "auto"
+
     with pytest.deprecated_call():
         col = SampleCollection(samples, field="readcount_w_children")
     assert isinstance(col, SampleCollection)
+    assert col._kwargs["metric"] == "readcount_w_children"
 
     col = SampleCollection(samples, metric="abundance_w_children")
     assert isinstance(col, SampleCollection)
+    assert col._kwargs["metric"] == "abundance_w_children"
+
+    with pytest.raises(OneCodexException):
+        SampleCollection(samples, metric="abundance_w_children", field="readcount_w_children")
 
 
 def test_biom(ocx, api_data):


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Previously when constructing a `SampleCollection`, the only way to override the default metric of "auto" was via the `field` parameter, which is deprecated. Anything passed via `metric` was ignored, *unless* `field` was set to something false-y.

Now the constructor uses `metric` correctly, and disallows passing both `metric` and `field`. `field` is aliased to `metric` and raises a `DeprecationWarning`.

Closes DEV-6052

## Related PRs
- [x] This PR is independent