### PR TITLE
Bugfix: undefined behavior if one of metadata columns is the same as magic/special df columns

### DIFF
--- a/onecodex/viz/_functional.py
+++ b/onecodex/viz/_functional.py
@@ -138,9 +138,7 @@ class VizFunctionalHeatmapMixin(object):
             value_name="value",
         )
         # It is helpful to have function_id and function_name not just one of them
-        df[function_name_column] = pd.Series(
-            [get_feature_name(x) for x in df[function_id_column]]
-        )
+        df[function_name_column] = pd.Series([get_feature_name(x) for x in df[function_id_column]])
 
         column_kwargs = {}
         if haxis:

--- a/onecodex/viz/_primitives.py
+++ b/onecodex/viz/_primitives.py
@@ -142,3 +142,22 @@ def dendrogram(tree):
     )
 
     return chart
+
+
+def get_unique_column(preferred_name, existing_columns):
+    """Generates a unique column name
+
+    Parameters
+    ----------
+    preferred_name : `str`
+        Starting point. Returns this if it does not collide with `existing_columns`.
+    existing_columns : `list`
+
+    Returns
+    -------
+    `str`
+    """
+    result = preferred_name
+    while result in existing_columns:
+        result = "_" + result
+    return result

--- a/onecodex/viz/_primitives.py
+++ b/onecodex/viz/_primitives.py
@@ -145,7 +145,7 @@ def dendrogram(tree):
 
 
 def get_unique_column(preferred_name, existing_columns):
-    """Generates a unique column name
+    """Generate a unique column name.
 
     Parameters
     ----------

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -871,5 +871,5 @@ def test_plot_functional_heatmap_when_metadata_contains_function_id(ocx_experime
     assert set(chart.data["function_name"]) == {
         "[MF] single-stranded DNA endodeoxyribonuclease activity",
         "[CC] phosphopyruvate hydratase complex",
-        "[BP] ribosomal large subunit assembly"
+        "[BP] ribosomal large subunit assembly",
     }


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description

Sometimes a metadata column would override a hardcoded column but sometimes hardcoded column would override a metadata column. A true undefined behaviour. I've fixed it by introduced a unique name generator. Which is fancy for just prefixing a name with `_` until it is unique.

## Related PRs
- [x] This PR is independent