### PR TITLE
Add beta diversity stats tests

### DIFF
--- a/onecodex/analyses.py
+++ b/onecodex/analyses.py
@@ -194,6 +194,7 @@ class AnalysisMixin(
                 # concatenate the columns together with underscores
                 composite_field = "_".join(f)
                 magic_metadata[composite_field] = ""
+
                 if coerce_missing_composite_fields:
                     magic_metadata[composite_field] = (
                         magic_metadata[composite_field]
@@ -218,6 +219,7 @@ class AnalysisMixin(
                         )
                         .str.lstrip("_")
                     )
+
                 magic_fields[f] = composite_field
             else:
                 str_f = str(f)

--- a/onecodex/lib/enums.py
+++ b/onecodex/lib/enums.py
@@ -107,6 +107,10 @@ class AlphaDiversityStatsTest(BaseEnum):
     Kruskal = "kruskal"
 
 
+class BetaDiversityStatsTest(BaseEnum):
+    Permanova = "permanova"
+
+
 class AnalysisType(BaseEnum):
     Classification = "classification"
     Functional = "functional"

--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -1,13 +1,26 @@
 from __future__ import annotations
-from dataclasses import dataclass
+import itertools
 import warnings
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 from onecodex.exceptions import OneCodexException, StatsException, StatsWarning
-from onecodex.lib.enums import Rank, AlphaDiversityMetric, AlphaDiversityStatsTest
+from onecodex.lib.enums import (
+    Rank,
+    AlphaDiversityMetric,
+    AlphaDiversityStatsTest,
+    BetaDiversityMetric,
+    BetaDiversityStatsTest,
+)
 
 if TYPE_CHECKING:
     import pandas as pd
+    import skbio
+
+
+# TODO when min Python version is >=3.10, create a base class with
+# @dataclass(frozen=True, kw_only=True) and have AlphaDiversityStatsResults and
+# BetaDiversityStatsResults inherit from it
 
 
 @dataclass(frozen=True)
@@ -15,10 +28,39 @@ class AlphaDiversityStatsResults:
     test: AlphaDiversityStatsTest
     statistic: float
     pvalue: float
+    sample_size: int
     group_by_variable: str
     groups: set[str]
     paired_by_variable: Optional[str] = None
-    posthoc_df: Optional[pd.DataFrame] = None
+    posthoc: Optional[PosthocResults] = None
+
+    @property
+    def posthoc_df(self) -> Optional[pd.DataFrame]:
+        warnings.warn(
+            "`posthoc_df` is deprecated and will be removed in a future release. Please use "
+            "`posthoc.adjusted_pvalues` instead.",
+            DeprecationWarning,
+        )
+        return self.posthoc.adjusted_pvalues if self.posthoc else None
+
+
+@dataclass(frozen=True)
+class BetaDiversityStatsResults:
+    test: BetaDiversityStatsTest
+    statistic: float
+    pvalue: float
+    num_permutations: int
+    sample_size: int
+    group_by_variable: str
+    groups: set[str]
+    posthoc: Optional[PosthocResults] = None
+
+
+@dataclass(frozen=True)
+class PosthocResults:
+    adjusted_pvalues: pd.DataFrame
+    pvalues: Optional[pd.DataFrame] = None
+    statistics: Optional[pd.DataFrame] = None
 
 
 class StatsMixin:
@@ -35,6 +77,7 @@ class StatsMixin:
         """Perform a test for significant differences between groups of alpha diversity values.
 
         The following tests are supported:
+
         - Wilcoxon (2 groups, paired data)
         - Mann-Whitney U (2 groups, unpaired data)
         - Kruskal-Wallis with optional posthoc Dunn test (>=2 groups, unpaired data)
@@ -45,9 +88,9 @@ class StatsMixin:
             Metadata variable to group samples by. At least two groups are required. If `group_by`
             is a tuple or list, field values are joined with an underscore character ("_").
         paired_by : str or tuple of str or list of str, optional
-            Metadata variable to pair samples in each group. May only be used with `test="wilcoxon"`.
-            If `paired_by` is a tuple or list, field values are joined with an underscore character
-            ("_").
+            Metadata variable to pair samples in each group. May only be used with
+            `test="wilcoxon"`. If `paired_by` is a tuple or list, field values are joined with an
+            underscore character ("_").
         test : {'auto', 'wilcoxon', 'mannwhitneyu', 'kruskal'}, optional
             Stats test to perform. If `'auto'`, `'mannwhitneyu'` will be chosen if there are two
             groups of unpaired data. `'wilcoxon'` will be chosen if there are two groups and
@@ -58,24 +101,26 @@ class StatsMixin:
         rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
             Analysis will be restricted to abundances of taxa at the specified level.
         alpha : float, optional
-            Threshold to determine statistical significance when `test="kruskal"` (e.g. p < `alpha`).
-            Must be between 0 and 1 (exclusive). If the Kruskal-Wallis p-value is significant and
-            there are more than two groups, a posthoc Dunn test is performed.
+            Threshold to determine statistical significance when `test="kruskal"`
+            (e.g. p < `alpha`). Must be between 0 and 1 (exclusive). If the Kruskal-Wallis p-value
+            is significant and there are more than two groups, a posthoc Dunn test is performed.
 
         Returns
         -------
         AlphaDiversityStatsResults
             A dataclass with these attributes:
-            - `test`: the stats test that was performed
-            - `statistic`: the computed test statistic (e.g. U statistic if `test="mannwhitneyu"`)
-            - `pvalue`: the computed p-value
-            - `group_by_variable`: the name of the variable used to group samples by
-            - `groups`: the names of the groups defined by `group_by_variable`
-            - `paired_by_variable`: the name of the variable used to pair samples by (if the data
-              were paired)
-            - `posthoc_df`: `pd.DataFrame` containing Dunn test p-values (if a Dunn test was
-              performed). p-values are adjusted for false discovery rate using Benjamini-Hochberg.
-              The index and columns are sorted group names.
+            - `test`: stats test that was performed
+            - `statistic`: computed test statistic (e.g. U statistic if `test="mannwhitneyu"`)
+            - `pvalue`: computed p-value
+            - `sample_size`: number of samples used in the test after filtering
+            - `group_by_variable`: name of the variable used to group samples by
+            - `groups`: names of the groups defined by `group_by_variable`
+            - `paired_by_variable`: name of the variable used to pair samples by (if the data were
+              paired)
+            - `posthoc`: A dataclass with these attributes (if posthoc results were computed):
+              - `adjusted_pvalues`: `pd.DataFrame` containing Dunn test *adjusted* p-values.
+                p-values are adjusted for false discovery rate using Benjamini-Hochberg. The index
+                and columns are sorted group names.
 
         See Also
         --------
@@ -85,8 +130,7 @@ class StatsMixin:
         scikit_posthocs.posthoc_dunn
 
         """
-        if not (0.0 < alpha < 1.0):
-            raise StatsException("`alpha` must be between 0 and 1 (exclusive).")
+        self._assert_valid_alpha(alpha)
 
         group_by = self._tuplize(group_by)
         metadata_fields = [group_by]
@@ -119,48 +163,24 @@ class StatsMixin:
             )
 
         # Drop samples with missing group_by data
