### PR TITLE
Remove open_links_in_new_tabs functionality

### DIFF
--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -6,7 +6,6 @@ from onecodex.viz._primitives import (
     sort_helper,
     get_ncbi_taxonomy_browser_url,
     get_classification_url,
-    open_links_in_new_tab,
 )
 
 
@@ -32,7 +31,6 @@ class VizBargraphMixin(object):
         height=None,
         group_by=None,
         link=Link.Ocx,
-        open_links_in_new_tabs=True,
     ):
         """Plot a bargraph of relative abundance of taxa for multiple samples.
 
@@ -81,11 +79,7 @@ class VizBargraphMixin(object):
             averaged within each group.
         link: {'ocx', 'ncbi'}, optional
             If `link` is 'ocx', clicking a sample will open its classification results in the One
-            Codex app in a new tab. If `link` is 'ncbi', clicking a taxon will open the NCBI
-            taxonomy browser in a new tab.
-        open_links_in_new_tabs: `bool`, optional
-            Whether or not `usermeta` should be added to the chart with link_target = _blank, which opens
-            links in new tabs.
+            Codex app. If `link` is 'ncbi', clicking a taxon will open the NCBI taxonomy browser.
 
         Examples
         --------
@@ -305,8 +299,5 @@ class VizBargraphMixin(object):
             chart = chart.resolve_scale(x="independent")
 
         chart = chart.properties(**prepare_props(title=title, width=width, height=height))
-
-        if open_links_in_new_tabs:
-            open_links_in_new_tab(chart)
 
         return chart if return_chart else chart.display()

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -32,7 +32,7 @@ class VizBargraphMixin(object):
         height=None,
         group_by=None,
         link=Link.Ocx,
-        exclude_usermeta=False,
+        open_links_in_new_tabs=True,
     ):
         """Plot a bargraph of relative abundance of taxa for multiple samples.
 
@@ -83,9 +83,9 @@ class VizBargraphMixin(object):
             If `link` is 'ocx', clicking a sample will open its classification results in the One
             Codex app in a new tab. If `link` is 'ncbi', clicking a taxon will open the NCBI
             taxonomy browser in a new tab.
-        exclude_usermeta: `bool`, optional
-            Whether or not `usermeta` should be added to the chart. Currently, we use this to open
-            links in new tabs by default.
+        open_links_in_new_tabs: `bool`, optional
+            Whether or not `usermeta` should be added to the chart with link_target = _blank, which opens
+            links in new tabs.
 
         Examples
         --------
@@ -306,7 +306,7 @@ class VizBargraphMixin(object):
 
         chart = chart.properties(**prepare_props(title=title, width=width, height=height))
 
-        if not exclude_usermeta:
+        if open_links_in_new_tabs:
             open_links_in_new_tab(chart)
 
         return chart if return_chart else chart.display()

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -32,6 +32,7 @@ class VizBargraphMixin(object):
         height=None,
         group_by=None,
         link=Link.Ocx,
+        exclude_usermeta=False,
     ):
         """Plot a bargraph of relative abundance of taxa for multiple samples.
 
@@ -82,6 +83,9 @@ class VizBargraphMixin(object):
             If `link` is 'ocx', clicking a sample will open its classification results in the One
             Codex app in a new tab. If `link` is 'ncbi', clicking a taxon will open the NCBI
             taxonomy browser in a new tab.
+        exclude_usermeta: `bool`, optional
+            Whether or not `usermeta` should be added to the chart. Currently, we use this to open
+            links in new tabs by default.
 
         Examples
         --------
@@ -301,6 +305,8 @@ class VizBargraphMixin(object):
             chart = chart.resolve_scale(x="independent")
 
         chart = chart.properties(**prepare_props(title=title, width=width, height=height))
-        open_links_in_new_tab(chart)
+
+        if not exclude_usermeta:
+            open_links_in_new_tab(chart)
 
         return chart if return_chart else chart.display()

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -95,7 +95,7 @@ class VizDistanceMixin(DistanceMixin):
         label=None,
         width=None,
         height=None,
-        exclude_usermeta=False,
+        open_links_in_new_tabs=True,
     ):
         """Plot beta diversity distance matrix as a heatmap and dendrogram.
 
