### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]  # , windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -22,12 +22,6 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies in a venv
         run: |
-          # fix for installing scikit-bio==0.5.7 on python-3.7
-          if [[ $(python3 --version 2>&1) == *"Python 3.7"* ]]; then
-              echo "--- Manually installing build deps for scikit-bio==0.5.7 w/ Python 3.7"
-              pip install 'cython==0.29.32' 'numpy>=1.9.2' 'setuptools' 'wheel'
-              pip install --no-build-isolation scikit-bio==0.5.7
-          fi
           python3 -m venv venv
           . venv/bin/activate
           pip install -q -U pip

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MAINTAINERS: [@clausmith](https://github.com/clausmith), [@boydgreenfield](https
 
 This package provides 3 major pieces of functionality: (1) a core Python client library; (2) a simple CLI for interacting with the One Codex platform that uses that core library; and (3) optional extensions to the client library, which offers many features aimed at advanced users and provides functionality for use in interactive notebook environments (e.g., IPython notebooks).
 
-Python 3.7 or later is required. **Python 2 is no longer supported.**
+Python 3.8 or later is required. **Python 2 is no longer supported.**
 
 
 ### _Basic installation_
@@ -168,7 +168,7 @@ all_completed_analyses.to_df()    # Returns a pandas dataframe
 
 ## Environment Setup
 
-Before developing, `git` and `python` version >=3.7 are needed. We recommend using [pyenv](https://github.com/yyuu/pyenv) for Python version management.
+Before developing, `git` and `python` version >=3.8 are needed. We recommend using [pyenv](https://github.com/yyuu/pyenv) for Python version management.
 
 To download the client library from GitHub:
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ ALL_DEPS = [
     "numpy>=1.11.0",
     "pandas>=1.0.3",
     "pillow>=9.0.1",
-    "scikit-bio>=0.5.7",
+    "scikit-bio>=0.5.8",
     "scikit-learn>=0.19.0",
     "scipy",
     "jupyter-client==7.2.0",
@@ -60,7 +60,7 @@ setup(
     name="onecodex",
     version=__version__,  # noqa
     packages=find_packages(exclude=["*test*"]),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "boto3>=1.17.98",
         "click>=8.0",
@@ -97,7 +97,6 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -10,7 +10,7 @@ import pytest
 from onecodex import Cli
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
 @pytest.mark.parametrize(
     "import_command,package_max_import_times,total_time_secs",
     [


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Python 3.7 is EOL and we're encountering some issues with dependencies (e.g. https://github.com/onecodex/onecodex/pull/453).

Closes DEV-8496

## Related PRs
- [x] This PR is independent