-        prev_count = len(df)
-        df.dropna(subset=[group_by_column_name], inplace=True)
-        num_dropped = prev_count - len(df)
-        if num_dropped > 0:
-            warnings.warn(
-                f"{num_dropped} sample{'s were' if num_dropped > 1 else ' was'} excluded from the "
-                f"test as {'they were' if num_dropped > 1 else 'it was'} missing `group_by` "
-                f"metadata.",
-                StatsWarning,
-            )
+        df = self._drop_missing_data(df, group_by_column_name, "group_by")
 
         if paired_by_column_name:
             # Drop samples with missing paired_by data
-            prev_count = len(df)
-            df.dropna(subset=[paired_by_column_name], inplace=True)
-            num_dropped = prev_count - len(df)
-            if num_dropped > 0:
-                warnings.warn(
-                    f"{num_dropped} sample{'s were' if num_dropped > 1 else ' was'} excluded from "
-                    f"the test as {'they were' if num_dropped > 1 else 'it was'} missing "
-                    f"`paired_by` metadata.",
-                    StatsWarning,
-                )
+            df = self._drop_missing_data(df, paired_by_column_name, "paired_by")
+
+        # Drop samples missing abundance data
+        df = self._drop_classifications_without_abundances(df)
 
         # Drop groups of size < 2
