### PR TITLE
Include taxonomic lineages in BIOM exports

### DIFF
--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -657,7 +657,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
         for tax_id in sorted(rows):
             row_id = len(otu["rows"])
             tax_node = root.find(tax_id)
-            lineage = ([tax_node] + tax_node.ancestors())[::-1]
+            lineage = tax_node.ancestors() + [tax_node]
 
             rank_to_name = {n.rank: n.tax_name for n in lineage}
 

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -643,7 +643,7 @@ class SampleCollection(ResourceList, AnalysisMixin):
 
                 # only keep canonical rows (e.g., don't include things like
                 # "root" in the OTU table)
-                if tax_node.rank not in CANONICAL_RANKS:
+                if tax_node.rank not in include_ranks:
                     continue
 
                 rows[tax_id][col_id] = int(row[1][Metric.Readcount])

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -618,8 +618,6 @@ class SampleCollection(ResourceList, AnalysisMixin):
 
         self._collate_results(include_host=True)  # make sure 9606 is in the taxonomy
 
-        ordered_column_ids = []
-
         root = self.tree_build()
         for classification in self._classifications:
             col_id = len(otu["columns"])  # 0 index
@@ -639,8 +637,6 @@ class SampleCollection(ResourceList, AnalysisMixin):
             otu["columns"].append(columns_entry)
             sample_df = classification.table()
 
-            ordered_column_ids.append(col_id)
-
             for row in sample_df.iterrows():
                 tax_id = row[1]["tax_id"]
                 tax_node = root.find(tax_id)
@@ -651,9 +647,6 @@ class SampleCollection(ResourceList, AnalysisMixin):
                     continue
 
                 rows[tax_id][col_id] = int(row[1][Metric.Readcount])
-
-        # paranoid check that there are no repeated column IDs
-        assert len(set(ordered_column_ids)) == len(ordered_column_ids)
 
         num_rows = len(rows)
         num_cols = len(otu["columns"])

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -616,6 +616,8 @@ class SampleCollection(ResourceList, AnalysisMixin):
 
         rows = defaultdict(dict)
 
+        self._collate_results(include_host=True)  # make sure 9606 is in the taxonomy
+
         ordered_column_ids = []
 
         root = self.tree_build()
@@ -659,7 +661,8 @@ class SampleCollection(ResourceList, AnalysisMixin):
         otu["shape"] = [num_rows, num_cols]
         otu["data"] = []
 
-        for row_id, tax_id in enumerate(sorted(rows.keys())):
+        for tax_id in sorted(rows):
+            row_id = len(otu["rows"])
             tax_node = root.find(tax_id)
             lineage = ([tax_node] + tax_node.ancestors())[::-1]
 
@@ -671,8 +674,8 @@ class SampleCollection(ResourceList, AnalysisMixin):
 
             otu["rows"].append({"id": tax_id, "metadata": {"taxonomy": canonical_names}})
 
-            for col_id in ordered_column_ids:
-                counts = rows[tax_id][col_id]
-                otu["data"].append([row_id, col_id, counts])
+            for sample_with_hit in rows[tax_id]:
+                counts = rows[tax_id][sample_with_hit]
+                otu["data"].append([row_id, sample_with_hit, counts])
 
         return otu

--- a/onecodex/models/collection.py
+++ b/onecodex/models/collection.py
@@ -16,6 +16,17 @@ except ImportError:
 
 from onecodex.models import OneCodexBase, ResourceList
 
