### PR TITLE
Exclude all-nan-abundance samples from min # samples check 

### DIFF
--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -172,6 +172,11 @@ class VizDistanceMixin(DistanceMixin):
                 "There are too few samples for distance matrix plots after filtering. Please "
                 "select 2 or more samples to plot."
             )
+        elif len(self._results) - len(self._all_nan_classification_ids) < 2:
+            raise PlottingException(
+                "There are too few samples for distance matrix plots after filtering out samples "
+                "with no abundances calculated; please select more samples to plot."
+            )
 
         # this will be passed to the heatmap chart as a dataframe eventually
         plot_data = {"1) Label": [], "2) Label": [], "Distance": [], "classification_id": []}

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -385,6 +385,24 @@ def test_plot_distance_excludes_all_nan_class_id_not_in_chart(ocx, api_data):
         )
 
 
+def test_plot_distance_min_with_abundances(ocx, api_data):
+    import numpy as np
+
+    sample1 = ocx.Samples.get("cc18208d98ad48b3")
+    sample2 = ocx.Samples.get("5445740666134eee")
+    samples = SampleCollection([sample1, sample2])
+
+    # Set abundances for both samples to be all NaN
+    samples._results.loc[sample1.primary_classification.id] = np.nan
+    samples._results.loc[sample2.primary_classification.id] = np.nan
+    assert len(samples._all_nan_classification_ids) == 2
+
+    # We should raise a PlottingException if we don't have >= 2 samples with abundances calculated
+    with pytest.raises(PlottingException) as e:
+        samples.plot_distance()
+        assert "There are too few samples for distance matrix plots" in str(e.value)
+
+
 def test_plot_heatmap_exceptions(ocx, api_data):
     samples = ocx.Samples.where(project="4b53797444f846c4")
 


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
`plot_distance` includes a check for a minimum of 2 samples in order to continue plotting. We should update this to be a minimum of 2 _with abundances_ since we exclude all-nan-abundances samples (those that have no abundances calculated for them) from the plot.

## Related PRs
- [x] This PR is independent

## TODOs

- [x] Tests