-        prev_count = len(df)
-        df = df.groupby(group_by_column_name).filter(lambda group: len(group) > 1)
-        num_dropped = prev_count - len(df)
-        if num_dropped > 0:
-            warnings.warn(
-                f"{num_dropped} sample{'s were' if num_dropped > 1 else ' was'} excluded from the "
-                f"test as {'they' if num_dropped > 1 else 'it'} belonged to group(s) of size < 2.",
-                StatsWarning,
-            )
+        # NOTE: it's important to do this filtering *after* the other filters in case those filters
+        # change the group sizes.
+        df = self._drop_group_sizes_smaller_than(df, group_by_column_name, 2)
 
-        num_groups = df[group_by_column_name].nunique()
-        if num_groups < 2:
-            raise StatsException(
-                f"`group_by` must have at least two groups to test between after filtering (found {num_groups})."
-            )
+        self._assert_min_num_groups(df, group_by_column_name, 2)
 
         if test == AlphaDiversityStatsTest.Auto:
+            num_groups = df[group_by_column_name].nunique()
             if num_groups == 2:
                 if paired_by_column_name:
                     test = AlphaDiversityStatsTest.Wilcoxon
@@ -181,6 +201,95 @@ class StatsMixin:
         else:
             raise OneCodexException(f"Stats test {test} is not supported.")
 
