### PR TITLE
Add filtered FunctionalAnalysis results endpoint and cache

### DIFF
--- a/onecodex/lib/enums.py
+++ b/onecodex/lib/enums.py
@@ -122,6 +122,14 @@ class FunctionalAnnotationsMetric(BaseEnum):
     Abundance = "abundance"
     Coverage = "coverage"
 
+    @classmethod
+    def metrics_for_annotation(cls, annotation: FunctionalAnnotations):
+        return (
+            [FunctionalAnnotationsMetric.Abundance, FunctionalAnnotationsMetric.Coverage]
+            if annotation == FunctionalAnnotations.Pathways
+            else [FunctionalAnnotationsMetric.Cpm, FunctionalAnnotationsMetric.Rpk]
+        )
+
 
 class Link(BaseEnum):
     Ocx = "ocx"

--- a/onecodex/models/experimental.py
+++ b/onecodex/models/experimental.py
@@ -1,7 +1,7 @@
 from onecodex.models import OneCodexBase, ResourceList
 from onecodex.models.helpers import ResourceDownloadMixin
 from onecodex.models.analysis import Analyses
-from onecodex.lib.enums import FunctionalAnnotations
+from onecodex.lib.enums import FunctionalAnnotations, FunctionalAnnotationsMetric
 
 
 class AnnotationSets(OneCodexBase, ResourceDownloadMixin):
@@ -141,6 +141,11 @@ class Taxa(OneCodexBase):
 class FunctionalProfiles(Analyses):
     _resource_path = "/api/v1_experimental/functional_profiles"
 
+    def _filtered_results(self, functional_group, metric, taxa_stratified):
+        return self._resource.filtered_results(
+            functional_group=functional_group, metric=metric, taxa_stratified=taxa_stratified
+        )
+
     def results(self, json=True):
         """Return the complete results table for a functional analysis.
 
@@ -159,7 +164,7 @@ class FunctionalProfiles(Analyses):
         else:
             return self.table()
 
-    def table(self, annotation="all", taxa_stratified=True):
+    def table(self, annotation="all", taxa_stratified: bool = True):
         """Return a results table for the functional analysis.
 
         Parameters
