### PR TITLE
update handling of missing phenotype

### DIFF
--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -152,6 +152,9 @@ class VizHeatmapMixin(object):
 
         # and for metadata
         for f in tooltip:
+            if f == haxis:
+                magic_metadata[[haxis]] = magic_metadata[[haxis]].replace(np.nan, "None")
+
             df[magic_fields[f]] = magic_metadata[magic_fields[f]][df["classification_id"]].tolist()
 
         # if we've already been normalized, we must cluster samples by euclidean distance. beta
@@ -265,10 +268,6 @@ class VizHeatmapMixin(object):
 
         df = df.replace(np.nan, 0)
         df = pd.concat([df, *dropped])
-
-        if haxis and type(haxis) == str:
-            # If there are samples without the specified haxis, update to `None`
-            df[[haxis]] = df[[haxis]].replace({0: "None"})
 
         assert set(df["Label"].values) == set(labels_in_order)
 

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -145,7 +145,7 @@ class VizHeatmapMixin(object):
         tooltip.insert(0, "Label")
 
         magic_metadata, magic_fields = self._metadata_fetch(tooltip, label=label)
-        magic_metadata.replace(np.nan, "None", inplace=True)
+        magic_metadata.replace(np.nan, "N/A", inplace=True)
 
         # add columns for prettier display
         df["Label"] = magic_metadata["Label"][df["classification_id"]].tolist()

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -205,7 +205,7 @@ class VizHeatmapMixin(object):
                 labels_in_order = []
                 df_sample_cluster[haxis] = self.metadata[haxis]
 
-                for group, group_df in df_sample_cluster.groupby(haxis):
+                for group, group_df in df_sample_cluster.groupby(haxis, dropna=False):
 
                     if group_df.shape[0] <= 3:
                         # we can't cluster
@@ -265,6 +265,10 @@ class VizHeatmapMixin(object):
 
         df = df.replace(np.nan, 0)
         df = pd.concat([df, *dropped])
+
+        if haxis and type(haxis) == str:
+            # If there are samples without the specified haxis, update to `None`
+            df[[haxis]] = df[[haxis]].replace({0: "None"})
 
         assert set(df["Label"].values) == set(labels_in_order)
 

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -145,6 +145,7 @@ class VizHeatmapMixin(object):
         tooltip.insert(0, "Label")
 
         magic_metadata, magic_fields = self._metadata_fetch(tooltip, label=label)
+        magic_metadata.replace(np.nan, "None", inplace=True)
 
         # add columns for prettier display
         df["Label"] = magic_metadata["Label"][df["classification_id"]].tolist()
@@ -152,9 +153,6 @@ class VizHeatmapMixin(object):
 
         # and for metadata
         for f in tooltip:
-            if f == haxis:
-                magic_metadata[[haxis]] = magic_metadata[[haxis]].replace(np.nan, "None")
-
             df[magic_fields[f]] = magic_metadata[magic_fields[f]][df["classification_id"]].tolist()
 
         # if we've already been normalized, we must cluster samples by euclidean distance. beta

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -254,6 +254,16 @@ def test_plot_heatmap(ocx, api_data):
     assert all(chart.data.groupby("tax_id").max()["Relative Abundance"] > 0.01)
 
 
+def test_plot_heatmap_with_missing_haxis_sample(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    samples[2].metadata.custom.pop("eggs")
+
+    # Does not raise exception if a sample is missing `haxis` value in custom metadata
+    chart = samples.plot_heatmap(top_n=10, threshold=0.1, haxis="eggs", return_chart=True)
+
+    assert "N/A" in chart.data["eggs"].unique()
+
+
 @pytest.mark.parametrize(
     "is_onecodex_accessor",
     [


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
If samples don't have a specified `haxis`, it breaks plotting. With this change, we update the `0`s to `None`s so that those samples will be clustered by themselves with the `None` label.

## Related PRs
- [x] This PR is independent