@@ -122,9 +122,9 @@ class VizDistanceMixin(DistanceMixin):
             A metadata field (or function) used to label each analysis. If passing a function, a
             dict containing the metadata for each analysis is passed as the first and only
             positional argument. The callable function must return a string.
-        exclude_usermeta: `bool`, optional
-            Whether or not `usermeta` should be added to the chart. Currently, we use this to open
-            links in new tabs by default.
+        open_links_in_new_tabs: `bool`, optional
+            Whether or not `usermeta` should be added to the chart with link_target = _blank, which opens
+            links in new tabs.
 
         Examples
         --------
@@ -222,7 +222,7 @@ class VizDistanceMixin(DistanceMixin):
         concat_chart = alt.hconcat(dendro_chart, chart, spacing=0, **title_kwargs).configure_view(
             strokeWidth=0
         )
-        if not exclude_usermeta:
+        if open_links_in_new_tabs:
             open_links_in_new_tab(concat_chart)
 
         if return_chart:
@@ -249,7 +249,7 @@ class VizDistanceMixin(DistanceMixin):
         mark_size=100,
         width=None,
         height=None,
-        exclude_usermeta=False,
+        open_links_in_new_tabs=True,
     ):
         """Plot beta diversity distance matrix using multidimensional scaling (MDS).
 
@@ -284,9 +284,9 @@ class VizDistanceMixin(DistanceMixin):
             A metadata field (or function) used to label each analysis. If passing a function, a
             dict containing the metadata for each analysis is passed as the first and only
             positional argument. The callable function must return a string.
-        exclude_usermeta: `bool`, optional
-            Whether or not `usermeta` should be added to the chart. Currently, we use this to open
-            links in new tabs by default.
+        open_links_in_new_tabs: `bool`, optional
+            Whether or not `usermeta` should be added to the chart with link_target = _blank, which opens
+            links in new tabs.
 
         Examples
         --------
@@ -424,7 +424,7 @@ class VizDistanceMixin(DistanceMixin):
         chart = alt.Chart(plot_data).mark_circle(size=mark_size).encode(**alt_kwargs)
 
         chart = chart.properties(**prepare_props(title=title, height=height, width=width))
-        if not exclude_usermeta:
+        if open_links_in_new_tabs:
             open_links_in_new_tab(chart)
 
         if return_chart:

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -9,7 +9,6 @@ from onecodex.viz._primitives import (
     interleave_palette,
     prepare_props,
     get_classification_url,
-    open_links_in_new_tab,
 )
 from onecodex.utils import is_continuous, has_missing_values
 
@@ -95,7 +94,6 @@ class VizDistanceMixin(DistanceMixin):
         label=None,
         width=None,
         height=None,
-        open_links_in_new_tabs=True,
     ):
         """Plot beta diversity distance matrix as a heatmap and dendrogram.
 
@@ -122,9 +120,6 @@ class VizDistanceMixin(DistanceMixin):
             A metadata field (or function) used to label each analysis. If passing a function, a
             dict containing the metadata for each analysis is passed as the first and only
             positional argument. The callable function must return a string.
-        open_links_in_new_tabs: `bool`, optional
-            Whether or not `usermeta` should be added to the chart with link_target = _blank, which opens
-            links in new tabs.
 
         Examples
         --------
@@ -222,8 +217,6 @@ class VizDistanceMixin(DistanceMixin):
         concat_chart = alt.hconcat(dendro_chart, chart, spacing=0, **title_kwargs).configure_view(
             strokeWidth=0
         )
