### PR TITLE
Fix outdated docs URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Which returns a `Samples` resource (as of `0.5.0`). Samples can be associated wi
 ```python
 # Note format must match the schema defined for our API, with arbitrary
 # metadata allowed as a single-level dictionary in the `custom` field.
-# See https://developer.onecodex.com/reference#the-metadata-resource for details.
+# See http://developer.onecodex.com/api-reference/metadata-resource for details.
 metadata = {
     "platform": "Illumina NovaSeq 6000",
     "date_collected": "2019-04-14T00:51:54.832048+00:00",

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Which returns a `Samples` resource (as of `0.5.0`). Samples can be associated wi
 ```python
 # Note format must match the schema defined for our API, with arbitrary
 # metadata allowed as a single-level dictionary in the `custom` field.
-# See http://developer.onecodex.com/api-reference/metadata-resource for details.
+# See https://developer.onecodex.com/api-reference/metadata-resource for details.
 metadata = {
     "platform": "Illumina NovaSeq 6000",
     "date_collected": "2019-04-14T00:51:54.832048+00:00",


### PR DESCRIPTION
## Status
- [X] **Ready**

## Description
Fix from `/reference#` to newer `/api-reference/metadata-resource` docs link.

## Related PRs
- [X] This PR is independent

## TODOs
None.