### PR TITLE
Upgrade dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	py.test -W ignore::DeprecationWarning --ignore tests/test_speed.py --ignore tests/test_reports.py tests/
+	py.test --ignore tests/test_speed.py --ignore tests/test_reports.py tests/
 	@echo "Successfully passed all tests (one environment only)."
 
 lint:
@@ -7,10 +7,10 @@ lint:
 	@echo "Successfully linted all files."
 
 coverage:
-	py.test -W ignore::DeprecationWarning --cov-report=term-missing --cov=onecodex --ignore tests/test_speed.py --ignore tests/test_reports.py tests/
+	py.test --cov-report=term-missing --cov=onecodex --ignore tests/test_speed.py --ignore tests/test_reports.py tests/
 
 coveragehtml:
-	py.test -W ignore::DeprecationWarning --cov-report=html --cov=onecodex --ignore tests/test_speed.py --ignore tests/test_reports.py tests/
+	py.test --cov-report=html --cov=onecodex --ignore tests/test_speed.py --ignore tests/test_reports.py tests/
 
 install:
 	python setup.py install

--- a/README.md
+++ b/README.md
@@ -272,13 +272,13 @@ We also package custom Jupyter notebook [`nbconvert`](https://nbconvert.readthed
 Our `OneCodexHTMLExporter`:
 
 ```sh
-jupyter nbconvert --execute --to onecodex_html --ExecutePreprocessor.timeout=-1 --output="$ONE_CODEX_REPORT_FILENAME" --output-dir="." notebook_examples/example.ipynb && open example.html
+ONE_CODEX_REPORT_FILENAME=example.html jupyter nbconvert --execute --to onecodex_html --ExecutePreprocessor.timeout=-1 --output="$ONE_CODEX_REPORT_FILENAME" --output-dir="." notebook_examples/example.ipynb && open example.html
 ```
 
 And using the `OneCodexPDFExporter`:
 
 ```sh
-jupyter nbconvert --execute --to onecodex_pdf --ExecutePreprocessor.timeout=-1 --output="$ONE_CODEX_REPORT_FILENAME" --output-dir="." notebook_examples/example.ipynb && open example.pdf
+ONE_CODEX_REPORT_FILENAME=example.pdf jupyter nbconvert --execute --to onecodex_pdf --ExecutePreprocessor.timeout=-1 --output="$ONE_CODEX_REPORT_FILENAME" --output-dir="." notebook_examples/example.ipynb && open example.pdf
 ```
 
 Note these require the installation of several `npm` packages for headless rendering: `npm install vega-lite vega-cli canvas`. See [altair-saver](`https://github.com/altair-viz/altair_saver`) for more details.

--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -147,8 +147,8 @@ class AnalysisMixin(
 
                     if not (
                         pd.api.types.is_bool_dtype(self.metadata[field])
-                        or pd.api.types.is_categorical_dtype(self.metadata[field])  # noqa
-                        or pd.api.types.is_object_dtype(self.metadata[field])  # noqa
+                        or isinstance(self.metadata[field].dtype, pd.CategoricalDtype)
+                        or pd.api.types.is_object_dtype(self.metadata[field])
                     ):
                         raise OneCodexException(
                             "When specifying multiple metadata fields, all must be categorical"

--- a/onecodex/notebooks/exporters.py
+++ b/onecodex/notebooks/exporters.py
@@ -81,7 +81,7 @@ class OneCodexHTMLExporter(HTMLExporter):
         -----
         This exporter will only save cells generated with Altair/Vega if they have an SVG image type
         stored with them. This data is only stored if our fork of `ipyvega` is installed or the onecodex
-        # renderer is used--otherwise, they will be low-resolution PNGs, which will not be exported.
+        renderer is used--otherwise, they will be low-resolution PNGs, which will not be exported.
         """
         nb = copy.deepcopy(nb)
 

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -477,8 +477,8 @@ def is_continuous(series):
 
     return not (
         pd.api.types.is_bool_dtype(series)
-        or pd.api.types.is_categorical_dtype(series)  # noqa
-        or pd.api.types.is_object_dtype(series)  # noqa
+        or isinstance(series.dtype, pd.CategoricalDtype)
+        or pd.api.types.is_object_dtype(series)
     )
 
 

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -387,7 +387,12 @@ class VizDistanceMixin(DistanceMixin):
 
             seed = np.random.RandomState(seed=3)
             mds = manifold.MDS(
-                max_iter=3000, eps=1e-12, random_state=seed, dissimilarity="precomputed", n_jobs=1
+                max_iter=3000,
+                eps=1e-12,
+                random_state=seed,
+                dissimilarity="precomputed",
+                n_jobs=1,
+                normalized_stress="auto",
             )
             pos = mds.fit(dists).embedding_
             plot_data = pd.DataFrame(pos, columns=[x_field, y_field], index=dists.index)
@@ -425,8 +430,8 @@ class VizDistanceMixin(DistanceMixin):
             plot_data.index.names = ["classification_id"]
             x_field, y_field = plot_data.columns.tolist()  # name of first two components
 
-            x_extra_label = "%0.02f%%" % (ord_result.proportion_explained[0] * 100,)
-            y_extra_label = "%0.02f%%" % (ord_result.proportion_explained[1] * 100,)
+            x_extra_label = "%0.02f%%" % (ord_result.proportion_explained.iloc[0] * 100,)
+            y_extra_label = "%0.02f%%" % (ord_result.proportion_explained.iloc[1] * 100,)
         else:
             raise OneCodexException(
                 "MDS method must be one of: {}".format(", ".join(OrdinationMethod.values))

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -196,9 +196,9 @@ class VizHeatmapMixin(object):
             else:
                 if not (
                     pd.api.types.is_bool_dtype(df[magic_fields[haxis]])
-                    or pd.api.types.is_categorical_dtype(df[magic_fields[haxis]])  # noqa
-                    or pd.api.types.is_object_dtype(df[magic_fields[haxis]])  # noqa
-                ):  # noqa
+                    or isinstance(df[magic_fields[haxis]].dtype, pd.CategoricalDtype)
+                    or pd.api.types.is_object_dtype(df[magic_fields[haxis]])
+                ):
                     raise OneCodexException(
                         "Metadata field on horizontal axis can not be numerical"
                     )

--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -115,10 +115,10 @@ class VizMetadataMixin(object):
             # we require the vertical axis to be numerical otherwise plots get weird
             if (
                 pd.api.types.is_bool_dtype(vert_df[vert_magic_fields[vaxis]])
-                or pd.api.types.is_categorical_dtype(vert_df[vert_magic_fields[vaxis]])
+                or isinstance(vert_df[vert_magic_fields[vaxis]].dtype, pd.CategoricalDtype)
                 or pd.api.types.is_object_dtype(vert_df[vert_magic_fields[vaxis]])
                 or not pd.api.types.is_numeric_dtype(vert_df[vert_magic_fields[vaxis]])
-            ):  # noqa
+            ):
                 raise OneCodexException("Metadata field on vertical axis must be numerical")
 
             df = pd.concat([df, vert_df], axis=1).dropna(subset=[vert_magic_fields[vaxis]])
@@ -137,9 +137,9 @@ class VizMetadataMixin(object):
                 plot_type = PlotType.BoxPlot
         elif (
             pd.api.types.is_bool_dtype(df[magic_fields[haxis]])
-            or pd.api.types.is_categorical_dtype(df[magic_fields[haxis]])
+            or isinstance(df[magic_fields[haxis]].dtype, pd.CategoricalDtype)
             or pd.api.types.is_object_dtype(df[magic_fields[haxis]])
-        ):  # noqa
+        ):
             df = df.fillna({field: "N/A" for field in df.columns})
 
             if plot_type == PlotType.Auto:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore:Experimental API:UserWarning
+    ignore:Using base API URL:UserWarning

--- a/setup.py
+++ b/setup.py
@@ -37,21 +37,19 @@ TESTING_DEPS = [
     "pdfplumber",
 ]
 ALL_DEPS = [
-    "altair==4.2.2",
+    "altair==4.2.2",  # altair_saver doesn't support altair 5
     "numpy>=1.11.0",
     "pandas>=1.0.3",
     "pillow>=9.0.1",
     "scikit-bio>=0.5.8",
     "scikit-learn>=0.19.0",
     "scipy",
-    "jupyter-client==7.2.0",
+    "jupyter-client==8.6.0",
 ]
 REPORT_DEPS = ALL_DEPS + [
-    "notebook==6.4.10",
-    "nbconvert>=6",
-    # Hardcoding jinja2 version for https://github.com/jupyter/nbconvert/issues/1742
-    "jinja2<=3.1",
-    "WeasyPrint==59.0",
+    "notebook==7.0.6",
+    "nbconvert>=6.4.3",
+    "WeasyPrint==60.1",  # 60.2 truncates y-axis titles
     "altair-saver==0.5.0",
     "selenium<4.3.0",  # see https://github.com/altair-viz/altair_saver/issues/104
 ]

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -222,7 +222,9 @@ def test_filter_functional_runs_to_newest_job(ocx_experimental, raw_api_data, cu
         sample_ids = ["543c9c046e3e4e09", "66c1531cb0b244f6", "37e5151e7bcb4f87"]
         samples = [ocx_experimental.Samples.get(sample_id) for sample_id in sample_ids]
         sc = SampleCollection(samples)
-        df = sc.to_df(analysis_type="functional")
+        with pytest.warns(UserWarning, match="mixing functional profile versions"):
+            df = sc.to_df(analysis_type="functional")
+
         # All samples are included, one with newer version has proper values
         assert df.shape == (3, 112)
         assert df.loc["37e5151e7bcb4f87", "PF00005"] == 256.524  # older version has 4919.47


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Upgraded pinned dependencies to their latest versions:

- jupyter-client
- notebook
- nbconvert
- WeasyPrint
- unpinned jinja2

Fixed all FutureWarnings, and either assert or ignore other warnings being raised by the tests. `make test` no longer generates warnings in its output.

Closes DEV-9019

## Related PRs
- [x] This PR is independent