### PR TITLE
Fix CI for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,12 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies in a venv
         run: |
+          # fix for installing scikit-bio==0.5.7 on python-3.7
+          if [[ $(python3 --version 2>&1) == *"Python 3.7"* ]]; then
+              echo "--- Manually installing build deps for scikit-bio==0.5.7 w/ Python 3.7"
+              pip install 'cython==0.29.32' 'numpy>=1.9.2' 'setuptools' 'wheel'
+              pip install --no-build-isolation scikit-bio==0.5.7
+          fi
           python3 -m venv venv
           . venv/bin/activate
           pip install -q -U pip


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description

Cython 3 breaks scikit-bio installation under Python 3.7 (scikit-bio>=0.5.8 has other incompatibility issues with Python 3.7). Since these are [build dependencies](https://github.com/biocore/scikit-bio/blob/0.5.7/pyproject.toml#L2), they cannot be pinned in `setup.py`.

This PR manually installs build deps for scikit-bio==0.5.7 under Python 3.7 to pin the Cython version.

## Related PRs
- [x] This PR is independent

## TODOs

- [x] Tests
