### PR TITLE
Handle no abundances calculated for any samples in plot_heatmap()

### DIFF
--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -105,6 +105,11 @@ class VizHeatmapMixin(object):
                 "There are too few samples for heatmap plots after filtering. Please select 2 or "
                 "more samples to plot."
             )
+        elif len(self._results) - len(self._all_nan_classification_ids) <= 0:
+            raise PlottingException(
+                "Abundances are not calculated for any of the selected samples. Please select a "
+                "different metric or a different set of samples to plot."
+            )
 
         if top_n == "auto" and threshold == "auto":
             top_n = 10

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -375,6 +375,14 @@ def test_plot_heatmap_with_haxis_two_cluster_groups(ocx, api_data, samples):
     samples.plot_heatmap(rank="genus", top_n=15, haxis="wheat", return_chart=True)
 
 
+def test_plot_heatmap_all_samples_are_nan(ocx, api_data, samples):
+    samples._results[:] = np.nan
+    assert len(samples._all_nan_classification_ids) == 3
+
+    with pytest.raises(PlottingException, match="Abundances are not calculated for any"):
+        samples.plot_heatmap(top_n=10, return_chart=True)
+
+
 def test_plot_distance_excludes_all_nan_clustering_helper_called_with(ocx, api_data, samples):
     sample1 = ocx.Samples.get("cc18208d98ad48b3")
     sample2 = ocx.Samples.get("5445740666134eee")


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
`plot_heatmap()` now raises `PlottingException` with an informative error message if abundances are not calculated for any of the selected samples. Previously, a cryptic `ValueError` was raised within the clustering code.

Closes DEV-9327

## Related PRs
- [x] This PR is independent