-        if open_links_in_new_tabs:
-            open_links_in_new_tab(concat_chart)
 
         if return_chart:
             return concat_chart
@@ -249,7 +242,6 @@ class VizDistanceMixin(DistanceMixin):
         mark_size=100,
         width=None,
         height=None,
-        open_links_in_new_tabs=True,
     ):
         """Plot beta diversity distance matrix using multidimensional scaling (MDS).
 
@@ -284,9 +276,6 @@ class VizDistanceMixin(DistanceMixin):
             A metadata field (or function) used to label each analysis. If passing a function, a
             dict containing the metadata for each analysis is passed as the first and only
             positional argument. The callable function must return a string.
-        open_links_in_new_tabs: `bool`, optional
-            Whether or not `usermeta` should be added to the chart with link_target = _blank, which opens
-            links in new tabs.
 
         Examples
         --------
@@ -422,10 +411,7 @@ class VizDistanceMixin(DistanceMixin):
             alt_kwargs["size"] = magic_fields[size]
 
         chart = alt.Chart(plot_data).mark_circle(size=mark_size).encode(**alt_kwargs)
-
         chart = chart.properties(**prepare_props(title=title, height=height, width=width))
-        if open_links_in_new_tabs:
-            open_links_in_new_tab(chart)
 
         if return_chart:
             return chart

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -95,6 +95,7 @@ class VizDistanceMixin(DistanceMixin):
         label=None,
         width=None,
         height=None,
+        exclude_usermeta=False,
     ):
         """Plot beta diversity distance matrix as a heatmap and dendrogram.
 
@@ -121,6 +122,9 @@ class VizDistanceMixin(DistanceMixin):
             A metadata field (or function) used to label each analysis. If passing a function, a
             dict containing the metadata for each analysis is passed as the first and only
             positional argument. The callable function must return a string.
+        exclude_usermeta: `bool`, optional
+            Whether or not `usermeta` should be added to the chart. Currently, we use this to open
+            links in new tabs by default.
 
         Examples
         --------
@@ -218,7 +222,8 @@ class VizDistanceMixin(DistanceMixin):
         concat_chart = alt.hconcat(dendro_chart, chart, spacing=0, **title_kwargs).configure_view(
             strokeWidth=0
         )
-        open_links_in_new_tab(concat_chart)
+        if not exclude_usermeta:
+            open_links_in_new_tab(concat_chart)
 
         if return_chart:
             return concat_chart
@@ -244,6 +249,7 @@ class VizDistanceMixin(DistanceMixin):
         mark_size=100,
         width=None,
         height=None,
+        exclude_usermeta=False,
     ):
         """Plot beta diversity distance matrix using multidimensional scaling (MDS).
 
@@ -278,6 +284,9 @@ class VizDistanceMixin(DistanceMixin):
             A metadata field (or function) used to label each analysis. If passing a function, a
             dict containing the metadata for each analysis is passed as the first and only
             positional argument. The callable function must return a string.
+        exclude_usermeta: `bool`, optional
+            Whether or not `usermeta` should be added to the chart. Currently, we use this to open
+            links in new tabs by default.
 
         Examples
         --------
@@ -415,7 +424,8 @@ class VizDistanceMixin(DistanceMixin):
         chart = alt.Chart(plot_data).mark_circle(size=mark_size).encode(**alt_kwargs)
 
         chart = chart.properties(**prepare_props(title=title, height=height, width=width))
-        open_links_in_new_tab(chart)
+        if not exclude_usermeta:
+            open_links_in_new_tab(chart)
 
         if return_chart:
             return chart

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -31,7 +31,7 @@ class VizHeatmapMixin(object):
         width=None,
         height=None,
         link=Link.Ocx,
-        exclude_usermeta=False,
+        open_links_in_new_tabs=True,
     ):
         """Plot heatmap of taxa abundance/count data for several samples.
 