+    def _assert_valid_alpha(self, alpha: float):
+        if not (0.0 < alpha < 1.0):
+            raise StatsException("`alpha` must be between 0 and 1 (exclusive).")
+
+    def _tuplize(self, value) -> tuple:
+        if not isinstance(value, tuple):
+            if isinstance(value, list):
+                # Convert to tuple so that it's hashable in self._metadata_fetch()
+                value = tuple(value)
+            else:
+                value = (value,)
+        return value
+
+    def _drop_missing_data(
+        self, df: pd.DataFrame, column_name: str, param_name: str
+    ) -> pd.DataFrame:
+        prev_count = len(df)
+        df = df.dropna(subset=[column_name])
+        num_dropped = prev_count - len(df)
+        if num_dropped > 0:
+            warnings.warn(
+                f"{num_dropped} sample{'s were' if num_dropped > 1 else ' was'} excluded from the "
+                f"test as {'they were' if num_dropped > 1 else 'it was'} missing `{param_name}` "
+                f"metadata.",
+                StatsWarning,
+            )
+        return df
+
+    def _drop_classifications_without_abundances(self, df: pd.DataFrame) -> pd.DataFrame:
+        prev_count = len(df)
+        df = df.drop(
+            [id_ for id_ in self._classification_ids_without_abundances if id_ in df.index]
+        )
+        num_dropped = prev_count - len(df)
+        if num_dropped > 0:
+            warnings.warn(
+                f"{num_dropped} sample{'s were' if num_dropped > 1 else ' was'} excluded from the "
+                f"test as {'they were' if num_dropped > 1 else 'it was'} missing abundance "
+                f"calculations.",
+                StatsWarning,
+            )
+        return df
+
+    def _drop_group_sizes_smaller_than(
+        self, df: pd.DataFrame, group_by_column_name: str, min_group_size: int
+    ) -> pd.DataFrame:
+        prev_count = len(df)
+        df = df.groupby(group_by_column_name).filter(lambda group: len(group) >= min_group_size)
+        num_dropped = prev_count - len(df)
+        if num_dropped > 0:
+            warnings.warn(
+                f"{num_dropped} sample{'s were' if num_dropped > 1 else ' was'} excluded from the "
+                f"test as {'they' if num_dropped > 1 else 'it'} belonged to group(s) of size < "
+                f"{min_group_size}.",
+                StatsWarning,
+            )
+        return df
+
+    def _assert_min_num_groups(
+        self, df: pd.DataFrame, group_by_column_name: str, min_num_groups: int
+    ):
+        num_groups = df[group_by_column_name].nunique()
+        if num_groups < min_num_groups:
+            raise StatsException(
+                f"`group_by` must have at least {min_num_groups} groups to test between after "
+                f"filtering (found {num_groups})."
+            )
+
+    def _assert_exact_num_groups(
+        self, df: pd.DataFrame, group_by_column_name: str, exact_num_groups: int
+    ):
+        num_groups = df[group_by_column_name].nunique()
+        if num_groups != exact_num_groups:
+            raise StatsException(
+                f"`group_by` must have exactly {exact_num_groups} groups to test between after "
+                f"filtering (found {num_groups})."
+            )
+
+    def _get_group_names_and_alpha_values(
+        self, df: pd.DataFrame, metric: str, group_by_column_name: str
+    ) -> tuple[set[str], list[pd.Series]]:
+        group_names = set()
+        group_alpha_values = []
+        for group_name, group_df in df.groupby(group_by_column_name):
+            group_names.add(group_name)
+            group_alpha_values.append(group_df[metric])
+
+        return group_names, group_alpha_values
+
     def _wilcoxon(
         self,
         df: pd.DataFrame,
@@ -193,12 +302,13 @@ class StatsMixin:
         if not paired_by_column_name:
             raise StatsException('`paired_by` must be specified with `test="wilcoxon"`.')
 
-        self._assert_two_groups(df, group_by_column_name)
+        self._assert_exact_num_groups(df, group_by_column_name, 2)
 
         (group1_name, group1_df), (group2_name, group2_df) = df.groupby(group_by_column_name)
         if len(group1_df) != len(group2_df):
             raise StatsException(
-                f"`group_by` must have two groups of the same size after filtering (found size {len(group1_df)} and size {len(group2_df)})."
+                f"`group_by` must have two groups of the same size after filtering "
+                f"(found size {len(group1_df)} and size {len(group2_df)})."
             )
 
         if group1_df[paired_by_column_name].nunique() != len(group1_df) or group2_df[
@@ -222,6 +332,7 @@ class StatsMixin:
             test=AlphaDiversityStatsTest.Wilcoxon,
             statistic=result.statistic,
             pvalue=result.pvalue,
+            sample_size=len(df),
             group_by_variable=group_by_column_name,
             groups={group1_name, group2_name},
             paired_by_variable=paired_by_column_name,
@@ -232,7 +343,7 @@ class StatsMixin:
     ) -> AlphaDiversityStatsResults:
         from scipy.stats import mannwhitneyu
 
-        self._assert_two_groups(df, group_by_column_name)
+        self._assert_exact_num_groups(df, group_by_column_name, 2)
 
         group_names, group_alpha_values = self._get_group_names_and_alpha_values(
             df, metric, group_by_column_name
@@ -243,6 +354,7 @@ class StatsMixin:
             test=AlphaDiversityStatsTest.Mannwhitneyu,
             statistic=result.statistic,
             pvalue=result.pvalue,
+            sample_size=len(df),
             group_by_variable=group_by_column_name,
             groups=group_names,
         )
@@ -258,44 +370,195 @@ class StatsMixin:
         )
         result = kruskal(*group_alpha_values)
 
-        posthoc_df = None
+        posthoc = None
         if result.pvalue < alpha and len(group_names) > 2:
