### PR TITLE
exclude all-nan samples from distance heatmap

### DIFF
--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -43,7 +43,9 @@ class DistanceMixin(TaxonomyMixin):
 
         return pd.DataFrame(output, columns=[metric])
 
-    def beta_diversity(self, metric=BetaDiversityMetric.BrayCurtis, rank=Rank.Auto):
+    def beta_diversity(
+        self, metric=BetaDiversityMetric.BrayCurtis, rank=Rank.Auto, exclude_all_nan=False
+    ):
         """Calculate the diversity between two communities.
 
         Parameters
@@ -53,6 +55,8 @@ class DistanceMixin(TaxonomyMixin):
             Note that 'cityblock' and 'manhattan' are equivalent metrics.
         rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
             Analysis will be restricted to abundances of taxa at the specified level.
+        exclude_all_nan : bool, optional
+            If true, samples with no abundances calculated will be excluded.
 
         Returns
         -------
@@ -75,6 +79,12 @@ class DistanceMixin(TaxonomyMixin):
             return self.aitchison_distance(rank=rank)
 
         df = self.to_df(rank=rank, normalize=self._guess_normalized())
+
+        if exclude_all_nan:
+            all_nan_classification_ids = [
+                x for x in self._all_nan_classification_ids if x in df.index
+            ]
+            df = df.drop(all_nan_classification_ids)
 
         if metric == BetaDiversityMetric.Jaccard:
             df = df > 0  # Jaccard requires a boolean matrix, otherwise it throws a warning

--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -43,9 +43,7 @@ class DistanceMixin(TaxonomyMixin):
 
         return pd.DataFrame(output, columns=[metric])
 
-    def beta_diversity(
-        self, metric=BetaDiversityMetric.BrayCurtis, rank=Rank.Auto, exclude_all_nan=False
-    ):
+    def beta_diversity(self, metric=BetaDiversityMetric.BrayCurtis, rank=Rank.Auto):
         """Calculate the diversity between two communities.
 
         Parameters
@@ -55,8 +53,6 @@ class DistanceMixin(TaxonomyMixin):
             Note that 'cityblock' and 'manhattan' are equivalent metrics.
         rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
             Analysis will be restricted to abundances of taxa at the specified level.
-        exclude_all_nan : bool, optional
-            If true, samples with no abundances calculated will be excluded.
 
         Returns
         -------
@@ -79,12 +75,6 @@ class DistanceMixin(TaxonomyMixin):
             return self.aitchison_distance(rank=rank)
 
         df = self.to_df(rank=rank, normalize=self._guess_normalized())
-
-        if exclude_all_nan:
-            all_nan_classification_ids = [
-                x for x in self._all_nan_classification_ids if x in df.index
-            ]
-            df = df.drop(all_nan_classification_ids)
 
         if metric == BetaDiversityMetric.Jaccard:
             df = df > 0  # Jaccard requires a boolean matrix, otherwise it throws a warning

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -208,10 +208,9 @@ class VizDistanceMixin(DistanceMixin):
 
         if self._all_nan_classification_ids:
             warnings.warn(
-                PlottingWarning(
-                    f"{len(self._all_nan_classification_ids)} sample(s) have no abundances "
-                    "calculated and have been omitted from the distance heatmap."
-                )
+                f"{len(self._all_nan_classification_ids)} sample(s) have no abundances "
+                "calculated and have been omitted from the distance heatmap.",
+                PlottingWarning,
             )
 
         # must convert to long format for heatmap plotting

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -200,6 +200,12 @@ class VizDistanceMixin(DistanceMixin):
             exclude_all_nan=True,
         )
 
+        if self._all_nan_classification_ids:
+            warnings.warn(
+                f"{len(self._all_nan_classification_ids)} sample(s) have no abundances "
+                "calculated and have been omitted from the distance heatmap."
+            )
+
         # must convert to long format for heatmap plotting
         for idx1, id1 in enumerate(clust["dist_matrix"].index):
             for idx2, id2 in enumerate(clust["dist_matrix"].index):

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -207,9 +207,11 @@ class VizDistanceMixin(DistanceMixin):
         )
 
         if self._all_nan_classification_ids:
