### PR TITLE
`onecodex login` is not working (Missing header)

### DIFF
--- a/onecodex/lib/auth.py
+++ b/onecodex/lib/auth.py
@@ -32,7 +32,13 @@ def fetch_api_key_from_uname(username, password, server_url):
             "csrf_token": csrf,
             "next": "/api/get_token",
         }
-        page = session.post(server_url + "login", data=login_data)
+        page = session.post(
+            server_url + "login",
+            data=login_data,
+            headers={
+                "Referer": server_url + "login",
+            },
+        )
         try:
             key = page.json()["key"]
         except (ValueError, KeyError):  # ValueError includes simplejson.decoder.JSONDecodeError


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description

It was missing "Referer" header and returning 404 instead of 200.

## Related PRs
- [x] This PR is independent
