### PR TITLE
Bugfix: Metadata resource was trying to update "updated_at" 

### DIFF
--- a/onecodex/models/sample.py
+++ b/onecodex/models/sample.py
@@ -317,6 +317,6 @@ class Metadata(OneCodexBase):
             if "sample" in ref_props or "$uri" in ref_props:  # May not be there if not resolved!
                 ref_props.pop("$uri", None)
                 ref_props.pop("sample", None)
-                self._resource._update(ref_props)
+                self._resource._update(**ref_props)
             else:
                 super(Metadata, self).save()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def mock_requests(mock_json):
                 rsps.add(
                     method, compiled_url, body=json.dumps(mock_data), content_type=content_type
                 )
-        yield
+        yield rsps
 
 
 def _make_callback_resp(data, status_code=200):
@@ -394,8 +394,8 @@ API_DATA.update(SCHEMA_ROUTES)
 
 @pytest.yield_fixture(scope="function")
 def api_data():
-    with mock_requests(API_DATA):
-        yield
+    with mock_requests(API_DATA) as rsps:
+        yield rsps
 
 
 @pytest.yield_fixture(scope="function")

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
 import datetime
 import io
-import pytest
+import json
 import mock
+import pytest
 import responses
 import sys
 
@@ -289,6 +290,17 @@ def test_metadata_saving(ocx, api_data):
     assert isinstance(metadata1.date_collected, datetime.datetime)
     assert metadata1.description == "my new description -- testing!"
     assert hasattr(metadata1, "sample")  # This will fail because we don't mock it in the return
+
+
+def test_metadata_saving_should_ignore_updated_at_prop(ocx, api_data):
+    m = ocx.Metadata.get("4fe05e748b5a4f0e")
+    m.custom["foobar"] = "baz"
+    m.save()
+    patch_request = api_data.calls[-1].request
+    assert patch_request.method == "PATCH"
+    patch_data = json.loads(patch_request.body)
+    assert "custom" in patch_data
+    assert "updated_at" not in patch_data
 
 
 def test_dir_patching(ocx, api_data):


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description

`Metadata` resource has a custom logic to handle updating. The way a request data was passed to the `_update` before would make `LinkBinding.request_factory` to just call PATCH with that data. Passing request data as kwargs would make `LinkBinding.request_factory` to actually filter some props (including `updated_at`) away using `can_include_property`.

## Related PRs
- [x] This PR is independent
