### PR TITLE
Add Python 3.12 and scikit-bio 0.6.0 support

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies in a venv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]  # , windows-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install dependencies in a venv
         run: |
           python3 -m venv venv
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Set Up Node
         uses: actions/setup-node@v1
         with:
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install dependencies in a venv
         run: |
           python3 -m venv venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.1.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/pydocstyle

--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -173,7 +173,7 @@ class DistanceMixin(TaxonomyMixin):
                 df,
                 df.index,
                 tree=new_tree,
-                otu_ids=tax_ids,
+                taxa=tax_ids,
                 normalized=True,
             )
         else:
@@ -182,7 +182,7 @@ class DistanceMixin(TaxonomyMixin):
                 df,
                 df.index,
                 tree=new_tree,
-                otu_ids=tax_ids,
+                taxa=tax_ids,
             )
 
     def aitchison_distance(self, rank=Rank.Auto):

--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,13 @@ TESTING_DEPS = [
 ]
 ALL_DEPS = [
     "altair==4.2.2",  # altair_saver doesn't support altair 5
-    "numpy>=1.11.0",
+    "numpy>=1.21.6",
     "pandas>=1.0.3",
     "pillow>=9.0.1",
-    "scikit-bio==0.5.9",
+    "scikit-bio==0.6.0",
     "scikit-learn>=0.19.0",
     "scikit-posthocs",
-    "scipy",
+    "scipy>=1.11.0",
     "jupyter-client==8.6.0",
 ]
 REPORT_DEPS = ALL_DEPS + [
@@ -103,6 +103,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     entry_points={
         "console_scripts": ["onecodex = onecodex.cli:onecodex"],

--- a/tests/test_metadata_upload.py
+++ b/tests/test_metadata_upload.py
@@ -205,7 +205,7 @@ def test_is_blacklisted_invalid():
 def test_coerce_custom_value_float():
     custom_value = coerce_custom_value("42")
     assert custom_value == 42.0
-    assert type(custom_value) == float
+    assert type(custom_value) is float
 
 
 def test_coerce_custom_value_truthy():


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Added Python 3.12 and scikit-bio 0.6.0 support. Bumped minimum scipy version to 1.11.0 and numpy version to 1.21.6.

Closes DEV-8899
Closes DEV-9415

## Related PRs
- [x] This PR is independent