### PR TITLE
Fix failing tests & bump Altair

### DIFF
--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -421,6 +421,7 @@ class VizDistanceMixin(DistanceMixin):
                 random_state=seed,
                 dissimilarity="precomputed",
                 n_jobs=1,
+                n_init=4,  # The default changes from 4 to 1 in sklearn 1.9
                 normalized_stress="auto",
             )
             pos = mds.fit(dists).embedding_

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ TESTING_DEPS = [
 ]
 
 ALL_DEPS = [
-    "altair==5.4.1",
+    "altair==5.5.0",
     "numpy>=1.21.6,<2",
     "pandas>=1.0.3",
     "pillow>=9.0.1",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -227,7 +227,7 @@ def test_standard_uploads(
         for f in files:
             args.append(generate_fastq(f))
 
-        result = runner.invoke(Cli, args, catch_exceptions=False)
+        result = runner.invoke(Cli, args, catch_exceptions=False, input="\n")
         assert result.exit_code == 0
         assert "7428cca4a3a04a8e" in caplog.text  # mocked file id
 
@@ -286,7 +286,7 @@ def test_paired_and_multiline_files(
 
     args = ["--api-key", "01234567890123456789012345678901", "upload"] + files
     # check that 2 uploads are kicked off for the pair of files
-    result = runner.invoke(Cli, args, catch_exceptions=False)
+    result = runner.invoke(Cli, args, catch_exceptions=False, input="\n\n\n")
     assert mock_file_upload.call_count == n_files_uploaded
     assert mock_sample_get.call_count == n_samples_uploaded
     assert result.exit_code == 0
@@ -423,7 +423,7 @@ def test_paired_and_ont_files(
     files = [generate_fastq(x) for x in files]
 
     args = ["--api-key", "01234567890123456789012345678901", "upload"] + files
-    result = runner.invoke(Cli, args, catch_exceptions=False)
+    result = runner.invoke(Cli, args, catch_exceptions=False, input="\n\n")
     assert mock_file_upload.call_count == n_files_uploaded
     assert mock_sample_get.call_count == n_samples_uploaded
     assert result.exit_code == 0

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -672,17 +672,18 @@ def test_plot_distance_exceptions(samples):
 
 
 @pytest.mark.parametrize(
-    "metric,dissimilarity_metric,smacof",
+    "metric,dissimilarity_metric,smacofs",
     [
-        ("abundance_w_children", "weighted_unifrac", 0.7595),
-        ("abundance_w_children", "unweighted_unifrac", 0.1734),
-        ("abundance_w_children", "braycurtis", 0.0143),
-        ("readcount_w_children", "weighted_unifrac", 0.4956),
-        ("readcount_w_children", "unweighted_unifrac", 0.3579),
-        ("readcount_w_children", "braycurtis", 0.1735),
+        # Some results differ between sklearn 1.6 and 1.7
+        ("abundance_w_children", "weighted_unifrac", {0.7595}),
+        ("abundance_w_children", "unweighted_unifrac", {0.1734}),
+        ("abundance_w_children", "braycurtis", {0.0143, 0.1284}),
+        ("readcount_w_children", "weighted_unifrac", {0.4956, 0.0918}),
+        ("readcount_w_children", "unweighted_unifrac", {0.3579}),
+        ("readcount_w_children", "braycurtis", {0.1735, 0.0798}),
     ],
 )
-def test_plot_mds(samples, metric, dissimilarity_metric, smacof):
+def test_plot_mds(samples, metric, dissimilarity_metric, smacofs):
     samples._collate_results(metric=metric)
 
     chart = samples.plot_mds(
@@ -705,7 +706,7 @@ def test_plot_mds(samples, metric, dissimilarity_metric, smacof):
     chart = samples.plot_mds(
         method="smacof", rank="species", metric=dissimilarity_metric, return_chart=True
     )
-    assert (chart.data["MDS1"] * chart.data["MDS2"]).sum().round(4) == smacof
+    assert (chart.data["MDS1"] * chart.data["MDS2"]).sum().round(4) in smacofs
 
 
 def test_plot_mds_color_by_bool_field(samples):


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Fixed failing tests and bumped pinned Altair version.

Tests were failing due to:
- The latest version of Click changed its CLI runner stdin behavior when input was expected but not provided.
- The pinned Altair version was incompatible with its resolved `narwhals` dependency (upgrading Altair fixes the issue).
- scikit-learn updated `manifold` (MDS) to have better defaults and produce results closer to R. I plotted Bray-Curtis and Weighted Unifrac MDS in the example notebook and the results are *very* similar between sklearn 1.6 and 1.7.

Closes DEV-10624

## Related PRs
- [x] This PR is independent