### PR TITLE
Filter and warn if samples are missing abundances in `plot_metadata()`

### DIFF
--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -94,9 +94,11 @@ class StatsMixin:
             metadata_fields.append(paired_by)
 
         # Munge the metadata first in case there's any errors
-        df, magic_fields = self._metadata_fetch(
+        metadata_results = self._metadata_fetch(
             metadata_fields, coerce_missing_composite_fields=False
         )
+        df = metadata_results.df
+        magic_fields = metadata_results.renamed_fields
         group_by_column_name = magic_fields[group_by]
         paired_by_column_name = magic_fields.get(paired_by, None)
 

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -205,7 +205,9 @@ class VizBargraphMixin(object):
 
             # takes metadata columns and returns a dataframe with just those columns
             # renames columns in the case where columns are taxids
-            magic_metadata, magic_fields = self._metadata_fetch(tooltip, label=label)
+            metadata_results = self._metadata_fetch(tooltip, label=label)
+            magic_metadata = metadata_results.df
+            magic_fields = metadata_results.renamed_fields
             df = df.join(magic_metadata)
             metadata_columns = magic_metadata.columns.tolist()
             tooltip = [magic_fields[f] for f in tooltip]

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -190,9 +190,11 @@ class VizDistanceMixin(DistanceMixin):
 
         tooltip.insert(0, "Label")
 
-        magic_metadata, magic_fields = self._metadata_fetch(tooltip, label=label)
-        formatted_fields = []
+        metadata_results = self._metadata_fetch(tooltip, label=label)
+        magic_metadata = metadata_results.df
+        magic_fields = metadata_results.renamed_fields
 
+        formatted_fields = []
         for _, magic_field in magic_fields.items():
             field_group = []
 
@@ -378,7 +380,9 @@ class VizDistanceMixin(DistanceMixin):
         if size and size not in tooltip:
             tooltip.insert(2, size)
 
-        magic_metadata, magic_fields = self._metadata_fetch(tooltip, label=label)
+        metadata_results = self._metadata_fetch(tooltip, label=label)
+        magic_metadata = metadata_results.df
+        magic_fields = metadata_results.renamed_fields
 
         if method == OrdinationMethod.Smacof:
             # adapted from https://scikit-learn.org/stable/auto_examples/manifold/plot_mds.html

--- a/onecodex/viz/_heatmap.py
+++ b/onecodex/viz/_heatmap.py
@@ -149,7 +149,9 @@ class VizHeatmapMixin(object):
 
         tooltip.insert(0, "Label")
 
-        magic_metadata, magic_fields = self._metadata_fetch(tooltip, label=label)
+        metadata_results = self._metadata_fetch(tooltip, label=label)
+        magic_metadata = metadata_results.df
+        magic_fields = metadata_results.renamed_fields
         magic_metadata.replace(np.nan, "N/A", inplace=True)
 
         # add columns for prettier display

--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -1,7 +1,8 @@
+import warnings
 from typing import Optional, Literal, Union
 
 from onecodex.lib.enums import AlphaDiversityMetric, Rank, BaseEnum
-from onecodex.exceptions import OneCodexException, PlottingException
+from onecodex.exceptions import OneCodexException, PlottingException, PlottingWarning
 from onecodex.viz._primitives import (
     prepare_props,
     sort_helper,
@@ -129,15 +130,21 @@ class VizMetadataMixin(object):
         if secondary_haxis:
             metadata_fields.append(secondary_haxis)
 
-        df, magic_fields = self._metadata_fetch(metadata_fields, label=label)
+        metadata_results = self._metadata_fetch(metadata_fields, label=label)
+        df = metadata_results.df
+        magic_fields = metadata_results.renamed_fields
 
+        filter_samples_missing_abundances = True
         if AlphaDiversityMetric.has_value(vaxis):
             df.loc[:, vaxis] = self.alpha_diversity(vaxis, rank=rank)
             magic_fields[vaxis] = vaxis
             df.dropna(subset=[magic_fields[vaxis]], inplace=True)
         else:
             # if it's not alpha diversity, vertical axis can also be magically mapped
-            vert_df, vert_magic_fields = self._metadata_fetch([vaxis])
+            vert_metadata_results = self._metadata_fetch([vaxis])
+            vert_df = vert_metadata_results.df
+            vert_magic_fields = vert_metadata_results.renamed_fields
+            filter_samples_missing_abundances = vaxis in vert_metadata_results.taxonomy_fields
 
             # we require the vertical axis to be numerical otherwise plots get weird
             if (
@@ -150,6 +157,21 @@ class VizMetadataMixin(object):
 
             df = pd.concat([df, vert_df], axis=1).dropna(subset=[vert_magic_fields[vaxis]])
             magic_fields.update(vert_magic_fields)
+
+        if filter_samples_missing_abundances and self._all_nan_classification_ids:
+            df = df[~df.index.isin(self._all_nan_classification_ids)]
+
+            if len(df) < 1:
+                raise PlottingException(
+                    "Abundances are not calculated for any of the selected samples. Please select "
+                    "a different metric or a different set of samples to plot."
+                )
+
+            warnings.warn(
+                f"{len(self._all_nan_classification_ids)} sample(s) have no abundances calculated "
+                "and have been omitted from the metadata plot.",
+                PlottingWarning,
+            )
 
         # plots can look different depending on what the horizontal axis contains
         if pd.api.types.is_datetime64_any_dtype(df[magic_fields[haxis]]):
@@ -238,7 +260,7 @@ class VizMetadataMixin(object):
                 .encode(
                     x=alt.X(magic_fields[haxis], **x_kwargs),
                     y=alt.Y(magic_fields[vaxis], axis=alt.Axis(title=ylabel)),
-                    **encode_kwargs
+                    **encode_kwargs,
                 )
             )
 

--- a/onecodex/viz/_pca.py
+++ b/onecodex/viz/_pca.py
@@ -116,7 +116,9 @@ class VizPCAMixin(object):
         if size and size not in tooltip:
             tooltip.insert(2, size)
 
-        magic_metadata, magic_fields = self._metadata_fetch(tooltip, label=label)
+        metadata_results = self._metadata_fetch(tooltip, label=label)
+        magic_metadata = metadata_results.df
+        magic_fields = metadata_results.renamed_fields
 
         pca = PCA()
         pca_vals = pca.fit(df.values).transform(df.values)

--- a/tests/test_analyses.py
+++ b/tests/test_analyses.py
@@ -96,59 +96,75 @@ def test_metadata_fetch(samples):
     assert "must be categorical" in str(e.value)
 
     # proper tuple of categorical metadata fields
-    df, fields = samples._metadata_fetch([("eggs", "vegetables")])
-    assert fields[("eggs", "vegetables")] == "eggs_vegetables"
-    assert df["eggs_vegetables"].tolist() == ["True_True", "True_True", "True_True"]
+    results = samples._metadata_fetch([("eggs", "vegetables")])
+    assert results.renamed_fields[("eggs", "vegetables")] == "eggs_vegetables"
+    assert results.df["eggs_vegetables"].tolist() == ["True_True", "True_True", "True_True"]
+    assert not results.taxonomy_fields
 
     # Label reserved field name
-    df, fields = samples._metadata_fetch(["Label"])
-    assert fields["Label"] == "Label"
-    assert df["Label"].tolist() == ["SRR4408293.fastq", "SRR4305031.fastq", "SRR4408292.fastq"]
+    results = samples._metadata_fetch(["Label"])
+    assert results.renamed_fields["Label"] == "Label"
+    assert results.df["Label"].tolist() == [
+        "SRR4408293.fastq",
+        "SRR4305031.fastq",
+        "SRR4408292.fastq",
+    ]
+    assert not results.taxonomy_fields
 
     # exact match of single metadata field
-    df, fields = samples._metadata_fetch(["totalige"])
-    assert fields["totalige"] == "totalige"
-    assert df["totalige"].tolist() == [62.9, 91.5, 112.0]
+    results = samples._metadata_fetch(["totalige"])
+    assert results.renamed_fields["totalige"] == "totalige"
+    assert results.df["totalige"].tolist() == [62.9, 91.5, 112.0]
+    assert not results.taxonomy_fields
 
     # single metadata field doesn't match anything
-    df, fields = samples._metadata_fetch(["does_not_exist"])
-    assert fields["does_not_exist"] == "does_not_exist"
-    assert df["does_not_exist"].tolist() == [None, None, None]
+    results = samples._metadata_fetch(["does_not_exist"])
+    assert results.renamed_fields["does_not_exist"] == "does_not_exist"
+    assert results.df["does_not_exist"].tolist() == [None, None, None]
+    assert not results.taxonomy_fields
 
     # tax_id coerced to string from integer
-    df, fields = samples._metadata_fetch([1279])
-    assert fields[1279] == "Staphylococcus (1279)"
-    assert df["Staphylococcus (1279)"].round(10).tolist() == [4.0172e-06, 4.89491e-05, 2.0881e-06]
+    results = samples._metadata_fetch([1279])
+    assert results.renamed_fields[1279] == "Staphylococcus (1279)"
+    assert results.df["Staphylococcus (1279)"].round(10).tolist() == [
+        4.0172e-06,
+        4.89491e-05,
+        2.0881e-06,
+    ]
+    assert results.taxonomy_fields == {1279}
 
     # tax_name, should take lowest matching tax_id, be case-insensitive, and report within-rank abundance
-    df, fields = samples._metadata_fetch(["bacteroid"])
-    assert fields["bacteroid"] == "Bacteroidaceae (815)"
-    assert df["Bacteroidaceae (815)"].round(10).tolist() == [
+    results = samples._metadata_fetch(["bacteroid"])
+    assert results.renamed_fields["bacteroid"] == "Bacteroidaceae (815)"
+    assert results.df["Bacteroidaceae (815)"].round(10).tolist() == [
         0.344903898,
         0.1656058794,
         0.7776093433,
     ]
+    assert results.taxonomy_fields == {"bacteroid"}
 
     # label is a metadata field or callable
-    df, fields = samples._metadata_fetch(["Label"], label="eggs")
-    assert df["Label"].tolist() == ["True (1)", "True (2)", "True (3)"]
+    results = samples._metadata_fetch(["Label"], label="eggs")
+    assert results.df["Label"].tolist() == ["True (1)", "True (2)", "True (3)"]
+    assert not results.taxonomy_fields
 
-    df, fields = samples._metadata_fetch(["Label"], label=lambda x: str(x["eggs"]) + "_foo")
-    assert df["Label"].tolist() == ["True_foo (1)", "True_foo (2)", "True_foo (3)"]
+    results = samples._metadata_fetch(["Label"], label=lambda x: str(x["eggs"]) + "_foo")
+    assert results.df["Label"].tolist() == ["True_foo (1)", "True_foo (2)", "True_foo (3)"]
+    assert not results.taxonomy_fields
 
     # label must be a string or callable
     with pytest.raises(OneCodexException) as e:
-        df, fields = samples._metadata_fetch(["Label"], label=False)
+        samples._metadata_fetch(["Label"], label=False)
     assert "string or callable" in str(e.value)
 
     # label is a field not in the table
     with pytest.raises(OneCodexException) as e:
-        df, fields = samples._metadata_fetch(["Label"], label="does_not_exist")
+        samples._metadata_fetch(["Label"], label="does_not_exist")
     assert "not found" in str(e.value)
 
     # label is a callable doesn't return a string
     with pytest.raises(OneCodexException) as e:
-        df, fields = samples._metadata_fetch(["Label"], label=lambda x: False)
+        samples._metadata_fetch(["Label"], label=lambda x: False)
     assert "string from label" in str(e.value)
 
 

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -217,6 +217,30 @@ def test_plot_metadata_exceptions(samples):
         samples.plot_metadata(vaxis="shannon", haxis="wheat", secondary_haxis="wheat")
 
 
+def test_plot_metadata_all_samples_are_nan(samples):
+    samples._results[:] = np.nan
+    assert len(samples._all_nan_classification_ids) == 3
+
+    # Raises for alpha diversity
+    with pytest.raises(PlottingException, match="Abundances are not calculated for any"):
+        samples.plot_metadata(vaxis="shannon")
+
+    # Does not raise for numeric metadata column
+    chart = samples.plot_metadata(vaxis="totalige", return_chart=True)
+    assert chart.mark == "circle"
+
+
+def test_plot_metadata_filters_nan_samples(samples):
+    samples._results.iloc[0, :] = np.nan
+    samples._results.iloc[1, :] = np.nan
+    assert len(samples._all_nan_classification_ids) == 2
+
+    with pytest.warns(PlottingWarning, match=r"2 sample\(s\) have no abundances calculated"):
+        chart = samples.plot_metadata(vaxis="shannon", return_chart=True)
+
+    assert len(chart["data"]) == 1
+
+
 def test_plot_metadata_group_with_single_value(samples):
     chart = samples.plot_metadata(
         plot_type="boxplot",


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Samples with missing abundances are filtered out in `plot_metadata()` when plotting alpha diversity or taxon abundances. A warning is also raised.

If numeric metadata is plotted on the vertical axis, this filtering is not applied because abundances are not needed to create the plot.

An error is raised if all samples are filtered out due to missing abundances.

Closes DEV-10065

## Related PRs
- [x] This PR is independent