### PR TITLE
Add differential abundance test and plots

### DIFF
--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -18,6 +18,7 @@ from onecodex.viz import (
     VizBargraphMixin,
     VizFunctionalHeatmapMixin,
 )
+from onecodex.stats import StatsMixin
 
 
 def _get_all_nan_classification_ids(df):
@@ -35,6 +36,7 @@ class AnalysisMixin(
     VizDistanceMixin,
     VizBargraphMixin,
     VizFunctionalHeatmapMixin,
+    StatsMixin,
 ):
     """Contains methods for analyzing Classifications results.
 
@@ -142,7 +144,7 @@ class AnalysisMixin(
                 for field in f:
                     if field not in self.metadata:
                         raise OneCodexException(
-                            "Metric {} not found. Choose from: {}".format(field, help_metadata)
+                            f"Metadata field {field} not found. Choose from: {help_metadata}"
                         )
 
                     if not (

--- a/onecodex/exceptions.py
+++ b/onecodex/exceptions.py
@@ -48,6 +48,18 @@ class PlottingWarning(UserWarning):
     pass
 
 
+class StatsException(OneCodexException):
+    """User-facing error for statistical methods."""
+
+    pass
+
+
+class StatsWarning(UserWarning):
+    """User-facing warning for statistical methods."""
+
+    pass
+
+
 def raise_api_error(resp, state=None):
     """Raise an exception with a pretty message in various states of upload."""
     # TODO: Refactor into an Exception class

--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+from dataclasses import dataclass
+import warnings
+from typing import TYPE_CHECKING, Optional
+
+from onecodex.exceptions import StatsException, StatsWarning, PlottingException
+from onecodex.lib.enums import Rank
+from onecodex.viz._primitives import prepare_props
+
+if TYPE_CHECKING:
+    import altair as alt
+    import pandas as pd
+
+
+@dataclass(frozen=True)
+class DifferentialAbundanceResults:
+    # ANCOM results
+    ancom_df: pd.DataFrame
+    percentile_df: pd.DataFrame
+
+    # Intermediate data needed for plotting
+    _taxa_df: pd.DataFrame
+    _metadata_df: pd.DataFrame
+    _group_by_column_name: str
+    _metric_name: str
+
+    def plot(
+        self,
+        title: Optional[str] = None,
+        width: Optional[int | str] = None,
+        height: Optional[int | str] = None,
+        return_chart: bool = False,
+    ) -> Optional[alt.FacetChart]:
+        """Plot differential abundance results as boxplots faceted by taxa.
+
+        A boxplot of abundances per group is generated for each significantly different taxon.
+
+        Parameters
+        ----------
+        title : str, optional
+            Text label at the top of the chart.
+        width : int or str, optional
+            The width of the chart. Can be `"container"` for responsive sizing.
+        height : int or str, optional
+            The height of the chart. Can be `"container"` for responsive sizing.
+        return_chart : bool, optional
+            When `True`, return an `altair.FacetChart` object instead of displaying the resulting
+            chart in the current notebook.
+
+        Returns
+        -------
+        alt.FacetChart or None
+            If `return_chart` is `True`, the Altair chart is returned, otherwise `None` is returned
+            and the chart is displayed in the current notebook.
+
+        """
+        import altair as alt
+        import pandas as pd
+
+        reject_column = self.ancom_df["Reject null hypothesis"]
+        if not reject_column.any():
+            raise PlottingException(
+                "No significantly different taxa were detected in ANCOM results."
+            )
+
+        # Filter to taxa that are significantly different
+        filtered_taxa_df = self._taxa_df[reject_column[reject_column].index].copy()
+
+        # Add grouping metadata variable
+        filtered_taxa_df.loc[:, self._group_by_column_name] = self._metadata_df[
+            self._group_by_column_name
+        ]
+
+        # - Facet based on the different taxa that were found to be significantly different
+        # - Color by the grouping metadata variable
+        plotting_df = pd.melt(
+            filtered_taxa_df,
+            id_vars=self._group_by_column_name,
+            var_name="Significantly Different Taxa",
+            value_name=self._metric_name,
+        )
+        chart = (
+            alt.Chart(plotting_df)
+            .mark_boxplot(median={"stroke": "black"})
+            .encode(
+                x=alt.X(self._group_by_column_name),
+                y=alt.Y(self._metric_name),
+                color=self._group_by_column_name,
+            )
+            .facet("Significantly Different Taxa")
+            .resolve_scale(y="independent")
+        )
+        chart = chart.properties(**prepare_props(title=title, width=width, height=height))
+
+        return chart if return_chart else chart.display()
+
+
+class StatsMixin:
+    def differential_abundance(
+        self,
+        *,
+        group_by: str | tuple[str, ...],
+        rank: Rank = Rank.Auto,
+        alpha: float = 0.05,
+    ) -> DifferentialAbundanceResults:
+        """
+        Perform a test for differentially abundant taxa using ANCOM.
+
+        Readcounts are normalized and zeros are replaced using multiplicative replacement. Results
+        indicate taxa that are significantly different in abundance across the grouping variable of
+        interest, as well as each taxon's W-statistic.
+
+        Parameters
+        ----------
+        group_by : str or tuple of str
+            Metadata variable to group samples by. At least two groups are required. If `group_by`
+            is a tuple, field values are joined with an underscore character ("_").
+        rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
+            Analysis will be restricted to abundances of taxa at the specified level.
+        alpha : float, optional
+            Threshold to determine statistical significance (e.g. p < `alpha`). Must be between 0
+            and 1 (exclusive).
+
+        Returns
+        -------
+        DifferentialAbundanceResults
+            A dataclass with these attributes:
+
+            - `ancom_df`: `pd.DataFrame` containing ANCOM test results: taxa, their W-statistics,
+            and whether or not they are significantly different. See `skbio.stats.composition.ancom`
+            for details.
+
+            - `percentile_df`: `pd.DataFrame` containing percentile abundances of taxa in each
+            group. See `skbio.stats.composition.ancom` for details.
+
+            There is also a `plot()` method for generating faceted boxplots.
+
+        See Also
+        --------
+        skbio.stats.composition.ancom
+        skbio.stats.composition.multiplicative_replacement
+
+        """
+        import pandas as pd
+        from skbio.stats.composition import ancom, multiplicative_replacement
+
+        if not isinstance(group_by, tuple):
+            group_by = (group_by,)
+
+        # Munge the metadata first in case there's any errors
+        metadata_df, magic_fields = self._metadata_fetch([group_by])
+
+        # Normalize because `multiplicative_replacement()` requires compositions
+        taxa_df = self.to_df(rank=rank, normalize=True)
+        taxa_df = taxa_df.rename(
+            columns=lambda tax_id: f"{self.taxonomy['name'][tax_id]} ({tax_id})"
+            if tax_id in self.taxonomy["name"]
+            else tax_id
+        )
+
+        # `multiplicative_replacement()` will error on rows that are all zeros
+        prev_index = taxa_df.index
+        taxa_df = taxa_df.loc[(taxa_df != 0).any(axis=1)]
+        num_dropped = len(prev_index) - len(taxa_df.index)
+        if num_dropped > 0:
+            warnings.warn(
+                f"{num_dropped} sample{'s' if num_dropped > 1 else ''} with zero abundance across "
+                f"all taxa {'were' if num_dropped > 1 else 'was'} ignored.",
+                StatsWarning,
+            )
+
+        # Drop any samples from the metadata df that are not in the taxa df
+        metadata_df = metadata_df.filter(items=taxa_df.index, axis="index")
+
+        group_by_column_name = magic_fields[group_by]
+        num_groups = metadata_df[group_by_column_name].nunique(dropna=False)
+        if num_groups < 2:
+            raise StatsException("`group_by` must have at least two groups to test between.")
+        if num_groups == len(metadata_df):
+            raise StatsException("Each group defined by `group_by` contains only one value.")
+
+        # Need to use pseudocounts or `multiplicative_replacement()` because ANCOM can't handle
+        # zeros
+        multiplicative_replacement_df = pd.DataFrame(
+            multiplicative_replacement(taxa_df), columns=taxa_df.columns, index=taxa_df.index
+        )
+        ancom_df, percentile_df = ancom(
+            multiplicative_replacement_df,
+            metadata_df[group_by_column_name],
+            alpha=alpha,
+            multiple_comparisons_correction="holm-bonferroni",
+        )
+
+        return DifferentialAbundanceResults(
+            ancom_df=ancom_df,
+            percentile_df=percentile_df,
+            _taxa_df=taxa_df,
+            _metadata_df=metadata_df,
+            _group_by_column_name=group_by_column_name,
+            _metric_name=self.metric,
+        )

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,81 @@
+import pytest
+import mock
+
+pytest.importorskip("pandas")  # noqa
+
+import pandas as pd
+
+from onecodex.exceptions import StatsException, PlottingException
+
+
+def test_differential_abundance_not_enough_groups(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    samples.metadata["wheat"] = "one value"
+
+    with pytest.raises(StatsException, match="`group_by` must have at least two groups"):
+        samples.differential_abundance(group_by="wheat")
+
+
+def test_differential_abundance_no_group_variance(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    samples.metadata["wheat"] = ["all", "unique", "values"]
+
+    with pytest.raises(StatsException, match="`group_by` contains only one value"):
+        samples.differential_abundance(group_by="wheat")
+
+
+def test_differential_abundance_one_group_var(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    results = samples.differential_abundance(group_by="wheat")
+
+    assert results.ancom_df.index.name == "tax_id"
+    assert "W" in results.ancom_df.columns
+    assert "Reject null hypothesis" in results.ancom_df.columns
+    assert results.ancom_df["Reject null hypothesis"].any()
+    assert results.percentile_df.index.name == "tax_id"
+
+    chart = results.plot(return_chart=True)
+    assert chart.facet.shorthand == "Significantly Different Taxa"
+    assert "wheat" in chart.data.columns
+
+
+def test_differential_abundance_multiple_group_vars(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    samples.metadata["tofu"] = ["soft", "extra firm", "soft"]
+    results = samples.differential_abundance(group_by=("wheat", "tofu"))
+
+    assert results.ancom_df.index.name == "tax_id"
+    assert "W" in results.ancom_df.columns
+    assert "Reject null hypothesis" in results.ancom_df.columns
+    assert results.ancom_df["Reject null hypothesis"].any()
+    assert results.percentile_df.index.name == "tax_id"
+
+    chart = results.plot(return_chart=True)
+    assert chart.facet.shorthand == "Significantly Different Taxa"
+    assert "wheat_tofu" in chart.data.columns
+
+
+def test_differential_abundance_no_significant_taxa(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    ancom_df = pd.DataFrame(
+        [[0, False], [5, False], [1, False]], columns=["W", "Reject null hypothesis"]
+    )
+    percentile_df = pd.DataFrame()
+
+    with mock.patch("skbio.stats.composition.ancom", return_value=(ancom_df, percentile_df)):
+        results = samples.differential_abundance(group_by="wheat")
+
+    assert not results.ancom_df["Reject null hypothesis"].any()
+
+    with pytest.raises(PlottingException, match="No significantly different taxa"):
+        results.plot()
+
+
+def test_differential_abundance_plot_props(ocx, api_data):
+    samples = ocx.Samples.where(project="4b53797444f846c4")
+    results = samples.differential_abundance(group_by="wheat")
+    chart = results.plot(title="New Title", width=100, height=100, return_chart=True)
+
+    assert chart.title == "New Title"
+    assert chart.width == 100
+    assert chart.height == 100


### PR DESCRIPTION
## Status
- [x] **Hold**

## Description
Added ANCOM differential abundance test and faceted boxplots of significantly different taxa abundances across groups.

- Test results are generated via `SampleCollection.differential_abundance()` (also available on OCX dataframes)
- Plots are generated via `plot()` method on test results object
- Multiple metadata grouping variables are supported (e.g. secondary, tertiary, ...)

Closes DEV-9176

<img width="1078" alt="Screenshot 2024-02-09 at 8 59 35 AM" src="https://github.com/onecodex/onecodex/assets/1847232/beffdc2e-b155-497d-9196-fbab062530bc">
<img width="1065" alt="Screenshot 2024-02-09 at 8 59 55 AM" src="https://github.com/onecodex/onecodex/assets/1847232/0d024cfb-1a4a-4b7c-9adf-42dea1fa0551">

## Related PRs
- [x] This PR is independent

## TODOs
- [ ] Filter samples with missing `group_by` data and raise a warning about the number of samples filtered
- [ ] Disallow group sizes < 2 samples
- [ ] Add minimum prevalence filter for taxa?