@@ -176,20 +181,71 @@ class FunctionalProfiles(Analyses):
         """
         import pandas as pd
 
-        results_df = pd.DataFrame(self._results()["table"])
+        result_json = self._results()
+        if not result_json["table"]:
+            return pd.DataFrame(
+                {
+                    "group_name": pd.Series(dtype="str"),
+                    "id": pd.Series(dtype="str"),
+                    "name": pd.Series(dtype="str"),
+                    "metric": pd.Series(dtype="str"),
+                    "value": pd.Series(dtype="float"),
+                    "taxa_stratified": pd.Series(dtype="bool"),
+                    "taxon_id": pd.Series(dtype="str"),
+                    "taxon_name": pd.Series(dtype="str"),
+                }
+            )
+        results_df = pd.DataFrame(result_json["table"])
         if annotation != "all":
             # Validate functional annotation
             FunctionalAnnotations(annotation)
-            if taxa_stratified:
-                return results_df[
+            return (
+                results_df[
                     (results_df["group_name"] == annotation) & (results_df["taxa_stratified"])
                 ]
-            else:
-                return results_df[
+                if taxa_stratified
+                else results_df[
                     (results_df["group_name"] == annotation) & ~results_df["taxa_stratified"]
                 ]
-        else:
-            if taxa_stratified:
-                return results_df[results_df["taxa_stratified"]]
-            else:
-                return results_df[~results_df["taxa_stratified"]]
+            )
+        return (
+            results_df[results_df["taxa_stratified"]]
+            if taxa_stratified
+            else results_df[~results_df["taxa_stratified"]]
+        )
+
+    def filtered_table(
+        self,
+        annotation: FunctionalAnnotations,
+        metric: FunctionalAnnotationsMetric,
+        taxa_stratified: bool = True,
+    ):
+        """Return a results table for the functional analysis.
+
+        Parameters
+        ----------
+        annotation : onecodex.lib.enum.FunctionalAnnotation, required
+            Return a table for a given `onecodex.lib.enum.FunctionalAnnotation`
+        metric : onecodex.lib.enum.FunctionalAnnotationMetric, required
+            Return a table for a given `onecodex.lib.enum.FunctionalAnnotationMetric`
+        taxa_stratified : bool, optional
+            If False, return data only by annotation ID, ignoring taxonomic stratification
+
+        Returns
+        -------
+        results_df : pd.DataFrame
+            A Pandas DataFrame of the functional results.
+        """
+        import pandas as pd
+
+        result_json = self._filtered_results(
+            functional_group=annotation, metric=metric, taxa_stratified=taxa_stratified
+        )
+        if not result_json["table"]:
+            return pd.DataFrame(
+                {
+                    "id": pd.Series(dtype="str"),
+                    "value": pd.Series(dtype="float"),
+                }
+            )
+        return pd.DataFrame(result_json["table"])

--- a/tests/data/api/v1_experimental/schema/index_all.json
+++ b/tests/data/api/v1_experimental/schema/index_all.json
@@ -11808,6 +11808,33 @@
                         "type": "object"
                     }
                 },
+              {
+                    "href": "/api/v1_experimental/functional_profiles/{id}/filtered_results",
+                    "method": "GET",
+                    "rel": "filtered_results",
+                    "targetSchema": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "table": {
+                                "default": [],
+                                "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "id": {
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
                 {
                     "href": "/api/v1_experimental/functional_profiles/{id}",
                     "method": "GET",

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -85,23 +85,24 @@ def test_collate_functional_results(ocx_experimental, api_data):
     )
     assert isinstance(df, pd.DataFrame)
     assert df.shape == (3, 39)
-    assert sc._cached["functional_results_content"] == {
-        "annotation": "go",
-        "taxa_stratified": True,
-        "metric": "rpk",
-        "fill_missing": False,
-        "filler": 0,
-    }
+    assert df.compare(
+        sc._cached[
+            "functional_results_annotation=go_metric=rpk_taxa_stratified=True_fill_missing=False_filler=0"
+        ]
+    ).empty
     df = sc._functional_results(
         annotation="eggnog", metric="cpm", taxa_stratified=False, fill_missing=True, filler=0
     )
-    assert sc._cached["functional_results_content"] == {
-        "annotation": "eggnog",
-        "taxa_stratified": False,
-        "metric": "cpm",
-        "fill_missing": True,
-        "filler": 0,
-    }
+    # Old cache is still kept
+    assert (
+        "functional_results_annotation=go_metric=rpk_taxa_stratified=True_fill_missing=False_filler=0"
+        in sc._cached
+    )
+    assert df.compare(
+        sc._cached[
+            "functional_results_annotation=eggnog_metric=cpm_taxa_stratified=False_fill_missing=True_filler=0"
+        ]
+    ).empty
     df = sc._functional_results(
         annotation="pathways", metric="coverage", taxa_stratified=True, fill_missing=False, filler=0
     )
@@ -121,15 +122,21 @@ def test_collate_functional_results(ocx_experimental, api_data):
     sc._functional_results(
         annotation="pfam", metric="cpm", taxa_stratified=False, fill_missing=False, filler=0
     )
-    assert sc._cached["functional_results"].shape == (3, 2)
+    assert sc._cached[
+        "functional_results_annotation=pfam_metric=cpm_taxa_stratified=False_fill_missing=False_filler=0"
+    ].shape == (3, 2)
     sc._functional_results(
         annotation="pfam", metric="rpk", taxa_stratified=False, fill_missing=False, filler=0
     )
-    assert sc._cached["functional_results"].shape == (3, 2)
+    assert sc._cached[
+        "functional_results_annotation=pfam_metric=rpk_taxa_stratified=False_fill_missing=False_filler=0"
+    ].shape == (3, 2)
     sc._functional_results(
         annotation="go", metric="rpk", taxa_stratified=True, fill_missing=False, filler=0
     )
-    assert sc._cached["functional_results"].shape == (3, 39)
+    assert sc._cached[
+        "functional_results_annotation=go_metric=rpk_taxa_stratified=True_fill_missing=False_filler=0"
+    ].shape == (3, 39)
 
 
 def test_to_df_for_functional_profiles(ocx_experimental, api_data):


### PR DESCRIPTION
## Status
- [X] **Ready**

## Description
This PR makes use of the filtered functional run results API endpoint in order to make functional run results analysis and plotting feasible.
*Important* do not merge before corresponding updates are deployed to mainline prod.

## Related PRs
- [X] Please see the following related PRs:
- See [custom-plots-functional](https://github.com/onecodex/mainline/tree/custom-plots-functional) mainline branch.

## TODOs
- [ ] Test extensively