@@ -84,9 +84,9 @@ class VizHeatmapMixin(object):
             If `link` is 'ocx', clicking a sample will open its classification results in the One
             Codex app in a new tab. If `link` is 'ncbi', clicking a taxon will open the NCBI
             taxonomy browser in a new tab.
-        exclude_usermeta: `bool`, optional
-            Whether or not `usermeta` should be added to the chart. Currently, we use this to open
-            links in new tabs by default.
+        open_links_in_new_tabs: `bool`, optional
+            Whether or not `usermeta` should be added to the chart with link_target = _blank, which opens
+            links in new tabs.
 
         Examples
         --------
@@ -252,7 +252,7 @@ class VizHeatmapMixin(object):
                 title=title, height=(height or 15 * row_count), width=(width or 15 * col_count)
             )
         )
-        if not exclude_usermeta:
+        if open_links_in_new_tabs:
             open_links_in_new_tab(chart)
 
         if haxis:

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -31,6 +31,7 @@ class VizHeatmapMixin(object):
         width=None,
         height=None,
         link=Link.Ocx,
+        exclude_usermeta=False,
     ):
         """Plot heatmap of taxa abundance/count data for several samples.
 
@@ -83,6 +84,9 @@ class VizHeatmapMixin(object):
             If `link` is 'ocx', clicking a sample will open its classification results in the One
             Codex app in a new tab. If `link` is 'ncbi', clicking a taxon will open the NCBI
             taxonomy browser in a new tab.
+        exclude_usermeta: `bool`, optional
+            Whether or not `usermeta` should be added to the chart. Currently, we use this to open
+            links in new tabs by default.
 
         Examples
         --------
@@ -248,7 +252,8 @@ class VizHeatmapMixin(object):
                 title=title, height=(height or 15 * row_count), width=(width or 15 * col_count)
             )
         )
-        open_links_in_new_tab(chart)
+        if not exclude_usermeta:
+            open_links_in_new_tab(chart)
 
         if haxis:
             chart = chart.resolve_scale(x="independent")

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -5,7 +5,6 @@ from onecodex.viz._primitives import (
     sort_helper,
     get_classification_url,
     get_ncbi_taxonomy_browser_url,
-    open_links_in_new_tab,
 )
 
 
@@ -31,7 +30,6 @@ class VizHeatmapMixin(object):
         width=None,
         height=None,
         link=Link.Ocx,
-        open_links_in_new_tabs=True,
     ):
         """Plot heatmap of taxa abundance/count data for several samples.
 
@@ -82,11 +80,7 @@ class VizHeatmapMixin(object):
             as the only argument, and must return the same list in a user-specified order.
         link : {'ocx', 'ncbi'}, optional
             If `link` is 'ocx', clicking a sample will open its classification results in the One
-            Codex app in a new tab. If `link` is 'ncbi', clicking a taxon will open the NCBI
-            taxonomy browser in a new tab.
-        open_links_in_new_tabs: `bool`, optional
-            Whether or not `usermeta` should be added to the chart with link_target = _blank, which opens
-            links in new tabs.
+            Codex app. If `link` is 'ncbi', clicking a taxon will open the NCBI taxonomy browser.
 
         Examples
         --------
@@ -252,8 +246,6 @@ class VizHeatmapMixin(object):
                 title=title, height=(height or 15 * row_count), width=(width or 15 * col_count)
             )
         )
-        if open_links_in_new_tabs:
-            open_links_in_new_tab(chart)
 
         if haxis:
             chart = chart.resolve_scale(x="independent")

--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -30,7 +30,7 @@ class VizMetadataMixin(object):
         width=200,
         height=400,
         facet_by=None,