+CANONICAL_RANKS = (
+    "superkingdom",
+    "kingdom",
+    "phylum",
+    "class",
+    "order",
+    "family",
+    "genus",
+    "species",
+)
+
 
 class SampleCollection(ResourceList, AnalysisMixin):
     """A collection of `Samples` or `Classifications` objects.
@@ -565,13 +576,18 @@ class SampleCollection(ResourceList, AnalysisMixin):
             self._cached[feature_map_key] = feature_map
         return self._cached[result_key], self._cached[feature_map_key]
 
-    def to_otu(self, biom_id=None):
-        """Transform a list of Classifications objects into a `dict` resembling an OTU table.
+    def to_otu(self, biom_id=None, include_ranks=CANONICAL_RANKS):
+        """
+        Generate a BIOM-formatted data structure.
 
         Parameters
         ----------
         biom_id : string, optional
             Optionally specify an `id` field for the generated v1 BIOM file.
+
+        include_ranks : list
+            A list of ranks to include in the taxonomy/OTU table. Uses
+            onecodex.models.collection.CANONICAL_RANKS by default.
 
         Returns
         -------
@@ -600,7 +616,9 @@ class SampleCollection(ResourceList, AnalysisMixin):
 
         rows = defaultdict(dict)
 
-        tax_ids_to_names = {}
+        ordered_column_ids = []
+
+        root = self.tree_build()
         for classification in self._classifications:
             col_id = len(otu["columns"])  # 0 index
 
@@ -619,10 +637,21 @@ class SampleCollection(ResourceList, AnalysisMixin):
             otu["columns"].append(columns_entry)
             sample_df = classification.table()
 
+            ordered_column_ids.append(col_id)
+
             for row in sample_df.iterrows():
                 tax_id = row[1]["tax_id"]
-                tax_ids_to_names[tax_id] = row[1]["name"]
+                tax_node = root.find(tax_id)
+
+                # only keep canonical rows (e.g., don't include things like
+                # "root" in the OTU table)
+                if tax_node.rank not in CANONICAL_RANKS:
+                    continue
+
                 rows[tax_id][col_id] = int(row[1][Metric.Readcount])
+
+        # paranoid check that there are no repeated column IDs
+        assert len(set(ordered_column_ids)) == len(ordered_column_ids)
 
         num_rows = len(rows)
         num_cols = len(otu["columns"])
@@ -630,15 +659,20 @@ class SampleCollection(ResourceList, AnalysisMixin):
         otu["shape"] = [num_rows, num_cols]
         otu["data"] = []
 
-        for present_taxa in sorted(rows):
-            # add the row entry
-            row_id = len(otu["rows"])
-            otu["rows"].append(
-                {"id": present_taxa, "metadata": {"taxonomy": tax_ids_to_names[present_taxa]}}
-            )
+        for row_id, tax_id in enumerate(sorted(rows.keys())):
+            tax_node = root.find(tax_id)
+            lineage = ([tax_node] + tax_node.ancestors())[::-1]
 
-            for sample_with_hit in rows[present_taxa]:
-                counts = rows[present_taxa][sample_with_hit]
-                otu["data"].append([row_id, sample_with_hit, counts])
+            rank_to_name = {n.rank: n.tax_name for n in lineage}
+
+            canonical_names = []
+            for rank in CANONICAL_RANKS:
+                canonical_names.append(rank_to_name.get(rank, ""))
+
+            otu["rows"].append({"id": tax_id, "metadata": {"taxonomy": canonical_names}})
+
+            for col_id in ordered_column_ids:
+                counts = rows[tax_id][col_id]
+                otu["data"].append([row_id, col_id, counts])
 
         return otu

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,15 @@ API_DATA = {
         "table": [
             {
                 "abundance": None,
+                "name": "root",
+                "parent_tax_id": None,
+                "rank": "no rank",
+                "readcount": 0,
+                "readcount_w_children": 3,
+                "tax_id": "1",
+            },
+            {
+                "abundance": None,
                 "name": "Staphylococcus",
                 "parent_tax_id": "1",
                 "rank": "genus",
@@ -162,6 +171,15 @@ API_DATA = {
     },
     "GET::api/v1/classifications/593601a797914cbf/results": {
         "table": [
+            {
+                "abundance": None,
+                "name": "root",
+                "parent_tax_id": None,
+                "rank": "no rank",
+                "readcount": 0,
+                "readcount_w_children": 3,
+                "tax_id": "1",
+            },
             {
                 "abundance": None,
                 "name": "Staphylococcus",

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -64,20 +64,40 @@ def test_biom(ocx, api_data):
     assert "taxonomy" in biom["rows"][0]["metadata"]
 
     # IDs
+    assert len(biom["columns"]) == 2
+
     assert biom["columns"][0]["id"] == c1.id
     assert biom["columns"][0]["sample_id"] == c1.sample.id
 
     # Reults
-    assert set(row["metadata"]["taxonomy"] for row in biom["rows"]) == {
-        "Staphylococcus sp. HGB0015",
-        "Staphylococcus",
-    }
+    assert len(biom["rows"]) == 2
 
-    # Format is row_id, sample id (column), count
-    assert biom["data"][0] == [0, 0, 3]
-    assert biom["data"][1] == [0, 1, 80]
-    assert biom["data"][2] == [1, 0, 0]
-    assert biom["data"][3] == [1, 1, 0]
+    assert biom["rows"][0]["metadata"]["taxonomy"] == [
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "Staphylococcus",
+        "Staphylococcus sp. HGB0015",
+    ]
+    assert biom["rows"][1]["metadata"]["taxonomy"] == [
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "Staphylococcus",
+        "",
+    ]
+
+    # make sure data is the correct shape
+    assert [len(x) for x in biom["data"]] == [3, 3, 3, 3]
+
+    # Format is row_id, sample id (column), count (sparse)
+    assert biom["data"] == [[0, 0, 3], [0, 1, 80], [1, 0, 0], [1, 1, 0]]
     assert biom["rows"][0]["id"] == "1078083"
     assert biom["rows"][1]["id"] == "1279"
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -97,7 +97,10 @@ def test_biom(ocx, api_data):
     assert [len(x) for x in biom["data"]] == [3, 3, 3, 3]
 
     # Format is row_id, sample id (column), count (sparse)
-    assert biom["data"] == [[0, 0, 3], [0, 1, 80], [1, 0, 0], [1, 1, 0]]
+    assert biom["data"][0] == [0, 0, 3]
+    assert biom["data"][1] == [0, 1, 80]
+    assert biom["data"][2] == [1, 0, 0]
+    assert biom["data"][3] == [1, 1, 0]
     assert biom["rows"][0]["id"] == "1078083"
     assert biom["rows"][1]["id"] == "1279"
 


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

- Include canonical taxonomic lineage in BIOM export

From One Codex to BIOM file:

```python
#!/usr/bin/env python3

import onecodex
import json

ocx = onecodex.Api()

# PRJNA692319: Metagenomic research in tundra Soils in Maritime Antarctica
proj = ocx.Projects.get("5e3ca50f0a8c4354")

samples = ocx.Samples.where(project=proj)

print(f"fetched {len(samples)} samples")

assert samples.taxonomy is not None

with open("tundra.biom", "w") as handle:
    json.dump(fp=handle, obj=samples.to_otu())

```

Load & plot BIOM file in Phyloseq

```R
#!/usr/bin/env Rscript

library(phyloseq)
library(magrittr)

phy <- import_biom('tundra.biom')

phy %>%
  transform_sample_counts(function(x) x/sum(x)) %>%
  prune_taxa(taxa_sums(.) > 0.03, .) %>%
  tax_glom('Rank7') %>%
  plot_bar(fill='Rank7')
```
<img width="913" alt="Screenshot 2024-05-03 at 3 21 58 PM" src="https://github.com/onecodex/onecodex/assets/115904/4cf8f761-7fa0-449d-8739-33110ff26e36">

## Related PRs
- [x] This PR is independent

## TODOs

- [x] Tests
