### PR TITLE
Add Python 3.11 enum compatibility

### DIFF
--- a/onecodex/lib/enums.py
+++ b/onecodex/lib/enums.py
@@ -1,4 +1,8 @@
-from enum import Enum
+try:
+    # Python 3.11 changed `__str__`/`__format__` behavior for enums with mixed-in data types
+    from enum import ReprEnum as Enum
+except ImportError:
+    from enum import Enum
 
 __all__ = ["Metric", "AbundanceMetric", "AlphaDiversityMetric", "BetaDiversityMetric"]
 

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,6 +1,13 @@
 import pytest
 
-from onecodex.lib.enums import Rank
+from onecodex.lib.enums import BaseEnum, Rank
+
+
+def test_base_enum_format_compat():
+    class MyEnum(BaseEnum):
+        Foo = "foo"
+
+    assert f"{MyEnum.Foo}" == "foo"
 
 
 def test_rank_level():


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Python 3.11 changed how enums work: https://docs.python.org/3/whatsnew/3.11.html#enum

This PR makes `BaseEnum` behave like it did in earlier Python versions.

## Related PRs
- [x] This PR is independent