-        exclude_usermeta=False,
+        open_links_in_new_tabs=True,
     ):
         """Plot an arbitrary metadata field versus an arbitrary quantity as a boxplot or scatter plot.
 
@@ -77,9 +77,9 @@ class VizMetadataMixin(object):
             The metadata field used to facet samples by (i.e. to create a separate subplot for each
             group of samples).
 
-        exclude_usermeta: `bool`, optional
-            Whether or not `usermeta` should be added to the chart. Currently, we use this to open
-            links in new tabs by default.
+        open_links_in_new_tabs: `bool`, optional
+            Whether or not `usermeta` should be added to the chart with link_target = _blank, which opens
+            links in new tabs.
 
         Examples
         --------
@@ -221,7 +221,7 @@ class VizMetadataMixin(object):
             chart = chart.resolve_scale(x="independent")
 
         chart = chart.properties(**prepare_props(title=title, height=height, width=width))
-        if not exclude_usermeta:
+        if open_links_in_new_tabs:
             open_links_in_new_tab(chart)
 
         if return_chart:

--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -4,7 +4,6 @@ from onecodex.viz._primitives import (
     prepare_props,
     sort_helper,
     get_classification_url,
-    open_links_in_new_tab,
 )
 
 
@@ -30,7 +29,6 @@ class VizMetadataMixin(object):
         width=200,
         height=400,
         facet_by=None,
-        open_links_in_new_tabs=True,
     ):
         """Plot an arbitrary metadata field versus an arbitrary quantity as a boxplot or scatter plot.
 
@@ -76,10 +74,6 @@ class VizMetadataMixin(object):
         facet_by : `string`, optional
             The metadata field used to facet samples by (i.e. to create a separate subplot for each
             group of samples).
-
-        open_links_in_new_tabs: `bool`, optional
-            Whether or not `usermeta` should be added to the chart with link_target = _blank, which opens
-            links in new tabs.
 
         Examples
         --------
@@ -221,8 +215,6 @@ class VizMetadataMixin(object):
             chart = chart.resolve_scale(x="independent")
 
         chart = chart.properties(**prepare_props(title=title, height=height, width=width))
-        if open_links_in_new_tabs:
-            open_links_in_new_tab(chart)
 
         if return_chart:
             return chart

--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -30,6 +30,7 @@ class VizMetadataMixin(object):
         width=200,
         height=400,
         facet_by=None,
+        exclude_usermeta=False,
     ):
         """Plot an arbitrary metadata field versus an arbitrary quantity as a boxplot or scatter plot.
 
@@ -75,6 +76,10 @@ class VizMetadataMixin(object):
         facet_by : `string`, optional
             The metadata field used to facet samples by (i.e. to create a separate subplot for each
             group of samples).
+
+        exclude_usermeta: `bool`, optional
+            Whether or not `usermeta` should be added to the chart. Currently, we use this to open
+            links in new tabs by default.
 
         Examples
         --------
@@ -216,7 +221,8 @@ class VizMetadataMixin(object):
             chart = chart.resolve_scale(x="independent")
 
         chart = chart.properties(**prepare_props(title=title, height=height, width=width))
-        open_links_in_new_tab(chart)
+        if not exclude_usermeta:
+            open_links_in_new_tab(chart)
 
         if return_chart:
             return chart

--- a/onecodex/viz/_pca.py
+++ b/onecodex/viz/_pca.py
@@ -27,6 +27,7 @@ class VizPCAMixin(object):
         mark_size=100,
         width=None,
         height=None,
+        exclude_usermeta=False,
     ):
         """Perform principal component analysis and plot first two axes.
 
@@ -63,6 +64,9 @@ class VizPCAMixin(object):
             positional argument. The callable function must return a string.
         mark_size: `int`, optional
             The size of the points in the scatter plot.
+        exclude_usermeta: `bool`, optional
+            Whether or not `usermeta` should be added to the chart. Currently, we use this to open
+            links in new tabs by default.
 
         Examples
         --------
@@ -210,7 +214,8 @@ class VizPCAMixin(object):
             chart = alt.layer(chart, vector_chart).resolve_scale(color="independent")
 
         chart = chart.properties(**prepare_props(title=title, height=height, width=width))