-            posthoc_df = posthoc_dunn(
-                df, val_col=metric, group_col=group_by_column_name, p_adjust="fdr_bh"
+            posthoc = PosthocResults(
+                adjusted_pvalues=posthoc_dunn(
+                    df, val_col=metric, group_col=group_by_column_name, p_adjust="fdr_bh"
+                )
             )
 
         return AlphaDiversityStatsResults(
             test=AlphaDiversityStatsTest.Kruskal,
             statistic=result.statistic,
             pvalue=result.pvalue,
+            sample_size=len(df),
             group_by_variable=group_by_column_name,
             groups=group_names,
-            posthoc_df=posthoc_df,
+            posthoc=posthoc,
         )
 
-    def _tuplize(self, value) -> tuple:
-        if not isinstance(value, tuple):
-            if isinstance(value, list):
-                # Convert to tuple so that it's hashable in self._metadata_fetch()
-                value = tuple(value)
-            else:
-                value = (value,)
-        return value
+    def beta_diversity_stats(
+        self,
+        *,
+        group_by: str | tuple[str, ...] | list[str],
+        metric: BetaDiversityMetric = BetaDiversityMetric.BrayCurtis,
+        rank: Rank = Rank.Auto,
+        alpha: float = 0.05,
+        num_permutations: int = 999,
+    ) -> BetaDiversityStatsResults:
+        """Test for significant differences between groups of samples based on their distances.
 
-    def _assert_two_groups(self, df: pd.DataFrame, group_by_column_name: str):
-        num_groups = df[group_by_column_name].nunique()
-        if num_groups != 2:
-            raise StatsException(
-                f"`group_by` must have exactly two groups to test between after filtering (found {num_groups})."
+        Beta diversity distances between samples are computed and a PERMANOVA test is performed to
+        assess whether there are significant differences between groups of samples. Posthoc pairwise
+        PERMANOVA tests are performed if the global test is found to be statistically significant
+        and there are more than two groups.
+
+        Parameters
+        ----------
+        group_by : str or tuple of str or list of str
+            Metadata variable to group samples by. At least two groups are required. If `group_by`
+            is a tuple or list, field values are joined with an underscore character ("_").
+        metric : {'braycurtis', 'jaccard', 'cityblock', 'manhattan', 'aitchison', 'unweighted_unifrac', 'weighted_unifrac'}, optional
+            The beta diversity distance metric to calculate. Note that 'cityblock' and 'manhattan'
+            are equivalent metrics.
+        rank : {'auto', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'}, optional
+            Analysis will be restricted to abundances of taxa at the specified level.
+        alpha : float, optional
+            Threshold to determine statistical significance (e.g. p < `alpha`). Must be between 0
+            and 1 (exclusive). If the p-value is significant and there are more than two groups,
+            posthoc pairwise PERMANOVA tests are performed.
+        num_permutations : int, optional
+            Number of permutations to use when computing the p-value.
+
+        Returns
+        -------
+        BetaDiversityStatsResults
+            A dataclass with these attributes:
+            - `test`: stats test that was performed
+            - `statistic`: PERMANOVA pseudo-F test statistic
+            - `pvalue`: p-value based on `num_permutations`
+            - `num_permutations`: number of permutations used to compute `pvalue`
+            - `sample_size`: number of samples used in the test after filtering
+            - `group_by_variable`: name of the variable used to group samples by
+            - `groups`: names of the groups defined by `group_by_variable`
+            - `posthoc`: A dataclass with these attributes (if posthoc results were computed):
+              - `statistics`: `pd.DataFrame` containing pairwise PERMANOVA pseudo-F statistics. The
+                index and columns are sorted group names.
+              - `pvalues`: `pd.DataFrame` containing pairwise PERMANOVA *unadjusted* p-values. The
+                index and columns are sorted group names.
+              - `adjusted_pvalues`: `pd.DataFrame` containing pairwise PERMANOVA *adjusted*
+                p-values. p-values are adjusted for false discovery rate using Benjamini-Hochberg.
+                The index columns are sorted group names.
+
+        See Also
+        --------
+        skbio.stats.distance.permanova
+        scipy.stats.false_discovery_control
+
+        """
+        self._assert_valid_alpha(alpha)
+
+        # Munge the metadata first in case there's any errors
+        group_by = self._tuplize(group_by)
+        metadata_results = self._metadata_fetch([group_by], coerce_missing_composite_fields=False)
+        df = metadata_results.df
+        magic_fields = metadata_results.renamed_fields
+        group_by_column_name = magic_fields[group_by]
+
+        # Drop samples with missing group_by data
+        df = self._drop_missing_data(df, group_by_column_name, "group_by")
+
+        # Drop samples missing abundance data
+        df = self._drop_classifications_without_abundances(df)
+
+        # Drop groups of size < 2
+        # NOTE: it's important to do this filtering *after* the other filters in case those filters
+        # change the group sizes.
+        df = self._drop_group_sizes_smaller_than(df, group_by_column_name, 2)
+
+        self._assert_min_num_groups(df, group_by_column_name, 2)
+
+        # Compute beta diversity distance matrix and filter it to match the remaining IDs in the
+        # metadata dataframe
+        dm = self.beta_diversity(metric=metric, rank=rank).filter(df.index, strict=True)
+
+        return self._permanova(dm, df, group_by_column_name, alpha, num_permutations)
+
+    def _permanova(
+        self,
+        dm: skbio.DistanceMatrix,
+        df: pd.DataFrame,
+        group_by_column_name: str,
+        alpha: float,
+        num_permutations: int,
+    ) -> BetaDiversityStatsResults:
+        import numpy as np
+        import pandas as pd
+        from scipy.stats import false_discovery_control
+        from skbio.stats.distance import permanova
+
+        group_names = {name for name, _ in df.groupby(group_by_column_name)}
+        result = permanova(dm, df, column=group_by_column_name, permutations=num_permutations)
+
+        posthoc = None
+        if result["p-value"] < alpha and result["number of groups"] > 2:
+            # Compute PERMANOVA for each pair of groups. Assuming we have groups "g1", "g2", "g3",
+            # we'll run PERMANOVA 3 times: g1 vs g2, g1 vs g3, g2 vs g3. We'll store the results in
+            # a 2D matrix ordered by sorted group names. Since results are symmetric and we don't
+            # need to compute the diagonal (e.g. g1 vs g1), we can just compute the upper triangle
+            # in row-major order:
+            #
+            #   g1  g2  g3
+            # g1 x   1   2
+            # g2 x   x   3
+            # g3 x   x   x
+            group_names = sorted(group_names)
+            upper_triangle_statistics = []
+            upper_triangle_pvalues = []
+            for group1, group2 in itertools.combinations(group_names, 2):
+                pairwise_dm = dm.filter(
+                    df[
+                        (df[group_by_column_name] == group1) | (df[group_by_column_name] == group2)
+                    ].index,
+                    strict=True,
+                )
+                # The dataframe can be a superset of the distance matrix and the IDs don't need
+                # to be in the same order.
+                pairwise_result = permanova(
+                    pairwise_dm, df, column=group_by_column_name, permutations=num_permutations
+                )
+                assert pairwise_result["number of groups"] == 2
+
+                upper_triangle_statistics.append(pairwise_result["test statistic"])
+                upper_triangle_pvalues.append(pairwise_result["p-value"])
+
+            num_groups = len(group_names)
+            shape = (num_groups, num_groups)
+            upper_triangle_indices = np.triu_indices(num_groups, k=1)
+
+            statistics = np.zeros(shape, dtype=float)
+            statistics[upper_triangle_indices] = upper_triangle_statistics
+            statistics += statistics.T
+            np.fill_diagonal(statistics, np.nan)
+
+            pvalues = np.zeros(shape, dtype=float)
+            pvalues[upper_triangle_indices] = upper_triangle_pvalues
+            pvalues += pvalues.T
+            np.fill_diagonal(pvalues, 1.0)
+
+            adjusted_pvalues = np.zeros(shape, dtype=float)
+            adjusted_pvalues[upper_triangle_indices] = false_discovery_control(
+                upper_triangle_pvalues, method="bh"
+            )
+            adjusted_pvalues += adjusted_pvalues.T
+            np.fill_diagonal(adjusted_pvalues, 1.0)
+
+            posthoc = PosthocResults(
+                statistics=pd.DataFrame(statistics, index=group_names, columns=group_names),
+                pvalues=pd.DataFrame(pvalues, index=group_names, columns=group_names),
+                adjusted_pvalues=pd.DataFrame(
+                    adjusted_pvalues, index=group_names, columns=group_names
+                ),
             )
 
-    def _get_group_names_and_alpha_values(
-        self, df: pd.DataFrame, metric: str, group_by_column_name: str
-    ) -> tuple[set[str], list[pd.Series]]:
-        group_names = set()
-        group_alpha_values = []
-        for group_name, group_df in df.groupby(group_by_column_name):
-            group_names.add(group_name)
-            group_alpha_values.append(group_df[metric])
-
-        return group_names, group_alpha_values
+        return BetaDiversityStatsResults(
+            test=BetaDiversityStatsTest.Permanova,
+            statistic=result["test statistic"],
+            pvalue=result["p-value"],
+            num_permutations=result["number of permutations"],
+            sample_size=result["sample size"],
+            group_by_variable=group_by_column_name,
+            groups=group_names,
+            posthoc=posthoc,
+        )

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -368,8 +368,22 @@ class VizDistanceMixin(DistanceMixin):
                 "There are too few samples for MDS/PCoA after filtering. Please select 3 or more "
                 "samples to plot."
             )
