### PR TITLE
Set median box plot line stroke to black

### DIFF
--- a/onecodex/viz/__init__.py
+++ b/onecodex/viz/__init__.py
@@ -120,7 +120,7 @@ def configure_onecodex_theme(altair_module=None):
 
         altair_module.renderers.enable(
             "altair_saver",
-            fmts=["html", "svg"],
+            fmts=["html"],
             embed_options=VEGAEMBED_OPTIONS,
             vega_cli_options=["--loglevel", "error"],
             stderr_filter=stderr_filter,

--- a/onecodex/viz/__init__.py
+++ b/onecodex/viz/__init__.py
@@ -68,7 +68,7 @@ def onecodex_theme():
         "config": {
             "range": {
                 "heatmap": list(reversed(onecodex_palette)),
-                "categroy": DEFAULT_PALETTES["ocx"],
+                "category": DEFAULT_PALETTES["ocx"],
                 "ramp": list(reversed(onecodex_palette)),
             },
             "area": {"fill": OCX_DARK_GREEN},

--- a/onecodex/viz/__init__.py
+++ b/onecodex/viz/__init__.py
@@ -120,7 +120,7 @@ def configure_onecodex_theme(altair_module=None):
 
         altair_module.renderers.enable(
             "altair_saver",
-            fmts=["html"],
+            fmts=["html", "svg"],
             embed_options=VEGAEMBED_OPTIONS,
             vega_cli_options=["--loglevel", "error"],
             stderr_filter=stderr_filter,

--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -227,7 +227,7 @@ class VizMetadataMixin(object):
 
             chart = (
                 alt.Chart(df)
-                .mark_boxplot(size=box_size)
+                .mark_boxplot(size=box_size, median={"stroke": "black"})
                 .encode(
                     x=alt.X(magic_fields[haxis], axis=alt.Axis(title=xlabel)),
                     y=alt.Y(magic_fields[vaxis], axis=alt.Axis(title=ylabel)),

--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -1,7 +1,5 @@
-import warnings
-
 from onecodex.lib.enums import AlphaDiversityMetric, Rank, BaseEnum
-from onecodex.exceptions import OneCodexException, PlottingException, PlottingWarning
+from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.viz._primitives import prepare_props, sort_helper, get_base_classification_url
 
 
@@ -196,26 +194,6 @@ class VizMetadataMixin(object):
         elif plot_type == PlotType.BoxPlot:
             if sort_x:
                 raise OneCodexException("Must not specify sort_x when plot_type is boxplot")
-
-            # See the following issue in case this gets fixed in altair:
-            # https://github.com/altair-viz/altair/issues/2144
-            if facet_by:
-                faceted_dfs = [faceted_df for _, faceted_df in df.groupby(facet_by)]
-            else:
-                faceted_dfs = [df]
-
-            warn_on_empty_boxes = False
-            for faceted_df in faceted_dfs:
-                if (faceted_df.groupby(magic_fields[haxis]).size() < 2).any():
-                    warn_on_empty_boxes = True
-                    break
-
-            if warn_on_empty_boxes:
-                warnings.warn(
-                    "There is at least one sample group consisting of only a single sample. Groups "
-                    "of size 1 may not have their boxes displayed in the plot.",
-                    PlottingWarning,
-                )
 
             box_size = 45
             increment = 5

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -6,7 +6,7 @@ pytest.importorskip("numpy")  # noqa
 pytest.importorskip("pandas")  # noqa
 
 import numpy as np
-
+import math
 from onecodex.exceptions import OneCodexException, PlottingException, PlottingWarning
 from onecodex.models.collection import SampleCollection
 from onecodex.utils import has_missing_values

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -7,7 +7,7 @@ pytest.importorskip("pandas")  # noqa
 
 import numpy as np
 
-from onecodex.exceptions import OneCodexException, PlottingException, PlottingWarning
+from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.models.collection import SampleCollection
 from onecodex.utils import has_missing_values
 from onecodex.viz._primitives import interleave_palette
@@ -25,7 +25,6 @@ def test_altair_renderer(ocx, api_data):
     assert alt.renderers.active in {"altair_saver", "html"}
 
 
-@pytest.mark.filterwarnings("ignore:.*Groups of size 1.*")
 def test_plot_metadata(ocx, api_data):
     samples = ocx.Samples.where(project="4b53797444f846c4")
 
@@ -72,7 +71,6 @@ def test_plot_metadata_facet_by_scatter(ocx, api_data):
     assert chart.encoding.x.axis.title == ""
 
 
-@pytest.mark.filterwarnings("ignore:.*Groups of size 1.*")
 def test_plot_metadata_facet_by_boxplot(ocx, api_data):
     samples = ocx.Samples.where(project="4b53797444f846c4")
 
@@ -118,25 +116,25 @@ def test_plot_metadata_exceptions(ocx, api_data):
     assert "too few samples" in str(e.value)
 
 
-def test_plot_metadata_warnings(ocx, api_data):
+def test_plot_metadata_group_with_single_value(ocx, api_data):
     samples = ocx.Samples.where(project="4b53797444f846c4")
 
-    with pytest.warns(PlottingWarning, match="Groups of size 1"):
-        samples.plot_metadata(
-            plot_type="boxplot",
-            haxis=("library_type", "external_sample_id"),
-            vaxis="observed_taxa",
-            return_chart=True,
-        )
+    chart = samples.plot_metadata(
+        plot_type="boxplot",
+        haxis=("library_type", "external_sample_id"),
+        vaxis="observed_taxa",
+        return_chart=True,
+    )
+    assert chart.mark.type == "boxplot"
 
-    with pytest.warns(PlottingWarning, match="Groups of size 1"):
-        samples.plot_metadata(
-            plot_type="boxplot",
-            haxis="library_type",
-            vaxis="observed_taxa",
-            facet_by="external_sample_id",
-            return_chart=True,
-        )
+    chart = samples.plot_metadata(
+        plot_type="boxplot",
+        haxis="library_type",
+        vaxis="observed_taxa",
+        facet_by="external_sample_id",
+        return_chart=True,
+    )
+    assert chart.mark.type == "boxplot"
 
 
 def test_plot_pca(ocx, api_data):

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -6,7 +6,7 @@ pytest.importorskip("numpy")  # noqa
 pytest.importorskip("pandas")  # noqa
 
 import numpy as np
-import math
+
 from onecodex.exceptions import OneCodexException, PlottingException, PlottingWarning
 from onecodex.models.collection import SampleCollection
 from onecodex.utils import has_missing_values


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
One possible solution to [DEV-7001](https://linear.app/onecodex/issue/DEV-7001/custom-plots-box-plot-bug-alpha-diversity-group-by) - if we set the stroke color for the median line in the box plot, then at least a visible horizontal line will display for this edge case.

How the edge case mentioned in the linear issue would look:
<img width="1044" alt="Screen Shot 2022-06-28 at 10 13 37 PM" src="https://user-images.githubusercontent.com/17586127/176356873-62f42d0e-a278-4c57-8ef7-d728be52a322.png">


How it would affect normal boxes:
<img width="1037" alt="Screen Shot 2022-06-28 at 10 12 53 PM" src="https://user-images.githubusercontent.com/17586127/176356785-60aaccab-caf7-446d-8bcf-ba935dce15d6.png">

**Alternate solution**: if we don't want to change the aesthetics of the box plot (current can be seen in linear issue), we could issue a warning at the top of the page along the lines of "box won't render on duplicate data". We do a similar warning for an empty box already.

Also fixed a random typo I found ("categroy" -> "category")

cc @clausmith @jairideout for thoughts
