### PR TITLE
Add legend customization to plot_bargraph() & larger default legend

### DIFF
--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -58,9 +58,10 @@ class VizBargraphMixin(object):
         haxis : `string`, optional
             The metadata field (or tuple containing multiple categorical fields) used to group
             samples together.
-        legend: `string`, optional
-            Title for color scale. Defaults to the metric used to generate the plot, e.g.
-            readcount_w_children or abundance.
+        legend: `string` or `altair.Legend`, optional
+            If a string is provided, it will be used as the legend title. Defaults to the metric
+            used to generate the plot, e.g. readcount_w_children or abundance. Alternatively, an
+            `altair.Legend` instance may be provided for legend customization.
         label : `string` or `callable`, optional
             A metadata field (or function) used to label each analysis. If passing a function, a
             dict containing the metadata for each analysis is passed as the first and only
@@ -119,8 +120,13 @@ class VizBargraphMixin(object):
         if include_other and normalize:
             df["Other"] = 1 - df.sum(axis=1)
 
-        if legend == "auto":
-            legend = self.metric
+        if isinstance(legend, str):
+            if legend == "auto":
+                legend = self.metric
+            legend = alt.Legend(title=legend, symbolLimit=40, labelLimit=0)
+
+        if not isinstance(legend, alt.Legend):
+            raise TypeError(f"`legend` must be of type str or altair.Legend, not {type(legend)}")
 
         if tooltip:
             if not isinstance(tooltip, list):
@@ -213,14 +219,14 @@ class VizBargraphMixin(object):
                 ),
                 color=alt.Color(
                     "tax_name",
-                    legend=alt.Legend(title=legend),
+                    legend=legend,
                     sort=domain,
                     scale=alt.Scale(domain=domain, range=color_range),
                 ),
                 tooltip=tooltip_for_altair,
                 href="url:N",
                 order=alt.Order("order", sort="descending"),
-                **kwargs
+                **kwargs,
             )
         )
 

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -5,6 +5,7 @@ import pytest
 pytest.importorskip("numpy")  # noqa
 pytest.importorskip("pandas")  # noqa
 
+import altair as alt
 import numpy as np
 
 from onecodex.exceptions import OneCodexException, PlottingException
@@ -476,6 +477,29 @@ def test_plot_bargraph_chart_result(ocx, api_data, metric, rank, label):
     assert chart.encoding.x.axis.title == "Exemplary Samples"
     assert chart.encoding.y.shorthand == label
     assert chart.encoding.y.axis.title == "Glorious Abundances"
+    assert chart.encoding.color.legend.title == label
+
+
+@pytest.mark.parametrize(
+    "legend,expected_title",
+    [
+        ("auto", "Reads"),
+        ("my plot title", "my plot title"),
+        (alt.Legend(title="a different title"), "a different title"),
+    ],
+)
+def test_plot_bargraph_legend(ocx, api_data, legend, expected_title):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    samples._collate_results(metric="readcount_w_children")
+    chart = samples.plot_bargraph(return_chart=True, legend=legend)
+
+    assert chart.encoding.color.legend.title == expected_title
+
+
+def test_plot_bargraph_legend_error(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    with pytest.raises(TypeError, match="legend.*list"):
+        samples.plot_bargraph(legend=[4, 2])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
`plot_bargraph()`'s `legend` parameter now accepts an `altair.Legend` instance (in addition to string title support). The default legend is bigger (displaying up to 40 items, and labels are no longer truncated).

Closes DEV-7144

## Related PRs
- [x] This PR is independent