### PR TITLE
Fix `None` report artefact

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,8 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/pydocstyle

--- a/onecodex/assets/notebook_template.tpl
+++ b/onecodex/assets/notebook_template.tpl
@@ -1,4 +1,4 @@
-{%- extends 'full.tpl' -%}
+{%- extends 'classic/index.html.j2' -%}
 
 {%- block html_head -%}
 <meta charset="utf-8" />


### PR DESCRIPTION
## Status
- [X] **Ready**

## Description
The `full` nbconvert template has been long deprecated and causes a `None` artefact to appear at the top of the report when exporting.
This PR fixes this by replacing this template with a newer counterpart.
Closes #DEV-7390

## Related PRs
- [X] This PR is independent

## TODOs
- [ ] Update report generating images to include new version of the onecodex lib
