### PR TITLE
Do no grab click v8 for now

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: "^(onecodex/vendored|tests/api_data|tests/data)"
 repos:
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     packages=find_packages(exclude=["*test*"]),
     install_requires=[
         "boto3>=1.17.98",
-        "click>=7.0",
+        "click>=7.0,<8",
         "jsonschema>=2.4",
         "python-dateutil>=2.5.3",
         "pytz>=2014.1",


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Click v8 drops python2 support and has breaking changes. We need to either:

1. stick to v7 (this PR)
2. get rid of python2 and update to v8