+        elif len(self._results) - len(self._classification_ids_without_abundances) < 3:
+            raise PlottingException(
+                "There are too few samples for MDS/PCoA after filtering out samples with no "
+                "abundances calculated; please select 3 or more samples to plot."
+            )
 
-        dists = self._compute_distance(rank, metric).to_data_frame()
+        dists = self._compute_distance(
+            rank, metric, exclude_classifications_without_abundances=True
+        ).to_data_frame()
+
+        if self._classification_ids_without_abundances:
+            warnings.warn(
+                f"{len(self._classification_ids_without_abundances)} sample(s) have no abundances "
+                f"calculated and have been omitted from the MDS/PCoA plot.",
+                PlottingWarning,
+            )
 
         # here we figure out what to put in the tooltips and get the appropriate data
         if tooltip:

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -327,6 +327,19 @@ def test_plot_pca_color_by_field_with_nans(samples):
     assert_expected_color_scale_range_len(chart, 1)
 
 
+def test_plot_pca_missing_abundances(ocx, api_data, samples):
+    sample1 = ocx.Samples.get("cc18208d98ad48b3")
+    sample2 = ocx.Samples.get("5445740666134eee")
+    samples.extend([sample1, sample2])
+
+    samples._results.loc[samples[1].primary_classification.id] = np.nan
+    samples._results.loc[samples[3].primary_classification.id] = np.nan
+    assert len(samples._classification_ids_without_abundances) == 2
+
+    with pytest.warns(PlottingWarning, match=r"2 sample\(s\) have no abundances calculated"):
+        samples.plot_pca(return_chart=True)
+
+
 def test_plot_pca_exceptions(samples):
     # expect error if rank is None, since that could lead to weird results
     with pytest.raises(OneCodexException) as e:
