### PR TITLE
Do not close file_obj in download

### DIFF
--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -118,6 +118,17 @@ def test_download_with_progressbar(runner, ocx, api_data):
     doc.download(file_obj=file_obj, progressbar=True)
 
 
+def test_download_file_obj(ocx, api_data):
+    file_obj = io.BytesIO()
+    doc = ocx.Documents.get("a4f6727a840a4df0")
+    doc.download(file_obj=file_obj)
+
+    file_obj.seek(0)
+    data = file_obj.read()
+
+    assert data == b'"1234567890"'
+
+
 def test_resourcelist(ocx, api_data):
     sample = ocx.Samples.get("761bc54b97f64980")
     tags1 = onecodex.models.ResourceList(sample.tags._resource, onecodex.models.misc.Tags)


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description

It is not currently possible to use `file_obj` with download because it gets closed by a context manager.

```python
buff = io.BytesIO()
sample.download(file_obj=buff)

buff.seek(0) # ValueError: I/O operation on closed file.
```

This PR does not close `file_obj` making it possible to read from the buffer.

## Related PRs

- [x] This PR is independent

## TODOs

- [x] Tests
