### PR TITLE
Expand missing level support

### DIFF
--- a/onecodex/lib/enums.py
+++ b/onecodex/lib/enums.py
@@ -63,6 +63,24 @@ class Rank(BaseEnum):
     Species = "species"
     Auto = "auto"
 
+    @property
+    def level(self):
+        if self not in _RANK_TO_LEVEL:
+            raise ValueError(f"Rank {self} has no level.")
+        return _RANK_TO_LEVEL[self]
+
+
+_RANK_TO_LEVEL = {
+    Rank.Species: 0,
+    Rank.Genus: 1,
+    Rank.Family: 2,
+    Rank.Order: 3,
+    Rank.Class: 4,
+    Rank.Phylum: 5,
+    Rank.Kingdom: 6,
+    Rank.Superkingdom: 7,
+}
+
 
 class Linkage(BaseEnum):
     Average = "average"

--- a/onecodex/lib/enums.py
+++ b/onecodex/lib/enums.py
@@ -52,20 +52,7 @@ class BetaDiversityMetric(BaseEnum):
     Aitchison = "aitchison"
 
 
-class NormalizedRank(BaseEnum):
-    Superkingdom = "superkingdom"
-    Kingdom = "kingdom"
-    Phylum = "phylum"
-    Class = "class"
-    Order = "order"
-    Family = "family"
-    Genus = "genus"
-    Species = "species"
-
-
 class Rank(BaseEnum):
-    """Python does not allow extending enums so we have to repeat the ranks."""
-
     Superkingdom = "superkingdom"
     Kingdom = "kingdom"
     Phylum = "phylum"

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ ALL_DEPS = [
     "pillow>=9.0.1",
     "scikit-bio>=0.5.7",
     "scikit-learn>=0.19.0",
+    "scipy<1.9",  # https://github.com/biocore/scikit-bio/issues/1818
     "jupyter-client==7.2.0",
 ]
 REPORT_DEPS = ALL_DEPS + [

--- a/tests/test_analyses.py
+++ b/tests/test_analyses.py
@@ -5,7 +5,6 @@ pytest.importorskip("pandas")  # noqa
 import warnings
 
 from onecodex.exceptions import OneCodexException
-from onecodex.analyses import RANK_TO_LEVEL
 from onecodex.lib.enums import Rank
 
 
@@ -252,9 +251,3 @@ def test_to_df_include_taxa_missing_rank_invalid_usage(ocx, api_data, metric):
 
     with pytest.raises(OneCodexException, match="`include_taxa_missing_rank`.*metrics"):
         samples.to_df(include_taxa_missing_rank=True)
-
-
-def test_all_ranks_have_a_level():
-    for rank in Rank:
-        if rank != Rank.Auto:
-            assert isinstance(RANK_TO_LEVEL[rank], int)

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,17 @@
+import pytest
+
+from onecodex.lib.enums import Rank
+
+
+def test_rank_level():
+    levels = []
+    for rank in Rank:
+        if rank == Rank.Auto:
+            with pytest.raises(ValueError):
+                rank.level
+        else:
+            level = rank.level
+            levels.append(level)
+            assert isinstance(level, int)
+
+    assert len(levels) == len(set(levels))


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
- Added `include_taxa_missing_rank` parameter to `to_df()` method for including taxa that do not have a designated parent at `rank` (will be grouped into a "No [rank]" column). Metrics `readcount_w_children` and `abundance_w_children` are supported.
- Added support for `readcount_w_children` metric to `plot_bargraph()` when passing `include_taxa_missing_rank` (only `abundance_w_children` was supported previously).

Note: the missing level algorithm was ported from the Quick Compare tool in the One Codex app.

Also pinned scipy<1.9 to work around https://github.com/biocore/scikit-bio/issues/1818

Closes DEV-5795

## Related PRs
- [x] This PR is independent