### PR TITLE
Rename singleton ONT files if merging by sample + print ONT concatenation groups

### DIFF
--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -43,7 +43,7 @@ def prompt_user_for_concatenation(ont_groups: dict) -> bool:
     n_files = sum([len(x) for x in ont_groups.values()])
 
     answer = click.prompt(
-        f"It appears there are {len(ont_groups)} of Oxford Nanopore samples split across {n_files} individual files. "
+        f"It appears there are {len(ont_groups)} sample(s) split across {n_files} individual file(s). "
         "\nWould you like to merge files by sample?"
         "\n[Y]es; [n]o; [d]isplay files; [c]ancel",
         type=click.Choice(["Y", "n", "d", "c"]),
@@ -91,7 +91,13 @@ def concatenate_ont_groups(files, prompt, tempdir):
     # filter to groups of at least 1 files
     ont_groups = {k: v for k, v in ont_groups.items()}
 
-    auto_group = prompt_user_for_concatenation(ont_groups)
+    # if there is only one group; do not prompt for concatenation
+    if len(files) == 1 and len(ont_groups) == 1:
+        auto_group = False
+    elif prompt:
+        auto_group = prompt_user_for_concatenation(ont_groups)
+    else:
+        auto_group = True
 
     if not auto_group:
         return files

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -54,7 +54,7 @@ def prompt_user_for_concatenation(ont_groups: dict) -> bool:
     elif answer[0] == "n":
         return False
     elif answer[0] == "c":
-        click.echo("Canceling upload.")
+        click.echo("Upload canceled")
         sys.exit(0)
     elif answer[0] == "d":
         for group_name, group_files in ont_groups.items():

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -35,9 +35,7 @@ def _replace_paired_filename_ordinal(filename, replacement):
 
 
 def prompt_user_for_concatenation(ont_groups: dict) -> bool:
-    """
-    Prompt user to determine whether ONT files should be concatenated.
-    """
+    """Prompt user to determine whether ONT files should be concatenated."""
 
     n_files = sum([len(x) for x in ont_groups.values()])
 
@@ -70,6 +68,8 @@ def prompt_user_for_concatenation(ont_groups: dict) -> bool:
     else:
         click.echo(f"Unknown option: {answer}")
         return prompt_user_for_concatenation(ont_groups)
+
+    return False
 
 
 def concatenate_ont_groups(files, prompt, tempdir):

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -36,8 +36,7 @@ def _replace_paired_filename_ordinal(filename, replacement):
 
 def prompt_user_for_concatenation(ont_groups: dict) -> bool:
     """
-    # TODO: there should be a cancel option here
-    # also, it would be nice to display the files / grups
+    Prompt user to determine whether ONT files should be concatenated.
     """
 
     n_files = sum([len(x) for x in ont_groups.values()])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -374,6 +374,18 @@ def test_paired_files_with_forward_and_reverse_args(
             0,
             4,
         ),
+        # 3 files, 2 ONT parts, 2 samples
+        (
+            [
+                "test_S1_0.fastq.gz",
+                "test_S1_1.fastq.gz",
+                "test_S2_0.fastq.gz",
+            ],
+            2,
+            2,
+            0,
+            2,
+        ),
         # 6 files, 2x3 ONT parts, 2 samples
         (
             [
@@ -423,7 +435,7 @@ def test_paired_and_ont_files(
     else:
         assert paired_files_prompt not in result.output
 
-    ont_prompt = f"It appears there are {n_ont_files} ONT files (of {len(files)} total)"
+    ont_prompt = f"It appears there are {n_samples_uploaded} sample(s)"
     if n_ont_files > 0:
         assert ont_prompt in result.output
     else:

--- a/tests/test_input_helpers.py
+++ b/tests/test_input_helpers.py
@@ -131,6 +131,10 @@ def test_concatenate_gzipped_multilane_files(generate_fastq_gz):
             ["test_1_0.fq", "test_1_1.fq", "test_1_3.fq"],
         ),
         (["test_1.fq", "test_2.fq", "other.fq", "test_0.fq"], ["test.fq", "other.fq"]),
+        # singleton groups
+        (["test1_0.fq", "test2_0.fq", "test2_1.fq"], ["test1.fq", "test2.fq"]),
+        # just one singleton group -- treat as a normal file
+        (["test1_0.fq"], ["test1_0.fq"]),
         (["test_1.fq", "test_2.fq"], ["test_1.fq", "test_2.fq"]),
         (
             [


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

Some changes to the ONT upload concatenation behavior:

- Singleton FASTQ files now have the `_0` stripped from their filename. Otherwise, you get a mix of concatenated/non-concatenated files which looks messy.
- You can now display the list of files that will be concatenated
- The user can now press `c` to cancel the upload

## Related PRs
- [x] This PR is independent

## TODOs
Add any todos here as needed for work in progress code. This section can be deleted if not relevant. Examples:

- [x] Tests
- [x] Documentation
