### PR TITLE
Handle samples with no abundances in heatmap

### DIFF
--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -19,6 +19,14 @@ from onecodex.viz import (
 )
 
 
+def get_all_nan_classification_ids(df):
+    all_nan_classification_ids = []
+    for class_id, is_all_nan in df.isnull().all(1).items():
+        if is_all_nan:
+            all_nan_classification_ids.append(class_id)
+    return all_nan_classification_ids
+
+
 class AnalysisMixin(
     VizPCAMixin, VizHeatmapMixin, VizMetadataMixin, VizDistanceMixin, VizBargraphMixin
 ):
@@ -245,6 +253,11 @@ class AnalysisMixin(
                         magic_fields[f] = str_f
 
         return magic_metadata, magic_fields
+
+    @property
+    def all_nan_classification_ids(self):
+        df = self._results.copy()
+        return get_all_nan_classification_ids(df)
 
     def to_df(self, analysis_type=AnalysisType.Classification, **kwargs):
         """

--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -306,6 +306,7 @@ class AnalysisMixin(
         normalize="auto",
         table_format="wide",
         include_taxa_missing_rank=False,
+        include_nans=False,
     ):
         """Generate a ClassificationDataFrame, performing any specified transformations.
 
@@ -350,7 +351,7 @@ class AnalysisMixin(
                 )
 
         rank = self._get_auto_rank(rank)
-        df = self._results.copy()
+        df = self._collate_results(include_nans=include_nans).copy()
 
         # subset by taxa
         if rank:

--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -351,7 +351,10 @@ class AnalysisMixin(
                 )
 
         rank = self._get_auto_rank(rank)
-        df = self._collate_results(include_nans=include_nans).copy()
+
+        df = self._results.copy()
+        if not include_nans:
+            df = df.fillna(0)
 
         # subset by taxa
         if rank:

--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -256,8 +256,9 @@ class AnalysisMixin(
 
     @property
     def all_nan_classification_ids(self):
-        df = self._results.copy()
-        return get_all_nan_classification_ids(df)
+        if self.__class__.__name__ == "OneCodexAccessor":
+            return self._all_nan_classification_ids
+        return get_all_nan_classification_ids(self._results)
 
     def to_df(self, analysis_type=AnalysisType.Classification, **kwargs):
         """
@@ -321,7 +322,7 @@ class AnalysisMixin(
         include_taxa_missing_rank=False,
         include_nans=False,
     ):
-        """Generate a ClassificationDataFrame, performing any specified transformations.
+        """Generate a ClassificationsDataFrame, performing any specified transformations.
 
         Takes the ClassificationsDataFrame associated with these samples, or SampleCollection,
         does some filtering, and returns a ClassificationsDataFrame copy.
@@ -441,6 +442,7 @@ class AnalysisMixin(
             "ocx_metric": self._metric,
             "ocx_taxonomy": self.taxonomy.copy(),
             "ocx_normalized": normalize,
+            "_all_nan_classification_ids": self.all_nan_classification_ids,
         }
 
         # generate long-format table

--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -268,11 +268,11 @@ class AnalysisMixin(
         from onecodex.dataframes import OneCodexAccessor
 
         if isinstance(self, OneCodexAccessor):
-            if self.ocx_all_nan_classification_ids is None:
+            if self._ocx_all_nan_classification_ids is None:
                 # We rely on this list for accurate plot data, and it shouldn't ever be None, but if
                 # it is None, we raise an exception to avoid generating misleading plots
                 raise OneCodexException("Unable to fetch list of all_nan_classification_ids")
-            return self.ocx_all_nan_classification_ids
+            return self._ocx_all_nan_classification_ids
         return _get_all_nan_classification_ids(self._results)
 
     def to_df(self, analysis_type=AnalysisType.Classification, **kwargs):

--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -257,6 +257,8 @@ class AnalysisMixin(
     @property
     def all_nan_classification_ids(self):
         if self.__class__.__name__ == "OneCodexAccessor":
+            if self._all_nan_classification_ids is None:
+                raise OneCodexException("Unable to fetch list of all_nan_classification_ids")
             return self._all_nan_classification_ids
         return get_all_nan_classification_ids(self._results)
 

--- a/onecodex/dataframes.py
+++ b/onecodex/dataframes.py
@@ -38,7 +38,14 @@ class ClassificationsDataFrame(pd.DataFrame):
         Whether the results in this DataFrame were normalized, each sample summing to 1.0.
     """
 
-    _metadata = ["ocx_rank", "ocx_metric", "ocx_taxonomy", "ocx_metadata", "ocx_normalized"]
+    _metadata = [
+        "ocx_rank",
+        "ocx_metric",
+        "ocx_taxonomy",
+        "ocx_metadata",
+        "ocx_normalized",
+        "_all_nan_classification_ids",
+    ]
 
     def __init__(
         self,
@@ -52,12 +59,14 @@ class ClassificationsDataFrame(pd.DataFrame):
         ocx_taxonomy=None,
         ocx_metadata=None,
         ocx_normalized=None,
+        _all_nan_classification_ids=None,
     ):
         self.ocx_rank = ocx_rank
         self.ocx_metric = ocx_metric
         self.ocx_taxonomy = ocx_taxonomy
         self.ocx_metadata = ocx_metadata
         self.ocx_normalized = ocx_normalized
+        self._all_nan_classification_ids = _all_nan_classification_ids
 
         pd.DataFrame.__init__(self, data=data, index=index, columns=columns, dtype=dtype, copy=copy)
 
@@ -160,6 +169,7 @@ class OneCodexAccessor(AnalysisMixin):
         self._metric = pandas_obj.ocx_metric
         self._rank = pandas_obj.ocx_rank
         self._results = pandas_obj
+        self._all_nan_classification_ids = pandas_obj._all_nan_classification_ids
 
         # prune back _taxonomy df to contain only taxa and parents in the ClassificationsDataFrame
         tree = self.tree_build()

--- a/onecodex/dataframes.py
+++ b/onecodex/dataframes.py
@@ -172,7 +172,7 @@ class OneCodexAccessor(AnalysisMixin):
         self._metric = pandas_obj.ocx_metric
         self._rank = pandas_obj.ocx_rank
         self._results = pandas_obj
-        self.ocx_all_nan_classification_ids = pandas_obj.ocx_all_nan_classification_ids
+        self._ocx_all_nan_classification_ids = pandas_obj.ocx_all_nan_classification_ids
 
         # prune back _taxonomy df to contain only taxa and parents in the ClassificationsDataFrame
         tree = self.tree_build()

--- a/onecodex/dataframes.py
+++ b/onecodex/dataframes.py
@@ -172,7 +172,7 @@ class OneCodexAccessor(AnalysisMixin):
         self._metric = pandas_obj.ocx_metric
         self._rank = pandas_obj.ocx_rank
         self._results = pandas_obj
-        self._all_nan_classification_ids = pandas_obj.ocx_all_nan_classification_ids
+        self.ocx_all_nan_classification_ids = pandas_obj.ocx_all_nan_classification_ids
 
         # prune back _taxonomy df to contain only taxa and parents in the ClassificationsDataFrame
         tree = self.tree_build()

--- a/onecodex/dataframes.py
+++ b/onecodex/dataframes.py
@@ -36,6 +36,9 @@ class ClassificationsDataFrame(pd.DataFrame):
 
     ocx_normalized : `bool`
         Whether the results in this DataFrame were normalized, each sample summing to 1.0.
+
+    ocx_all_nan_classification_ids : `list`
+        List of classification_ids for which no abundances were calculated.
     """
 
     _metadata = [
@@ -44,7 +47,7 @@ class ClassificationsDataFrame(pd.DataFrame):
         "ocx_taxonomy",
         "ocx_metadata",
         "ocx_normalized",
-        "_all_nan_classification_ids",
+        "ocx_all_nan_classification_ids",
     ]
 
     def __init__(
@@ -59,14 +62,14 @@ class ClassificationsDataFrame(pd.DataFrame):
         ocx_taxonomy=None,
         ocx_metadata=None,
         ocx_normalized=None,
-        _all_nan_classification_ids=None,
+        ocx_all_nan_classification_ids=None,
     ):
         self.ocx_rank = ocx_rank
         self.ocx_metric = ocx_metric
         self.ocx_taxonomy = ocx_taxonomy
         self.ocx_metadata = ocx_metadata
         self.ocx_normalized = ocx_normalized
-        self._all_nan_classification_ids = _all_nan_classification_ids
+        self.ocx_all_nan_classification_ids = ocx_all_nan_classification_ids
 
         pd.DataFrame.__init__(self, data=data, index=index, columns=columns, dtype=dtype, copy=copy)
 
@@ -169,7 +172,7 @@ class OneCodexAccessor(AnalysisMixin):
         self._metric = pandas_obj.ocx_metric
         self._rank = pandas_obj.ocx_rank
         self._results = pandas_obj
-        self._all_nan_classification_ids = pandas_obj._all_nan_classification_ids
+        self._all_nan_classification_ids = pandas_obj.ocx_all_nan_classification_ids
 
         # prune back _taxonomy df to contain only taxa and parents in the ClassificationsDataFrame
         tree = self.tree_build()

--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -141,7 +141,7 @@ class DistanceMixin(TaxonomyMixin):
         """
         import skbio.diversity
 
-        df = self.to_df(rank=rank, normalize=self._guess_normalized())
+        df = self.to_df(rank=rank, normalize=self._guess_normalized()).fillna(0)
 
         ocx_rank = df.ocx_rank
         # The scikit-bio implementations of phylogenetic metrics require integer counts

--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -141,7 +141,7 @@ class DistanceMixin(TaxonomyMixin):
         """
         import skbio.diversity
 
-        df = self.to_df(rank=rank, normalize=self._guess_normalized()).fillna(0)
+        df = self.to_df(rank=rank, normalize=self._guess_normalized(), fill_missing=True)
 
         ocx_rank = df.ocx_rank
         # The scikit-bio implementations of phylogenetic metrics require integer counts

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -262,7 +262,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
 
         return self._cached["metadata"]
 
-    def _collate_results(self, metric=None, include_host=None, include_nans=False):
+    def _collate_results(self, metric=None, include_host=None):
         """Transform a list of Classifications into `pd.DataFrames` of taxonomy and results data.
 
         Parameters

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -340,7 +340,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
         data = np.zeros((len(self._classifications), len(tax_info.index)), dtype=metric_dtype)
 
         if metric in [Metric.AbundanceWChildren, Metric.Abundance]:
-            data[:] = np.nan
+            data.fill(np.nan)
 
         for c_idx, c in enumerate(self._classifications):
             # results are cached from the call earlier in this method
@@ -354,7 +354,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
                     continue
 
                 if metric in [Metric.AbundanceWChildren, Metric.Abundance]:
-                    data[c_idx, tax_id_to_idx[d_tax_id]] = d[metric]
+                    data[c_idx, tax_id_to_idx[d_tax_id]] = d[metric] or np.nan
                 else:
                     data[c_idx, tax_id_to_idx[d_tax_id]] = d[metric] or 0
 

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -354,7 +354,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
                     continue
 
                 if metric in [Metric.AbundanceWChildren, Metric.Abundance]:
-                    data[c_idx, tax_id_to_idx[d_tax_id]] = d[metric] or np.nan
+                    data[c_idx, tax_id_to_idx[d_tax_id]] = d[metric]
                 else:
                     data[c_idx, tax_id_to_idx[d_tax_id]] = d[metric] or 0
 

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -339,6 +339,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
 
         data = np.zeros((len(self._classifications), len(tax_info.index)), dtype=metric_dtype)
 
+        data[:] = np.nan
         for c_idx, c in enumerate(self._classifications):
             # results are cached from the call earlier in this method
             results = c.results()
@@ -350,7 +351,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
                 if not include_host and d_tax_id in host_tax_ids:
                     continue
 
-                data[c_idx, tax_id_to_idx[d_tax_id]] = d[metric] or 0
+                data[c_idx, tax_id_to_idx[d_tax_id]] = d[metric]
 
         df = pd.DataFrame(
             data,

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -339,7 +339,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
 
         data = np.zeros((len(self._classifications), len(tax_info.index)), dtype=metric_dtype)
 
-        if include_nans:
+        if metric in [Metric.AbundanceWChildren, Metric.Abundance]:
             data[:] = np.nan
 
         for c_idx, c in enumerate(self._classifications):
@@ -353,7 +353,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
                 if not include_host and d_tax_id in host_tax_ids:
                     continue
 
-                if include_nans:
+                if metric in [Metric.AbundanceWChildren, Metric.Abundance]:
                     data[c_idx, tax_id_to_idx[d_tax_id]] = d[metric]
                 else:
                     data[c_idx, tax_id_to_idx[d_tax_id]] = d[metric] or 0
@@ -367,8 +367,6 @@ class SampleCollection(ResourceList, AnalysisMixin):
 
         self._cached["results"] = df
         self._cached["taxonomy"] = tax_info
-
-        return df
 
     @property
     def _metric(self):

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -56,17 +56,16 @@ class VizDistanceMixin(DistanceMixin):
             if is_all_nan:
                 all_nan_classification_ids.append(class_id)
 
-        df_without_all_nan_rows = self._results.dropna(how="all")
-        df_without_all_nan_rows = df_without_all_nan_rows.replace(np.nan, 0)
+        df = self._results.dropna(how="all").replace(np.nan, 0)
 
         if metric == "euclidean":
-            dist_matrix = euclidean_distances(df_without_all_nan_rows).round(6)
+            dist_matrix = euclidean_distances(df).round(6)
         else:
             dist_matrix = self._compute_distance(rank=rank, metric=metric).to_data_frame().round(6)
 
         clustering = hierarchy.linkage(squareform(dist_matrix), method=linkage)
         scipy_tree = hierarchy.dendrogram(clustering, no_plot=True)
-        ids_in_order = [df_without_all_nan_rows.index[int(x)] for x in scipy_tree["ivl"]]
+        ids_in_order = [df.index[int(x)] for x in scipy_tree["ivl"]]
         ids_in_order.extend(all_nan_classification_ids)
 
         return (
@@ -84,14 +83,13 @@ class VizDistanceMixin(DistanceMixin):
         from scipy.spatial.distance import squareform
         from sklearn.metrics.pairwise import euclidean_distances
 
-        df_without_all_nan_rows = self._results.dropna(how="all")
-        df_without_all_nan_rows = df_without_all_nan_rows.replace(np.nan, 0)
+        df = self._results.dropna(how="all").replace(np.nan, 0)
 
-        dist_matrix = euclidean_distances(df_without_all_nan_rows.T).round(6)
+        dist_matrix = euclidean_distances(df.T).round(6)
 
         clustering = hierarchy.linkage(squareform(dist_matrix, checks=False), method=linkage)
         scipy_tree = hierarchy.dendrogram(clustering, no_plot=True)
-        ids_in_order = [df_without_all_nan_rows.T.index[int(x)] for x in scipy_tree["ivl"]]
+        ids_in_order = [df.T.index[int(x)] for x in scipy_tree["ivl"]]
         labels_in_order = ["{} ({})".format(self.taxonomy["name"][t], t) for t in ids_in_order]
 
         return {

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -11,7 +11,6 @@ from onecodex.viz._primitives import (
     get_classification_url,
     open_links_in_new_tab,
 )
-from onecodex.viz._heatmap import get_all_nan_classification_ids
 from onecodex.utils import is_continuous, has_missing_values
 
 
@@ -49,6 +48,7 @@ class VizDistanceMixin(DistanceMixin):
         from scipy.cluster import hierarchy
         from scipy.spatial.distance import squareform
         from sklearn.metrics.pairwise import euclidean_distances
+        from onecodex.analyses import get_all_nan_classification_ids
 
         all_nan_classification_ids = get_all_nan_classification_ids(self._results)
 

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -13,6 +13,7 @@ from onecodex.viz._primitives import (
     get_classification_url,
     open_links_in_new_tab,
 )
+from onecodex.viz._heatmap import get_all_nan_classification_ids
 from onecodex.utils import is_continuous, has_missing_values
 
 
@@ -50,13 +51,9 @@ class VizDistanceMixin(DistanceMixin):
         from scipy.spatial.distance import squareform
         from sklearn.metrics.pairwise import euclidean_distances
 
-        all_nan_classification_ids = []
+        all_nan_classification_ids = get_all_nan_classification_ids(self._results)
 
-        for class_id, is_all_nan in self._results.isnull().all(1).items():
-            if is_all_nan:
-                all_nan_classification_ids.append(class_id)
-
-        df = self._results.dropna(how="all").replace(np.nan, 0)
+        df = self._results.dropna(how="all", axis="rows").replace(np.nan, 0)
 
         if metric == "euclidean":
             dist_matrix = euclidean_distances(df).round(6)
@@ -68,15 +65,12 @@ class VizDistanceMixin(DistanceMixin):
         ids_in_order = [df.index[int(x)] for x in scipy_tree["ivl"]]
         ids_in_order.extend(all_nan_classification_ids)
 
-        return (
-            {
-                "dist_matrix": dist_matrix,
-                "clustering": clustering,
-                "scipy_tree": scipy_tree,
-                "ids_in_order": ids_in_order,
-            },
-            all_nan_classification_ids,
-        )
+        return {
+            "dist_matrix": dist_matrix,
+            "clustering": clustering,
+            "scipy_tree": scipy_tree,
+            "ids_in_order": ids_in_order,
+        }
 
     def _cluster_by_taxa(self, linkage=Linkage.Average):
         from scipy.cluster import hierarchy

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -2,8 +2,6 @@
 from itertools import chain
 import warnings
 
-import numpy as np
-
 from onecodex.lib.enums import BetaDiversityMetric, Rank, Linkage, OrdinationMethod
 from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.distance import DistanceMixin
@@ -47,6 +45,7 @@ class VizDistanceMixin(DistanceMixin):
     def _cluster_by_sample(
         self, rank=Rank.Auto, metric=BetaDiversityMetric.BrayCurtis, linkage=Linkage.Average
     ):
+        import numpy as np
         from scipy.cluster import hierarchy
         from scipy.spatial.distance import squareform
         from sklearn.metrics.pairwise import euclidean_distances
@@ -73,6 +72,7 @@ class VizDistanceMixin(DistanceMixin):
         }
 
     def _cluster_by_taxa(self, linkage=Linkage.Average):
+        import numpy as np
         from scipy.cluster import hierarchy
         from scipy.spatial.distance import squareform
         from sklearn.metrics.pairwise import euclidean_distances

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -54,6 +54,9 @@ class VizDistanceMixin(DistanceMixin):
         from sklearn.metrics.pairwise import euclidean_distances
 
         df = self._results
+        import pdb
+
+        pdb.set_trace()
         if all_nan_classification_ids:
             df = df.drop(all_nan_classification_ids)
         df = df.replace(np.nan, 0)

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -54,9 +54,7 @@ class VizDistanceMixin(DistanceMixin):
         from sklearn.metrics.pairwise import euclidean_distances
 
         df = self._results
-        import pdb
 
-        pdb.set_trace()
         if all_nan_classification_ids:
             df = df.drop(all_nan_classification_ids)
         df = df.replace(np.nan, 0)

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -121,7 +121,7 @@ class VizHeatmapMixin(object):
             top_n=top_n,
             threshold=threshold,
             table_format="long",
-            include_nans=True,
+            fill_missing=False,
         )
         all_nan_classification_ids = self.all_nan_classification_ids
 
@@ -164,16 +164,16 @@ class VizHeatmapMixin(object):
                 )
 
             df_sample_cluster = self.to_df(
-                rank=rank, normalize=normalize, top_n=top_n, threshold=threshold, include_nans=True
+                rank=rank, normalize=normalize, top_n=top_n, threshold=threshold, fill_missing=False
             )
             df_taxa_cluster = df_sample_cluster
         else:
             df_sample_cluster = self.to_df(
-                rank=rank, normalize=False, top_n=top_n, threshold=threshold, include_nans=True
+                rank=rank, normalize=False, top_n=top_n, threshold=threshold, fill_missing=False
             )
 
             df_taxa_cluster = self.to_df(
-                rank=rank, normalize=normalize, top_n=top_n, threshold=threshold, include_nans=True
+                rank=rank, normalize=normalize, top_n=top_n, threshold=threshold, fill_missing=False
             )
 
         # applying clustering to determine order of taxa, or use custom sorting function if given
@@ -265,8 +265,7 @@ class VizHeatmapMixin(object):
             df = df.drop(index)
 
         df = df.replace(np.nan, 0)
-        for dropped_df in dropped:
-            df = pd.concat([df, dropped_df])
+        df = pd.concat([df, *dropped])
 
         assert set(df["Label"].values) == set(labels_in_order)
 

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -258,7 +258,7 @@ class VizHeatmapMixin(object):
             d = df[(df == classification_id).any(axis=1)]
             if self.__class__.__name__ == "OneCodexAccessor":
                 # the df of a `OneCodexAccessor` does not have NaNs, and we want to display
-                # all_nan_classificaion_id columns as white instead of color corresponding to 0
+                # all_nan_classification_id columns as white instead of color corresponding to 0
                 d = d.replace(0.0, np.nan)
             dropped.append(d)
             index = df[(df == classification_id).any(axis=1)].index

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -94,6 +94,7 @@ class VizHeatmapMixin(object):
         import altair as alt
         import pandas as pd
         import numpy as np
+        from onecodex.dataframes import OneCodexAccessor
 
         if rank is None:
             raise OneCodexException("Please specify a rank or 'auto' to choose automatically")
@@ -123,7 +124,7 @@ class VizHeatmapMixin(object):
             table_format="long",
             fill_missing=False,
         )
-        all_nan_classification_ids = self.all_nan_classification_ids
+        all_nan_classification_ids = self._all_nan_classification_ids
 
         if len(df["tax_id"].unique()) < 2:
             raise PlottingException(
@@ -256,7 +257,7 @@ class VizHeatmapMixin(object):
         dropped = []
         for classification_id in all_nan_classification_ids:
             d = df[(df == classification_id).any(axis=1)]
-            if self.__class__.__name__ == "OneCodexAccessor":
+            if isinstance(self, OneCodexAccessor):
                 # the df of a `OneCodexAccessor` does not have NaNs, and we want to display
                 # all_nan_classification_id columns as white instead of color corresponding to 0
                 d = d.replace(0.0, np.nan)

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -117,7 +117,12 @@ class VizHeatmapMixin(object):
             threshold = None
 
         df = self.to_df(
-            rank=rank, normalize=normalize, top_n=top_n, threshold=threshold, table_format="long"
+            rank=rank,
+            normalize=normalize,
+            top_n=top_n,
+            threshold=threshold,
+            table_format="long",
+            include_nans=True,
         )
 
         if len(df["tax_id"].unique()) < 2:
@@ -159,16 +164,16 @@ class VizHeatmapMixin(object):
                 )
 
             df_sample_cluster = self.to_df(
-                rank=rank, normalize=normalize, top_n=top_n, threshold=threshold
+                rank=rank, normalize=normalize, top_n=top_n, threshold=threshold, include_nans=True
             )
             df_taxa_cluster = df_sample_cluster
         else:
             df_sample_cluster = self.to_df(
-                rank=rank, normalize=False, top_n=top_n, threshold=threshold
+                rank=rank, normalize=False, top_n=top_n, threshold=threshold, include_nans=True
             )
 
             df_taxa_cluster = self.to_df(
-                rank=rank, normalize=normalize, top_n=top_n, threshold=threshold
+                rank=rank, normalize=normalize, top_n=top_n, threshold=threshold, include_nans=True
             )
 
         # applying clustering to determine order of taxa, or use custom sorting function if given

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from onecodex.lib.enums import Rank, Linkage, Link
 from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.viz._primitives import (
@@ -103,6 +101,7 @@ class VizHeatmapMixin(object):
         # Deferred imports
         import altair as alt
         import pandas as pd
+        import numpy as np
 
         if rank is None:
             raise OneCodexException("Please specify a rank or 'auto' to choose automatically")

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -11,6 +11,14 @@ from onecodex.viz._primitives import (
 )
 
 
+def get_all_nan_classification_ids(df):
+    all_nan_classification_ids = []
+    for class_id, is_all_nan in df.isnull().all(1).items():
+        if is_all_nan:
+            all_nan_classification_ids.append(class_id)
+    return all_nan_classification_ids
+
+
 class VizHeatmapMixin(object):
     def plot_heatmap(
         self,
@@ -124,6 +132,8 @@ class VizHeatmapMixin(object):
             table_format="long",
             include_nans=True,
         )
+        # this won't work because we've already taken the top_n
+        all_nan_classification_ids = get_all_nan_classification_ids(df)
 
         if len(df["tax_id"].unique()) < 2:
             raise PlottingException(
@@ -186,10 +196,7 @@ class VizHeatmapMixin(object):
         if sort_x is None:
             if haxis is None:
                 # cluster samples only once
-                (
-                    sample_cluster,
-                    all_nan_classification_ids,
-                ) = df_sample_cluster.ocx._cluster_by_sample(
+                sample_cluster = df_sample_cluster.ocx._cluster_by_sample(
                     rank=rank, metric=metric, linkage=linkage
                 )
                 labels_in_order = magic_metadata["Label"][sample_cluster["ids_in_order"]].tolist()

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -9,14 +9,6 @@ from onecodex.viz._primitives import (
 )
 
 
-def get_all_nan_classification_ids(df):
-    all_nan_classification_ids = []
-    for class_id, is_all_nan in df.isnull().all(1).items():
-        if is_all_nan:
-            all_nan_classification_ids.append(class_id)
-    return all_nan_classification_ids
-
-
 class VizHeatmapMixin(object):
     def plot_heatmap(
         self,
@@ -131,8 +123,7 @@ class VizHeatmapMixin(object):
             table_format="long",
             include_nans=True,
         )
-        # this won't work because we've already taken the top_n
-        all_nan_classification_ids = get_all_nan_classification_ids(df)
+        all_nan_classification_ids = self.all_nan_classification_ids
 
         if len(df["tax_id"].unique()) < 2:
             raise PlottingException(

--- a/tests/test_analyses.py
+++ b/tests/test_analyses.py
@@ -40,15 +40,15 @@ def test_all_nan_classification_id_property(ocx, api_data):
 
     samples = ocx.Samples.where(project="4b53797444f846c4")
     # should be the same when called on `SampleCollection` and on `OneCodexAccessor`
-    assert samples.all_nan_classification_ids == []
-    assert samples.to_df(fill_missing=False).ocx.all_nan_classification_ids == []
+    assert samples._all_nan_classification_ids == []
+    assert samples.to_df(fill_missing=False).ocx._all_nan_classification_ids == []
 
     samples._results.iloc[0] = np.nan
 
-    assert samples.to_df(fill_missing=False).ocx.all_nan_classification_ids == [
+    assert samples.to_df(fill_missing=False).ocx._all_nan_classification_ids == [
         samples._results.iloc[0].name
     ]
-    assert samples.all_nan_classification_ids == [samples._results.iloc[0].name]
+    assert samples._all_nan_classification_ids == [samples._results.iloc[0].name]
 
 
 def test_guess_normalization(ocx, api_data):

--- a/tests/test_analyses.py
+++ b/tests/test_analyses.py
@@ -86,8 +86,8 @@ def test_fill_missing_df(ocx, api_data):
     samples = ocx.Samples.where(project="4b53797444f846c4")
     samples._collate_results(metric="abundance_w_children")
 
-    assert samples.to_df(fill_missing=False).isnull().values.any() is True
-    assert samples.to_df(fill_missing=True).isnull().values.any() is False
+    assert samples.to_df(fill_missing=False).isnull().values.any() == True  # noqa
+    assert samples.to_df(fill_missing=True).isnull().values.any() == False  # noqa
 
 
 def test_metadata_fetch(ocx, api_data):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -162,7 +162,7 @@ def test_collate_results(ocx, api_data, metric, sha):
     for col in sorted(samples._results.columns.tolist()):
         for row in sorted(samples._results.index.tolist()):
             try:
-                string_to_hash += samples._results.loc[row, col].astype(str)
+                string_to_hash += samples._results.fillna(0).loc[row, col].astype(str)
             except AttributeError:
                 pass
 

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -254,7 +254,14 @@ def test_plot_heatmap(ocx, api_data):
     assert all(chart.data.groupby("tax_id").max()["Relative Abundance"] > 0.01)
 
 
-def test_plot_heatmap_plots_all_nan_samples_with_nans(ocx, api_data):
+@pytest.mark.parametrize(
+    "is_onecodex_accessor",
+    [
+        (False),
+        (True),
+    ],
+)
+def test_plot_heatmap_plots_all_nan_samples_with_nans(ocx, api_data, is_onecodex_accessor):
     import numpy as np
 
     samples = ocx.Samples.where(project="4b53797444f846c4")
@@ -262,49 +269,17 @@ def test_plot_heatmap_plots_all_nan_samples_with_nans(ocx, api_data):
     # Set abundances for first sample to be all NaN
     all_nan_sample = samples[0]
     samples._results.loc[all_nan_sample.primary_classification.id] = np.nan
-    assert len(samples.all_nan_classification_ids) == 1
+    assert len(samples._all_nan_classification_ids) == 1
 
-    all_nan_classification_id = samples.all_nan_classification_ids[0]
-    chart = samples.plot_heatmap(
-        top_n=10, title="my title", xlabel="my xlabel", ylabel="my ylabel", return_chart=True
-    )
-    chart_data = chart["data"]
-
-    # Samples with no abundances calculated for them should have all-NaN rows in chart data df
-    # Other classification_id rows should not have any `NaN`s
-    assert (
-        chart_data[(chart_data == all_nan_classification_id).any(axis=1)]["Relative Abundance"]
-        .isnull()
-        .all()
-        == True  # noqa
-    )
-    assert (
-        chart_data[(chart_data == samples[1].primary_classification.id).any(axis=1)][
-            "Relative Abundance"
-        ]
-        .isnull()
-        .any()
-        == False  # noqa
-    )
-
-    # Sample with all NaNs should be at the end
-    assert chart.encoding.x.sort[-1] == all_nan_sample.filename
-
-
-def test_plot_heatmap_on_df_plots_all_nan_samples_with_nans(ocx, api_data):
-    import numpy as np
-
-    samples = ocx.Samples.where(project="4b53797444f846c4")
-
-    # Set abundances for first sample to be all NaN
-    all_nan_sample = samples[0]
-    samples._results.loc[all_nan_sample.primary_classification.id] = np.nan
-    assert len(samples.all_nan_classification_ids) == 1
-
-    all_nan_classification_id = samples.all_nan_classification_ids[0]
-    chart = samples.to_df().ocx.plot_heatmap(
-        title="my title", xlabel="my xlabel", ylabel="my ylabel", return_chart=True
-    )
+    all_nan_classification_id = samples._all_nan_classification_ids[0]
+    if is_onecodex_accessor:
+        chart = samples.to_df().ocx.plot_heatmap(
+            title="my title", xlabel="my xlabel", ylabel="my ylabel", return_chart=True
+        )
+    else:
+        chart = samples.plot_heatmap(
+            top_n=10, title="my title", xlabel="my xlabel", ylabel="my ylabel", return_chart=True
+        )
     chart_data = chart["data"]
 
     # Samples with no abundances calculated for them should have all-NaN rows in chart data df

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -276,7 +276,7 @@ def test_plot_heatmap_plots_all_nan_samples_with_nans(ocx, api_data):
         chart_data[(chart_data == all_nan_classification_id).any(axis=1)]["Relative Abundance"]
         .isnull()
         .all()
-        is True
+        == True  # noqa
     )
     assert (
         chart_data[(chart_data == samples[1].primary_classification.id).any(axis=1)][
@@ -284,7 +284,7 @@ def test_plot_heatmap_plots_all_nan_samples_with_nans(ocx, api_data):
         ]
         .isnull()
         .any()
-        is False
+        == False  # noqa
     )
 
     # Sample with all NaNs should be at the end
@@ -313,7 +313,7 @@ def test_plot_heatmap_on_df_plots_all_nan_samples_with_nans(ocx, api_data):
         chart_data[(chart_data == all_nan_classification_id).any(axis=1)]["Relative Abundance"]
         .isnull()
         .all()
-        is True
+        == True  # noqa
     )
     assert (
         chart_data[(chart_data == samples[1].primary_classification.id).any(axis=1)][
@@ -321,7 +321,7 @@ def test_plot_heatmap_on_df_plots_all_nan_samples_with_nans(ocx, api_data):
         ]
         .isnull()
         .any()
-        is False
+        == False  # noqa
     )
 
     # Sample with all NaNs should be at the end

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -254,6 +254,80 @@ def test_plot_heatmap(ocx, api_data):
     assert all(chart.data.groupby("tax_id").max()["Relative Abundance"] > 0.01)
 
 
+def test_plot_heatmap_plots_all_nan_samples_with_nans(ocx, api_data):
+    import numpy as np
+
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+
+    # Set abundances for first sample to be all NaN
+    all_nan_sample = samples[0]
+    samples._results.loc[all_nan_sample.primary_classification.id] = np.nan
+    assert len(samples.all_nan_classification_ids) == 1
+
+    all_nan_classification_id = samples.all_nan_classification_ids[0]
+    chart = samples.plot_heatmap(
+        top_n=10, title="my title", xlabel="my xlabel", ylabel="my ylabel", return_chart=True
+    )
+    chart_data = chart["data"]
+
+    # Samples with no abundances calculated for them should have all-NaN rows in chart data df
+    # Other classification_id rows should not have any `NaN`s
+    assert (
+        chart_data[(chart_data == all_nan_classification_id).any(axis=1)]["Relative Abundance"]
+        .isnull()
+        .all()
+        is True
+    )
+    assert (
+        chart_data[(chart_data == samples[1].primary_classification.id).any(axis=1)][
+            "Relative Abundance"
+        ]
+        .isnull()
+        .any()
+        is False
+    )
+
+    # Sample with all NaNs should be at the end
+    assert chart.encoding.x.sort[-1] == all_nan_sample.filename
+
+
+def test_plot_heatmap_on_df_plots_all_nan_samples_with_nans(ocx, api_data):
+    import numpy as np
+
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+
+    # Set abundances for first sample to be all NaN
+    all_nan_sample = samples[0]
+    samples._results.loc[all_nan_sample.primary_classification.id] = np.nan
+    assert len(samples.all_nan_classification_ids) == 1
+
+    all_nan_classification_id = samples.all_nan_classification_ids[0]
+    chart = samples.to_df().ocx.plot_heatmap(
+        title="my title", xlabel="my xlabel", ylabel="my ylabel", return_chart=True
+    )
+    chart_data = chart["data"]
+
+    # Samples with no abundances calculated for them should have all-NaN rows in chart data df
+    # Other classification_id rows should not have any `NaN`s
+    assert (
+        chart_data[(chart_data == all_nan_classification_id).any(axis=1)]["Relative Abundance"]
+        .isnull()
+        .all()
+        is True
+    )
+    assert (
+        chart_data[(chart_data == samples[1].primary_classification.id).any(axis=1)][
+            "Relative Abundance"
+        ]
+        .isnull()
+        .any()
+        is False
+    )
+
+    # Sample with all NaNs should be at the end
+    assert chart.encoding.x.sort[-1] == all_nan_sample.filename
+
+
 def test_plot_heatmap_exceptions(ocx, api_data):
     samples = ocx.Samples.where(project="4b53797444f846c4")
 


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description

Currently, the custom plots abundances heatmap includes 0s even when the sample in question has no abundances calculated at all for it. For samples that have some abundances, but 0 for other taxa, a 0 value makes sense, but when a sample has no abundances at all, 0 should not be used as a stand-in. We would like to plot columns for samples fitting these criteria (no abundances calculated) as blank/none, and position them to one side of the chart.

<img width="612" alt="image" src="https://github.com/onecodex/onecodex/assets/7769529/fb9fcd5a-064f-4ce3-8c53-aab65edadcf3">


## Related PRs
- [x] This PR is independent
