### PR TITLE
Support missing fields in AnalysisMixin._metadata_fetch()

### DIFF
--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -234,11 +234,8 @@ class AnalysisMixin(
                         magic_fields[f] = renamed_field
                     else:
                         # matched nothing
-                        raise OneCodexException(
-                            "Metric or taxon {} not found. Choose from: {}".format(
-                                str_f, help_metadata
-                            )
-                        )
+                        magic_metadata[f] = None
+                        magic_fields[f] = str_f
 
         return magic_metadata, magic_fields
 

--- a/tests/test_analyses.py
+++ b/tests/test_analyses.py
@@ -95,6 +95,11 @@ def test_metadata_fetch(ocx, api_data):
     assert fields["totalige"] == "totalige"
     assert df["totalige"].tolist() == [62.9, 91.5, 112.0]
 
+    # single metadata field doesn't match anything
+    df, fields = samples._metadata_fetch(["does_not_exist"])
+    assert fields["does_not_exist"] == "does_not_exist"
+    assert df["does_not_exist"].tolist() == [None, None, None]
+
     # tax_id coerced to string from integer
     df, fields = samples._metadata_fetch([1279])
     assert fields[1279] == "Staphylococcus (1279)"

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -25,11 +25,11 @@ from onecodex import Cli
             "from onecodex.viz import VizPCAMixin",
             {
                 "onecodex": 0.25,
-                "onecodex.viz": 0.4,
+                "onecodex.viz": 0.6,
                 "onecodex.viz._pca": 0.01,
                 "onecodex.viz._distance": 0.01,
             },
-            0.4,
+            0.6,
         ),
         (
             "from onecodex.analyses import AnalysisMixin",


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Updated `AnalysisMixin._metadata_fetch()` to support fields that match neither metadata nor taxa. Instead of raising an error, the field is filled with `None` to represent an empty column of data.

This can be useful, for example, when working with metadata on a `SampleCollection` that has been filtered and the field no longer exists on the filtered collection.

Closes DEV-6191
Closes DEV-6700

## Related PRs
- [x] This PR is independent