### PR TITLE
Add secondary haxis grouping to `plot_metadata()`

### DIFF
--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -30,6 +30,7 @@ class VizMetadataMixin(object):
         height=400,
         facet_by=None,
         coerce_haxis_dates=True,
+        secondary_haxis=None,
     ):
         """Plot an arbitrary metadata field versus an arbitrary quantity as a boxplot or scatter plot.
 
@@ -81,6 +82,10 @@ class VizMetadataMixin(object):
             underscores) will be coerced to datetime dtype. For example, the field "date_collected"
             will be coerced if ``coerce_haxis_dates`` is ``True``.
 
+        secondary_haxis : str or tuple of str, optional
+            The secondary metadata field (or tuple containing multiple categorical fields) to be
+            plotted on the horizontal axis.
+
         Examples
         --------
         Generate a boxplot of the abundance of Bacteroides (genus) of samples grouped by whether the
@@ -98,6 +103,17 @@ class VizMetadataMixin(object):
         if not PlotType.has_value(plot_type):
             raise OneCodexException("Plot type must be one of: auto, boxplot, scatter")
 
+        # TODO we're hacking a grouped scatter/boxplot using faceting:
+        # https://stackoverflow.com/a/66877669/3776794
+        #
+        # Altair 5 supports alt.XOffset, which will enable the use of faceting *and* grouping. We
+        # can't upgrade to Altair 5 until we no longer depend on altair_saver.
+        if facet_by and secondary_haxis:
+            raise OneCodexException("Please only specify one of `facet_by` or `secondary_haxis`.")
+
+        if haxis == secondary_haxis:
+            raise OneCodexException("`haxis` and `secondary_haxis` cannot be the same field(s).")
+
         if len(self._results) < 1:
             raise PlottingException(
                 "There are too few samples for metadata plots after filtering. Please select 1 or "
@@ -108,6 +124,11 @@ class VizMetadataMixin(object):
         metadata_fields = [haxis, "Label"]
         if facet_by:
             metadata_fields.append(facet_by)
+        if secondary_haxis:
+            metadata_fields.append(secondary_haxis)
+            facet_by = haxis
+            haxis = secondary_haxis
+
         df, magic_fields = self._metadata_fetch(metadata_fields, label=label)
 
         if AlphaDiversityMetric.has_value(vaxis):
@@ -171,35 +192,45 @@ class VizMetadataMixin(object):
         if ylabel is None:
             ylabel = magic_fields[vaxis]
 
-        alt_kwargs = {}
+        encode_kwargs = {}
         if facet_by:
-            alt_kwargs["column"] = alt.Column(
+            encode_kwargs["column"] = alt.Column(
                 facet_by, header=alt.Header(titleOrient="bottom", labelOrient="bottom")
             )
+
+        x_kwargs = {"axis": alt.Axis(title=xlabel)}
+        if secondary_haxis:
+            # Part of the hack to make a faceted plot look like a grouped plot is turning off x-axis
+            # labels and ticks because they're redundant with the coloring and tooltip.
+            x_kwargs.update(
+                {
+                    "title": None,
+                    "axis": alt.Axis(title=xlabel, labels=False, ticks=False),
+                    "scale": alt.Scale(padding=1),
+                }
+            )
+            encode_kwargs["color"] = haxis
 
         if plot_type == "scatter":
             df = df.reset_index()
             sort_order = sort_helper(sort_x, df[magic_fields[haxis]].tolist())
             df["url"] = df["classification_id"].apply(get_classification_url)
 
-            alt_kwargs.update(
+            encode_kwargs.update(
                 dict(
-                    x=alt.X(magic_fields[haxis], axis=alt.Axis(title=xlabel), sort=sort_order),
+                    x=alt.X(magic_fields[haxis], sort=sort_order, **x_kwargs),
                     y=alt.Y(magic_fields[vaxis], axis=alt.Axis(title=ylabel)),
                     tooltip=["Label", "{}:Q".format(magic_fields[vaxis])],
                     href="url:N",
                 )
             )
-
-            chart = alt.Chart(df).mark_circle().encode(**alt_kwargs)
-
+            chart = alt.Chart(df).mark_circle().encode(**encode_kwargs)
         elif plot_type == PlotType.BoxPlot:
             if sort_x:
                 raise OneCodexException("Must not specify sort_x when plot_type is boxplot")
 
             box_size = 45
             increment = 5
-
             n_boxes = len(df[magic_fields[haxis]].unique())
 
             if width and width != "container" and (n_boxes * (box_size + increment)) > width:
@@ -209,14 +240,16 @@ class VizMetadataMixin(object):
                 alt.Chart(df)
                 .mark_boxplot(size=box_size, median={"stroke": "black"})
                 .encode(
-                    x=alt.X(magic_fields[haxis], axis=alt.Axis(title=xlabel)),
+                    x=alt.X(magic_fields[haxis], **x_kwargs),
                     y=alt.Y(magic_fields[vaxis], axis=alt.Axis(title=ylabel)),
-                    **alt_kwargs
+                    **encode_kwargs
                 )
             )
 
         if facet_by:
             chart = chart.resolve_scale(x="independent")
+        if secondary_haxis:
+            chart = chart.configure_facet(spacing=0).configure_view(stroke=None)
 
         chart = chart.properties(**prepare_props(title=title, height=height, width=width))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import responses
 
 from onecodex import Api
 from onecodex.analyses import FunctionalAnnotations, FunctionalAnnotationsMetric
+from onecodex.models.collection import SampleCollection
 
 
 # TODO: Fix a bug wherein this will return all the items to potion
@@ -505,6 +506,13 @@ def runner():
         env={"ONE_CODEX_API_BASE": "http://localhost:3000", "ONE_CODEX_NO_TELEMETRY": "True"}
     )
     return runner
+
+
+# SampleCollection fixtures
+@pytest.fixture
+def samples(ocx, api_data) -> SampleCollection:
+    # Project with 3 samples
+    return ocx.Samples.where(project="4b53797444f846c4")
 
 
 # CLI / FILE SYSTEM FIXTURE

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -10,9 +10,7 @@ from onecodex.models.collection import SampleCollection
 from onecodex.exceptions import OneCodexException
 
 
-def test_sample_collection_pandas(ocx, api_data):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
-
+def test_sample_collection_pandas(samples):
     # manipulations of samples in the collection ought to update the stored dfs
     class_id = samples[2].primary_classification.id
     del samples[2]
@@ -24,9 +22,7 @@ def test_sample_collection_pandas(ocx, api_data):
     assert class_id not in samples.metadata.index
 
 
-def test_collection_constructor(ocx, api_data):
-    samples = ocx.Samples.where(project="45a573fb7833449a")
-
+def test_collection_constructor(samples):
     col = SampleCollection(samples)
     assert col._kwargs["metric"] == "auto"
 
@@ -93,9 +89,7 @@ def test_biom(ocx, api_data):
     assert json.loads(json.dumps(biom)) == biom  # tests json serialization
 
 
-def test_classification_fetch(ocx, api_data):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
-
+def test_classification_fetch(ocx, samples):
     # should work with a list of classifications as input, not just samples
     samples._oc_model = ocx.Classifications
     samples._res_list = samples._classifications
@@ -115,9 +109,7 @@ def test_classification_fetch(ocx, api_data):
     samples._resource[0].success = True
 
 
-def test_collate_metadata(ocx, api_data):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
-
+def test_collate_metadata(samples):
     # check contents of metadata df--at least that which can easily be coerced to strings
     metadata = samples.metadata
     string_to_hash = ""
@@ -152,9 +144,7 @@ def test_collate_metadata(ocx, api_data):
         ),
     ],
 )
-def test_collate_results(ocx, api_data, metric, sha):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
-
+def test_collate_results(samples, metric, sha):
     samples._collate_results(metric=metric)
 
     # check contents of results df

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -36,8 +36,7 @@ def test_pandas_subclass():
     assert (new_df.ocx_metadata == inner_df).all().all()
 
 
-def test_pandas_extension(ocx, api_data):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
+def test_pandas_extension(samples):
     samples._collate_results(metric="readcount_w_children")
     results = samples.to_df()
 

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -16,25 +16,20 @@ from onecodex.lib.enums import BetaDiversityMetric
         ("observed_taxa", [164.0, 134.0, 103.0], {}),
     ],
 )
-def test_alpha_diversity(ocx, api_data, metric, value, kwargs):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
+def test_alpha_diversity(samples, metric, value, kwargs):
     divs = samples.alpha_diversity(metric=metric, **kwargs)
     assert isinstance(divs, pd.DataFrame)
     assert divs[metric].tolist() == value
 
 
-def test_alpha_diversity_exceptions(ocx, api_data):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
-
+def test_alpha_diversity_exceptions(samples):
     # must be a metric that exists
     with pytest.raises(OneCodexException) as e:
         samples.alpha_diversity("does_not_exist")
     assert "metric must be one of" in str(e.value)
 
 
-def test_alpha_diversity_warnings(ocx, api_data):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
-
+def test_alpha_diversity_warnings(samples):
     with pytest.warns(DeprecationWarning, match="`Chao1` is deprecated"):
         samples.alpha_diversity(metric="chao1")
 
@@ -51,15 +46,13 @@ def test_alpha_diversity_warnings(ocx, api_data):
         ("aitchison", [59.800677, 51.913911, 52.693709], {}),
     ],
 )
-def test_beta_diversity(ocx, api_data, metric, value, kwargs):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
+def test_beta_diversity(samples, metric, value, kwargs):
     dm = samples.beta_diversity(metric=metric, **kwargs)
     assert isinstance(dm, skbio.stats.distance._base.DistanceMatrix)
     assert dm.condensed_form().round(6).tolist() == value
 
 
-def test_beta_diversity_braycurtis_nans(ocx, api_data):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
+def test_beta_diversity_braycurtis_nans(samples):
     mock_df = samples.to_df()
     mock_df.loc[:, :] = 0
 
@@ -70,9 +63,7 @@ def test_beta_diversity_braycurtis_nans(ocx, api_data):
     assert (dm.condensed_form() == 0.0).all()
 
 
-def test_beta_diversity_exceptions(ocx, api_data):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
-
+def test_beta_diversity_exceptions(samples):
     # must be a metric that exists
     with pytest.raises(OneCodexException) as e:
         samples.beta_diversity("does_not_exist")
@@ -83,8 +74,7 @@ def test_beta_diversity_exceptions(ocx, api_data):
     "weighted,value",
     [(False, [0.6, 0.547486, 0.591304]), (True, [0.503168, 0.403155, 0.605155])],
 )
-def test_unifrac(ocx, api_data, value, weighted):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
+def test_unifrac(samples, value, weighted):
     dm = samples.unifrac(weighted=weighted)
     assert isinstance(dm, skbio.stats.distance._base.DistanceMatrix)
     assert dm.condensed_form().round(6).tolist() == value
@@ -95,8 +85,7 @@ def test_unifrac(ocx, api_data, value, weighted):
 # of `root`. There's a bug in scikit-bio where it requires that
 # the root has only one child, which isn't true in our taxonomy.
 # See onecodex/distances.py for more details.
-def test_unifrac_tree(ocx, api_data):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
+def test_unifrac_tree(samples):
     samples._classifications[0].results()["table"].append(
         {
             "abundance": None,

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -4,8 +4,7 @@ pytest.importorskip("pandas")  # noqa
 from skbio.tree import MissingNodeError
 
 
-def test_tree_generation(ocx, api_data):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
+def test_tree_generation(samples):
     tree = samples.tree_build()
     assert tree.has_children()
     assert tree.is_root()
@@ -13,9 +12,7 @@ def test_tree_generation(ocx, api_data):
     assert staph.tax_name == "Staphylococcus"
 
 
-def test_tree_pruning(ocx, api_data):
-    samples = ocx.Samples.where(project="4b53797444f846c4")
-
+def test_tree_pruning(samples):
     tree = samples.tree_build()
 
     # the species and genus nodes exist


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Added optional `secondary_haxis` parameter to `plot_metadata()`, which can be a field name or tuple of field names.

If provided, a grouped scatterplot or boxplot is generated, where `haxis` is the primary grouping and `secondary_haxis` is the secondary grouping. The secondary grouping is colored and includes a legend.

Closes DEV-9216

In the example below, `haxis="Cage"` and `secondary_haxis="Cohort"`:

<img width="759" alt="Screenshot 2024-02-14 at 2 23 43 PM" src="https://github.com/onecodex/onecodex/assets/1847232/6432ab95-c6c0-4796-a7ce-ae6edf2f1516">

## Related PRs
- [x] This PR is independent