### PR TITLE
Fixing numpy and pandas top-level dependencies

### DIFF
--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -3,9 +3,6 @@ from datetime import datetime
 import json
 import warnings
 
-import numpy as np
-import pandas as pd
-
 from onecodex.exceptions import OneCodexException
 from onecodex.lib.enums import Metric, FunctionalAnnotations, FunctionalAnnotationsMetric
 
@@ -481,6 +478,9 @@ class SampleCollection(ResourceList, AnalysisMixin):
         filler : float, optional
             Value with which to fill `np.nan` values
         """
+        import numpy as np
+        import pandas as pd
+
         # validate args
         annotation = FunctionalAnnotations(annotation)
         metric = FunctionalAnnotationsMetric(metric)


### PR DESCRIPTION
## Status
- [X] **Ready**

## Description
The CLI tool was designed to work without the heavyweight dependencies (`numpy` and `pandas`). A regression bug crept in a while back that caused those dependencies to be loaded even in simple CLI calls.
This PR fixes that by removing top-level dependencies for those libs and replacing them with deferred function-scoped imports instead.

## Related PRs
- [X] This PR is independent

## TODOs
- [ ] Release a new version of the One Codex lib
