### PR TITLE
Update `cache-apt-pkgs-action` version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     steps:
       - name: Install pandoc
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.2
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
         with:
           packages: pandoc
       - id: deployment


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
The previous version used `actions/upload-artifact@v3`, which is no longer supported by Github.

## Related PRs
- [x] This PR is independent