### PR TITLE
Fix date field type coercion in plot_metadata() & add `coerce_haxis_dates` parameter

### DIFF
--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -29,6 +29,7 @@ class VizMetadataMixin(object):
         width=200,
         height=400,
         facet_by=None,
+        coerce_haxis_dates=True,
     ):
         """Plot an arbitrary metadata field versus an arbitrary quantity as a boxplot or scatter plot.
 
@@ -74,6 +75,11 @@ class VizMetadataMixin(object):
         facet_by : `string`, optional
             The metadata field used to facet samples by (i.e. to create a separate subplot for each
             group of samples).
+
+        coerce_haxis_dates : `bool`, optional
+            If ``True``, ``haxis`` field name(s) containing the word "date" (after splitting on
+            underscores) will be coerced to datetime dtype. For example, the field "date_collected"
+            will be coerced if ``coerce_haxis_dates`` is ``True``.
 
         Examples
         --------
@@ -129,10 +135,8 @@ class VizMetadataMixin(object):
             if plot_type == PlotType.Auto:
                 plot_type = PlotType.BoxPlot
         elif "date" in magic_fields[haxis].split("_"):
-            df.loc[:, magic_fields[haxis]] = df.loc[:, magic_fields[haxis]].apply(
-                pd.to_datetime, utc=True
-            )
-
+            if coerce_haxis_dates:
+                df[magic_fields[haxis]] = pd.to_datetime(df[magic_fields[haxis]], utc=True)
             if plot_type == PlotType.Auto:
                 plot_type = PlotType.BoxPlot
         elif (

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,6 +1,7 @@
 import math
 import mock
 import pytest
+from datetime import datetime
 
 pytest.importorskip("numpy")  # noqa
 pytest.importorskip("pandas")  # noqa
@@ -99,6 +100,24 @@ def test_plot_metadata_alpha_diversity_with_nans(ocx, api_data):
     assert len(shannon_result) == 1
     assert math.isclose(shannon_result[0], 5.212043764541939)
     assert chart.mark == "circle"
+
+
+@pytest.mark.parametrize("coerce_haxis_dates", [True, False])
+def test_plot_metadata_haxis_date(ocx, api_data, coerce_haxis_dates):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    samples.metadata["date_collected"] = datetime.now().isoformat()
+
+    chart = samples.plot_metadata(
+        vaxis="shannon",
+        haxis="date_collected",
+        return_chart=True,
+        coerce_haxis_dates=coerce_haxis_dates,
+    )
+
+    assert chart.mark.type == "boxplot"
+    assert chart.encoding.x.shorthand == "date_collected"
+    # previous column type coercion would raise a json serialization TypeError
+    assert isinstance(chart.to_dict(), dict)
 
 
 def test_plot_metadata_exceptions(ocx, api_data):


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
In `plot_metadata()`, column names containing the word "date" (after splitting on underscores) have their column dtype coerced to datetime. This didn't work correctly because calling `chart.to_dict()` would raise a JSON serialization `TypeError`.

Fixed the type coercion and added a `coerce_haxis_dates` parameter to control whether type coercion happens (the default is `True` for backwards-compatibility).

Closes DEV-9026

## Related PRs
- [x] This PR is independent