### PR TITLE
Add optional name to asset upload

### DIFF
--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -247,6 +247,7 @@ def assets():
     "--name",
     nargs=1,
     required=False,
+    help=OPTION_HELP["name"],
 )
 @click.argument(
     "file",
@@ -261,7 +262,7 @@ def assets():
 @login_required_experimental_api
 def assets_upload(ctx, max_threads, file, name):
     """Upload an asset to One Codex."""
-    if len(file) == 0:
+    if len(file) == 0 or name == "":
         click.echo(ctx.get_help())
         return
 

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -243,6 +243,11 @@ def assets():
     help=OPTION_HELP["max_threads"],
     metavar="<int:threads>",
 )
+@click.option(
+    "--name",
+    nargs=1,
+    required=False,
+)
 @click.argument(
     "file",
     nargs=1,
@@ -254,7 +259,7 @@ def assets():
 @pretty_errors
 @telemetry
 @login_required_experimental_api
-def assets_upload(ctx, max_threads, file):
+def assets_upload(ctx, max_threads, file, name):
     """Upload an asset to One Codex."""
     if len(file) == 0:
         click.echo(ctx.get_help())
@@ -264,7 +269,7 @@ def assets_upload(ctx, max_threads, file):
     run_via_threadpool(
         ctx.obj["API"].Assets.upload,
         [file],
-        {"progressbar": bar},
+        {"progressbar": bar, "name": name},
         max_threads=8 if max_threads > 8 else max_threads,
         graceful_exit=False,
     )

--- a/onecodex/models/misc.py
+++ b/onecodex/models/misc.py
@@ -84,7 +84,7 @@ class Assets(OneCodexBase, ResourceDownloadMixin):
     _resource_path = "/api/v1_experimental/assets"
 
     @classmethod
-    def upload(cls, file_path, progressbar=None):
+    def upload(cls, file_path, progressbar=None, name=None):
         """Upload a file to an asset.
 
         Parameters
@@ -93,11 +93,13 @@ class Assets(OneCodexBase, ResourceDownloadMixin):
             A path to a file on the system.
         progressbar : `click.progressbar`, optional
             If passed, display a progress bar using Click.
+        name : `string`, optional
+            If passed, name is sent with upload request and is associated with asset.
 
         Returns
         -------
         An `Assets` object upon successful upload. None if the upload failed.
         """
-        asset_id = upload_asset(file_path, cls._resource, progressbar=progressbar)
+        asset_id = upload_asset(file_path, cls._resource, progressbar=progressbar, name=name)
 
         return cls.get(asset_id)

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -79,6 +79,7 @@ OPTION_HELP = {
     "then short name in that order.",
     "sample_id": "Provide an ID for a sample that was previously 'pre-uploaded' along with metadata.",
     "external_sample_id": "Provide an external sample ID for a sample that was previously 'pre-uploaded' along with metadata.",
+    "name": "Provide a display name for your asset (optional).",
 }
 
 SUPPORTED_EXTENSIONS = [

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -203,7 +203,21 @@ def test_upload_asset():
             upload_asset(file, FakeAssetsResource())
 
             assert upload_asset_fileobj.call_count == n_uploads
+            assert upload_asset_fileobj.call_args[-1] == {"name": None}
             assert passthru.call_count == 1
+
+
+def test_upload_asset_with_name():
+    with patch("boto3.session.Session"):
+        file = "test_asset_file.fa"
+        fake_size = 1000
+        name = "user-friendly-name"
+
+        with patch("onecodex.lib.upload._upload_asset_fileobj") as upload_asset_fileobj, patch(
+            "onecodex.lib.upload.FilePassthru"
+        ), patch("os.path.getsize", size_effect=fake_size):
+            upload_asset(file, FakeAssetsResource(), name=name)
+            assert upload_asset_fileobj.call_args[-1] == {"name": name}
 
 
 def test_api_failures(caplog):


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Add a `--name` option to `asset upload` command. This can be helpful so that a user can give a file/asset a more user-friendly name, rather than it using the filename by defaul.

## Related PRs
- [x] This PR is independent
