### PR TITLE
Add support for concatenating ONT files

### DIFF
--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -31,6 +31,7 @@ from onecodex.utils import (
     pretty_errors,
     run_via_threadpool,
     telemetry,
+    use_tempdir,
 )
 from onecodex.input_helpers import (
     auto_detect_pairs,
@@ -493,67 +494,68 @@ def upload(
         click.echo("You must specify both forward and reverse files", err=True)
         ctx.exit(1)
 
-    if forward and reverse:
-        if len(files) > 0:
-            click.echo(
-                "You may not pass a FILES argument when using the "
-                " --forward and --reverse options.",
-                err=True,
-            )
-            ctx.exit(1)
-        files = [(forward, reverse)]
-    elif len(files) == 0:
-        click.echo(ctx.get_help())
-        return
-    else:
-        files_set = set(files)
-        if files_set.symmetric_difference(files):
-            click.echo(
-                "Duplicate filenames detected in command line--please specific each file only once",
-                err=True,
-            )
-            ctx.exit(1)
+    with use_tempdir() as tempdir:
+        if forward and reverse:
+            if len(files) > 0:
+                click.echo(
+                    "You may not pass a FILES argument when using the "
+                    " --forward and --reverse options.",
+                    err=True,
+                )
+                ctx.exit(1)
+            files = [(forward, reverse)]
+        elif len(files) == 0:
+            click.echo(ctx.get_help())
+            return
+        else:
+            files_set = set(files)
+            if files_set.symmetric_difference(files):
+                click.echo(
+                    "Duplicate filenames detected in command line--please specific each file only once",
+                    err=True,
+                )
+                ctx.exit(1)
 
-        # Detecting ONT groups comes first as otherwise part of ONT group could
-        # be mistaken for a paired file
-        files = concatenate_ont_groups(files, prompt)
-        files = auto_detect_pairs(files, prompt)
+            # Detecting ONT groups comes first as otherwise part of ONT group could
+            # be mistaken for a paired file
+            files = concatenate_ont_groups(files, prompt, tempdir)
+            files = auto_detect_pairs(files, prompt)
 
-    files = concatenate_multilane_files(files, prompt)
+        files = concatenate_multilane_files(files, prompt, tempdir)
 
-    total_size = sum(
-        [
-            (os.path.getsize(x[0]) + os.path.getsize(x[1]))
-            if isinstance(x, tuple)
-            else os.path.getsize(x)
-            for x in files
-        ]
-    )
-
-    upload_kwargs = {
-        "metadata": appendables["valid_metadata"],
-        "tags": appendables["valid_tags"],
-        "project": project_id,
-        "coerce_ascii": coerce_ascii,
-        "progressbar": progressbar(length=total_size, label="Uploading..."),
-        "sample_id": sample_id,
-        "external_sample_id": external_sample_id,
-    }
-
-    if (sample_id or external_sample_id) and len(files) > 1:
-        click.echo(
-            "Please only specify a single file or pair of files to upload if using `sample_id` or `external_sample_id`",
-            err=True,
+        total_size = sum(
+            [
+                (os.path.getsize(x[0]) + os.path.getsize(x[1]))
+                if isinstance(x, tuple)
+                else os.path.getsize(x)
+                for x in files
+            ]
         )
-        ctx.exit(1)
 
-    run_via_threadpool(
-        ctx.obj["API"].Samples.upload,
-        files,
-        upload_kwargs,
-        max_threads=8 if max_threads > 8 else max_threads,
-        graceful_exit=False,
-    )
+        upload_kwargs = {
+            "metadata": appendables["valid_metadata"],
+            "tags": appendables["valid_tags"],
+            "project": project_id,
+            "coerce_ascii": coerce_ascii,
+            "progressbar": progressbar(length=total_size, label="Uploading..."),
+            "sample_id": sample_id,
+            "external_sample_id": external_sample_id,
+        }
+
+        if (sample_id or external_sample_id) and len(files) > 1:
+            click.echo(
+                "Please only specify a single file or pair of files to upload if using `sample_id` or `external_sample_id`",
+                err=True,
+            )
+            ctx.exit(1)
+
+        run_via_threadpool(
+            ctx.obj["API"].Samples.upload,
+            files,
+            upload_kwargs,
+            max_threads=8 if max_threads > 8 else max_threads,
+            graceful_exit=False,
+        )
 
 
 @onecodex.command("login")

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -32,7 +32,11 @@ from onecodex.utils import (
     run_via_threadpool,
     telemetry,
 )
-from onecodex.input_helpers import auto_detect_pairs, concatenate_multilane_files
+from onecodex.input_helpers import (
+    auto_detect_pairs,
+    concatenate_ont_groups,
+    concatenate_multilane_files,
+)
 from onecodex.version import __version__
 
 
@@ -510,6 +514,9 @@ def upload(
             )
             ctx.exit(1)
 
+        # Detecting ONT groups comes first as otherwise part of ONT group could
+        # be mistaken for a paired file
+        files = concatenate_ont_groups(files, prompt)
         files = auto_detect_pairs(files, prompt)
 
     files = concatenate_multilane_files(files, prompt)

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -11,7 +11,6 @@ import sys
 import sentry_sdk
 from contextlib import contextmanager
 import tempfile
-import shutil
 
 try:
     from StringIO import StringIO
@@ -491,11 +490,5 @@ def has_missing_values(dataframe_or_series):
 
 @contextmanager
 def use_tempdir():
-    path = tempfile.mkdtemp()
-    try:
-        yield path
-    finally:
-        try:
-            shutil.rmtree(path)
-        except IOError:
-            log.warning(f"Failed to clean up temp dir {path}")
+    with tempfile.TemporaryDirectory() as tempdir:
+        yield tempdir

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -9,6 +9,9 @@ import re
 import requests
 import sys
 import sentry_sdk
+from contextlib import contextmanager
+import tempfile
+import shutil
 
 try:
     from StringIO import StringIO
@@ -484,3 +487,15 @@ def is_continuous(series):
 
 def has_missing_values(dataframe_or_series):
     return dataframe_or_series.isnull().values.any()
+
+
+@contextmanager
+def use_tempdir():
+    path = tempfile.mkdtemp()
+    try:
+        yield path
+    finally:
+        try:
+            shutil.rmtree(path)
+        except IOError:
+            log.warning(f"Failed to clean up temp dir {path}")


### PR DESCRIPTION
## Status
- [X] **Ready**

## Description
This PR adds support for detecting and concatenating ONT file groups. The detection in based on ordinal in the file names - they need to end with `_X` (starting with 0 index) and have no gaps in the sequence.
If a user accepts (or skips the prompt altogether), such file sequences are concatenated and the resulting file is being uploaded instead of the captured sequence. 

## Related PRs
- [X] This PR is independent
