### PR TITLE
scikit-bio 0.6 was released and now tests are failing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ ALL_DEPS = [
     "numpy>=1.11.0",
     "pandas>=1.0.3",
     "pillow>=9.0.1",
-    "scikit-bio>=0.5.8",
+    "scikit-bio==0.5.9",
     "scikit-learn>=0.19.0",
     "scikit-posthocs",
     "scipy",


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description

https://github.com/scikit-bio/scikit-bio/blob/main/CHANGELOG.md#version-060

Let's pin it to `0.5.9` so tests will start to pass again and only then let's figure it out if we can upgrade to `0.6.0`. Or maybe let's wait for `0.6.1`.

## Related PRs
- [x] This PR is independent
