### PR TITLE
Add additional upload test, remove xfail-marked pd.Series coercion test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ filterwarnings = [
     'ignore:.*platformdirs.*:DeprecationWarning:jupyter_client.connect',
     'ignore:Parsing dates:DeprecationWarning:jupyter_client.jsonutil',
     'ignore:datetime.datetime.utcnow:DeprecationWarning:jupyter_client.session',
+    'ignore:datetime.datetime.utcnow:DeprecationWarning:botocore.auth',
 ]
 
 [tool.ruff]

--- a/tests/test_metadata_upload.py
+++ b/tests/test_metadata_upload.py
@@ -192,34 +192,3 @@ def test_coerce_custom_value_falsy():
 def test_coerce_custom_value_string():
     custom_value = coerce_custom_value("Foo")
     assert custom_value == "Foo"
-
-
-@pytest.mark.xfail(reason="Multipart upload not yet implemented")
-def test_pandas_and_numpy_type_coercions(ocx, upload_mocks):
-    # See https://github.com/onecodex/onecodex/issues/232 and
-    # https://github.com/pandas-dev/pandas/issues/25969
-    # We can remove this test once the Pandas bug above is fixed
-    # upstream and we require >= that version of pandas.
-    pytest.importorskip("pandas")
-    import numpy as np
-    import pandas as pd
-
-    series = pd.Series({"a": np.int64(64), "b": 10, "c": "ABC"})
-    metadata = {
-        "platform": "Illumina NovaSeq 6000",
-        "date_collected": "2019-04-14T00:51:54.832048+00:00",
-        "external_sample_id": "my-lims-ID-or-similar",
-        "custom": series.to_dict(),
-    }
-
-    # This works
-    ocx.Samples.init_multipart_upload(
-        filename="SRR2352185.fastq.gz", size=181687821, metadata=metadata
-    )
-
-    # Now try to serialize something really not supported, so we can get the Exception
-    with pytest.raises(TypeError):
-        metadata["custom"]["bad_field"] = ocx.Samples  # not JSON serializable
-        ocx.Samples.init_multipart_upload(
-            filename="SRR2352185.fastq.gz", size=181687821, metadata=metadata
-        )

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -41,7 +41,30 @@ def mock_api_responses():
         rsps.add(
             responses.POST,
             "http://localhost:3000/s3_confirm",
-            json={"sample_id": "s3_confirm_sample_id"},
+            json={"sample_id": "abcdef1234567890"},
+            status=200,
+        )
+
+        rsps.add(
+            responses.GET,
+            "http://localhost:3000/api/v1/samples/abcdef1234567890",
+            json={
+                "$uri": "/api/v1/samples/7428cca4a3a04a8e",
+                "created_at": "2015-09-25T17:27:19.596555-07:00",
+                "filename": "SRR2352185.fastq.gz",
+                "metadata": {"$ref": "/api/v1/metadata/a7fc7e430e704e2e"},
+                "owner": {"$ref": "/api/v1/users/4ada56103d9a48b8"},
+                "primary_classification": {"$ref": "/api/v1/classifications/464a7ebcf9f84050"},
+                "project": None,
+                "size": 181687821,
+                "tags": [
+                    {"$ref": "/api/v1/tags/42997b7a62634985"},
+                    {"$ref": "/api/v1/tags/fb8e3b693c874f9e"},
+                    {"$ref": "/api/v1/tags/ff4e81909a4348d9"},
+                ],
+                "visibility": "private",
+                "status": "available",
+            },
             status=200,
         )
 
@@ -256,6 +279,20 @@ def test_single_end_files(ocx, mock_api_responses):
         mock_file_obj._fsize = 1000  # Add size property to avoid comparison errors
 
         upload_sequence("tests/data/files/test_R1_L001.fq.gz", ocx.Samples)
+        assert b3.call_count == 1
+
+
+def test_single_end_files_upload_method(ocx, mock_api_responses):
+    with (
+        patch("onecodex.lib.upload.get_file_wrapper") as mock_wrapper,
+        patch("boto3.session.Session") as b3,
+    ):
+        # Configure mock file object
+        mock_file_obj = mock_wrapper.return_value
+        mock_file_obj.filename = "test_R1_L001.fq.gz"
+        mock_file_obj._fsize = 1000  # Add size property to avoid comparison errors
+
+        ocx.Samples.upload("tests/data/files/test_R1_L001.fq.gz")
         assert b3.call_count == 1
 
 


### PR DESCRIPTION
## Status
- [X] **Ready**

## Description
Adds a test for `ocx.Samples.upload` directly. Removes an old test related to obscure Pandas series coercion issues (where we no longer support the API used in the test harness).

## Related PRs
- [X] This PR is independent

## TODOs
None.