@@ -654,6 +667,19 @@ def test_plot_mds_color_by_field_with_nans(samples):
     assert_expected_legend_title(chart, "name")
     assert_expected_color_scale_domain_len(chart, 3)
     assert_expected_color_scale_range_len(chart, 1)
+
+
+def test_plot_mds_missing_abundances(ocx, api_data, samples):
+    sample1 = ocx.Samples.get("cc18208d98ad48b3")
+    sample2 = ocx.Samples.get("5445740666134eee")
+    samples.extend([sample1, sample2])
+
+    samples._results.loc[samples[1].primary_classification.id] = np.nan
+    samples._results.loc[samples[3].primary_classification.id] = np.nan
+    assert len(samples._classification_ids_without_abundances) == 2
+
+    with pytest.warns(PlottingWarning, match=r"2 sample\(s\) have no abundances calculated"):
+        samples.plot_mds(return_chart=True)
 
 
 def test_plot_pcoa(samples):


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Added PERMANOVA test for significant differences between groups of samples based on their beta diversity distances.

Posthoc pairwise PERMANOVA tests are performed if the global test is found to be statistically significant and there are more than two groups.

The tests are run via `SampleCollection.beta_diversity_stats()`.

Samples with missing abundances are filtered out (with a warning) in:

- `plot_pcoa()`
- `plot_mds()`
- `plot_pca()`
- `alpha_diversity_stats()`
- `beta_diversity_stats()`

Deprecated `AlphaDiversityStatsResults.posthoc_df` in favor of `AlphaDiversityStatsResults.posthoc.adjusted_pvalues`.

Closes DEV-9248

## Related PRs
- [x] This PR is independent