-        open_links_in_new_tab(chart)
+        if not exclude_usermeta:
+            open_links_in_new_tab(chart)
 
         if return_chart:
             return chart

--- a/onecodex/viz/_pca.py
+++ b/onecodex/viz/_pca.py
@@ -27,7 +27,7 @@ class VizPCAMixin(object):
         mark_size=100,
         width=None,
         height=None,
-        exclude_usermeta=False,
+        open_links_in_new_tabs=True,
     ):
         """Perform principal component analysis and plot first two axes.
 
@@ -64,9 +64,9 @@ class VizPCAMixin(object):
             positional argument. The callable function must return a string.
         mark_size: `int`, optional
             The size of the points in the scatter plot.
-        exclude_usermeta: `bool`, optional
-            Whether or not `usermeta` should be added to the chart. Currently, we use this to open
-            links in new tabs by default.
+        open_links_in_new_tabs: `bool`, optional
+            Whether or not `usermeta` should be added to the chart with link_target = _blank, which opens
+            links in new tabs.
 
         Examples
         --------
@@ -214,7 +214,7 @@ class VizPCAMixin(object):
             chart = alt.layer(chart, vector_chart).resolve_scale(color="independent")
 
         chart = chart.properties(**prepare_props(title=title, height=height, width=width))
-        if not exclude_usermeta:
+        if open_links_in_new_tabs:
             open_links_in_new_tab(chart)
 
         if return_chart:

--- a/onecodex/viz/_pca.py
+++ b/onecodex/viz/_pca.py
@@ -3,7 +3,6 @@ from onecodex.viz._primitives import (
     interleave_palette,
     prepare_props,
     get_classification_url,
-    open_links_in_new_tab,
 )
 from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.utils import is_continuous, has_missing_values
@@ -27,7 +26,6 @@ class VizPCAMixin(object):
         mark_size=100,
         width=None,
         height=None,
-        open_links_in_new_tabs=True,
     ):
         """Perform principal component analysis and plot first two axes.
 
@@ -64,9 +62,6 @@ class VizPCAMixin(object):
             positional argument. The callable function must return a string.
         mark_size: `int`, optional
             The size of the points in the scatter plot.
-        open_links_in_new_tabs: `bool`, optional
-            Whether or not `usermeta` should be added to the chart with link_target = _blank, which opens
-            links in new tabs.
 
         Examples
         --------
@@ -214,8 +209,6 @@ class VizPCAMixin(object):
             chart = alt.layer(chart, vector_chart).resolve_scale(color="independent")
 
         chart = chart.properties(**prepare_props(title=title, height=height, width=width))
-        if open_links_in_new_tabs:
-            open_links_in_new_tab(chart)
 
         if return_chart:
             return chart

--- a/onecodex/viz/_primitives.py
+++ b/onecodex/viz/_primitives.py
@@ -24,11 +24,6 @@ def get_ncbi_taxonomy_browser_url(tax_id):
     return ""
 
 
-# https://stackoverflow.com/a/72241020/3776794
-def open_links_in_new_tab(chart):
-    chart["usermeta"] = {"embedOptions": {"loader": {"target": "_blank", "rel": "noreferrer"}}}
-
-
 def sort_helper(sort, values):
     """Return a sorted list of values for the Altair chart axes."""
     sort_order = None


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
It looks like this is due to the fact that while individual charts can have usermeta added to them (in our case, we attach this field to charts to specify embedOptions in order to open links in a new tab by default), concatenated charts don't play well with this (the jsonschema that altair uses to validate the schemas of the individual charts disallows this field). 

This PR removes the `open_links_in_new_tabs` functionality from this repo. If it is desired, this functionality may be added by first returning the chart and then adding `usermeta` manually.

## Related PRs
- [x] This PR is independent