-            raise PlottingWarning(
-                f"{len(self._all_nan_classification_ids)} sample(s) have no abundances "
-                "calculated and have been omitted from the distance heatmap."
+            warnings.warn(
+                PlottingWarning(
+                    f"{len(self._all_nan_classification_ids)} sample(s) have no abundances "
+                    "calculated and have been omitted from the distance heatmap."
+                )
             )
 
         # must convert to long format for heatmap plotting

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -8,7 +8,7 @@ pytest.importorskip("pandas")  # noqa
 import altair as alt
 import numpy as np
 
-from onecodex.lib.enums import Metric, AbundanceMetric, Link, Rank
+from onecodex.lib.enums import Metric, AbundanceMetric, Link, Rank, BetaDiversityMetric, Linkage
 from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.models.collection import SampleCollection
 from onecodex.utils import has_missing_values
@@ -334,6 +334,55 @@ def test_plot_heatmap_with_haxis_two_cluster_groups(ocx, api_data):
 
     # Does not raise exception
     samples.plot_heatmap(rank="genus", top_n=15, haxis="wheat", return_chart=True)
+
+
+def test_plot_distance_excludes_all_nan_clustering_helper_called_with(ocx, api_data):
+    import numpy as np
+
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    sample1 = ocx.Samples.get("cc18208d98ad48b3")
+    sample2 = ocx.Samples.get("5445740666134eee")
+    samples.extend([sample1, sample2])
+
+    # Set abundances for one sample to be all NaN
+    all_nan_sample = samples[1]
+    samples._results.loc[all_nan_sample.primary_classification.id] = np.nan
+    assert len(samples._all_nan_classification_ids) == 1
+
+    with mock.patch(
+        "onecodex.viz._distance.VizDistanceMixin._cluster_by_sample"
+    ) as cluster_fn, mock.patch("onecodex.viz.dendrogram"), mock.patch("altair.hconcat"):
+        samples.plot_distance()
+        # the cluster function should be called with `exclude_all_nan=True` and
+        # the classification ID of the `all_nan_sample`
+        cluster_fn.assert_called_with(
+            rank=Rank.Auto,
+            metric=BetaDiversityMetric.BrayCurtis,
+            linkage=Linkage.Average,
+            all_nan_classification_ids=[all_nan_sample.primary_classification.id],
+            exclude_all_nan=True,
+        )
+
+
+def test_plot_distance_excludes_all_nan_class_id_not_in_chart(ocx, api_data):
+    import numpy as np
+
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    sample1 = ocx.Samples.get("cc18208d98ad48b3")
+    sample2 = ocx.Samples.get("5445740666134eee")
+    samples.extend([sample1, sample2])
+
+    # Set abundances for one sample to be all NaN
+    all_nan_sample = samples[1]
+    samples._results.loc[all_nan_sample.primary_classification.id] = np.nan
+    assert len(samples._all_nan_classification_ids) == 1
+
+    with mock.patch("altair.hconcat") as mock_hconcat:
+        samples.plot_distance()
+        assert (
+            all_nan_sample.primary_classification.id
+            not in mock_hconcat.call_args[0][1].data["1) Label"].values
+        )
 
 
 def test_plot_heatmap_exceptions(ocx, api_data):


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
We want to totally exclude samples that have no abundances calculated for them from the distance heatmap plot. This adds `exclude_all_nan` to a few places with a default of `False`, and a call to `_cluster_by_sample` with `exclude_all_nan=True` to get the desired results.

## Related PRs
- [ x] This PR is independent

## TODOs
Add any todos here as needed for work in progress code. This section can be deleted if not relevant. Examples:

- [x] Tests
