### PR TITLE
Fix calculation when all samples lack abundance estimates

### DIFF
--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -170,6 +170,9 @@ class VizBargraphMixin(object):
             df = df.loc[:, df.mean().sort_values(ascending=False).iloc[:top_n].index]
 
         if include_other and normalize:
+            # if there are no abundances in the dataframe, df.apply will yield a single column
+            # that has `None` as its name. Therefore, we must check if column.name is None AND
+            # whether or not the column name is in empty_rows
             df["Other"] = df.apply(
                 lambda row: 0.0 if (row.name is None or row.name in empty_rows) else 1 - row.sum(),
                 axis=1,

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -172,7 +172,7 @@ class VizBargraphMixin(object):
         if include_other and normalize:
             # if there are no abundances in the dataframe, df.apply will yield
             # a single item that has `None` as its name. Therefore, we must
-            # check if row.name is None AND whether or not the column name is
+            # check if row.name is None AND whether or not the row name is
             # in empty_rows
             df["Other"] = df.apply(
                 lambda row: 0.0 if (row.name is None or row.name in empty_rows) else 1 - row.sum(),

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -170,9 +170,10 @@ class VizBargraphMixin(object):
             df = df.loc[:, df.mean().sort_values(ascending=False).iloc[:top_n].index]
 
         if include_other and normalize:
-            # if there are no abundances in the dataframe, df.apply will yield a single column
-            # that has `None` as its name. Therefore, we must check if column.name is None AND
-            # whether or not the column name is in empty_rows
+            # if there are no abundances in the dataframe, df.apply will yield
+            # a single item that has `None` as its name. Therefore, we must
+            # check if row.name is None AND whether or not the column name is
+            # in empty_rows
             df["Other"] = df.apply(
                 lambda row: 0.0 if (row.name is None or row.name in empty_rows) else 1 - row.sum(),
                 axis=1,

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -88,6 +88,7 @@ class VizBargraphMixin(object):
 
         >>> plot_bargraph(rank='genus', top_n=10)
         """
+
         # Deferred imports
         import altair as alt
 
@@ -150,8 +151,8 @@ class VizBargraphMixin(object):
             # Replace nans with zeros for samples that have a total abundance of zero.
             df = df.div(df.sum(axis=1), axis=0).fillna(0.0)
 
-        # Keep track of empty rows *before* filtering taxa by threshold/top_n. We'll use this below
-        # to calculate "Other".
+        # Keep track of empty rows *before* filtering taxa by threshold/top_n.
+        # We'll use this below to calculate "Other".
         empty_rows = df[df.sum(axis=1) == 0.0].index
 
         if top_n == "auto" and threshold == "auto":
@@ -170,7 +171,8 @@ class VizBargraphMixin(object):
 
         if include_other and normalize:
             df["Other"] = df.apply(
-                lambda row: 0.0 if row.name in empty_rows else 1 - row.sum(), axis=1
+                lambda row: 0.0 if (row.name is None or row.name in empty_rows) else 1 - row.sum(),
+                axis=1,
             )
 
         if isinstance(legend, str):

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -383,6 +383,15 @@ def test_plot_heatmap_all_samples_are_nan(ocx, api_data, samples):
         samples.plot_heatmap(top_n=10, return_chart=True)
 
 
+def test_plot_bargraph_no_samples_have_abundances(ocx, api_data, samples):
+    samples._results[:] = np.nan
+    assert len(samples._all_nan_classification_ids) == 3
+
+    chart = samples.plot_bargraph(return_chart=True)
+
+    assert list(chart.data["Relative Abundance"].values) == [0.0, 0.0, 0.0]
+
+
 def test_plot_distance_excludes_all_nan_clustering_helper_called_with(ocx, api_data, samples):
     sample1 = ocx.Samples.get("cc18208d98ad48b3")
     sample2 = ocx.Samples.get("5445740666134eee")


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description

- Fix edge-case where abundance for "Other" is shown as 1.0 when there are no samples with abundance estimates. This is due to a weird behavior in Pandas where `df.apply` yields a single empty Series when the dataframe is empty.

## Related PRs

- [x] This PR is independent

## TODOs

- [x] Tests
