### PR TITLE
Fix allowed_methods

### DIFF
--- a/onecodex/api.py
+++ b/onecodex/api.py
@@ -107,7 +107,7 @@ class Api(object):
 
         # Set backoff / retry strategy for 429s
         retry_strategy = Retry(
-            total=3, backoff_factor=4, method_whitelist=False, status_forcelist=[429, 502, 503]
+            total=3, backoff_factor=4, allowed_methods=False, status_forcelist=[429, 502, 503]
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self._session.mount("http://", adapter)

--- a/onecodex/models/helpers.py
+++ b/onecodex/models/helpers.py
@@ -173,7 +173,7 @@ class ResourceDownloadMixin(object):
                 total=5,
                 backoff_factor=2,
                 status_forcelist=[404, 429, 500, 502, 503, 504],
-                method_whitelist=False,
+                allowed_methods=False,
             )
             adapter = HTTPAdapter(max_retries=retry_strategy)
             session.mount("http://", adapter)
@@ -181,7 +181,7 @@ class ResourceDownloadMixin(object):
 
             resp = session.get(link, stream=True)
 
-            with (open(path, "wb") if path else file_obj) as f_out:
+            with open(path, "wb") if path else file_obj as f_out:
                 if progressbar:
                     progress_label = os.path.basename(path) if path else self.filename
                     with click.progressbar(length=self.size, label=progress_label) as bar:

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -33,9 +33,9 @@ def test_retries_set_on_client_session(api_data):
     )
 
     assert ocx._session.adapters["http://"].max_retries.total == 3
-    assert ocx._session.adapters["http://"].max_retries.method_whitelist is False
+    assert ocx._session.adapters["http://"].max_retries.allowed_methods is False
     assert ocx._session.adapters["https://"].max_retries.total == 3
-    assert ocx._session.adapters["https://"].max_retries.method_whitelist is False
+    assert ocx._session.adapters["https://"].max_retries.allowed_methods is False
 
 
 def test_sample_int_id(ocx, api_data):


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description

* FIX `method_whitelist` was renamed to `allowed_methods` https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#1260-2020-11-10.

This was causing the following error on some machines:

```
TypeError                                 Traceback (most recent call last)
Cell In[1], line 8
      6 import pandas as pd
      7 alt.data_transformers.disable_max_rows()
----> 8 onecodex.Api(api_key="redacted")
File [/usr/local/lib/python3.11/site-packages/onecodex/api.py:109](https://file+.vscode-resource.vscode-cdn.net/usr/local/lib/python3.11/site-packages/onecodex/api.py:109), in Api.__init__(self, api_key, bearer_token, cache_schema, base_url, telemetry, schema_path, load_extensions, **kwargs)
    106 self._session = self._client.session
    108 # Set backoff [/](https://file+.vscode-resource.vscode-cdn.net/) retry strategy for 429s
--> 109 retry_strategy = Retry(
    110     total=3, backoff_factor=4, method_whitelist=False, status_forcelist=[429, 502, 503]
    111 )
    112 adapter = HTTPAdapter(max_retries=retry_strategy)
    113 self._session.mount("http://", adapter)
TypeError: Retry.__init__() got an unexpected keyword argument 'method_whitelist'
```

## Related PRs
- [x] This PR is independent

## TODOs

- [x] Tests
