### PR TITLE
Add ANCOM-BC differential abundance test

### DIFF
--- a/onecodex/lib/enums.py
+++ b/onecodex/lib/enums.py
@@ -292,6 +292,7 @@ class PosthocStatsTest(BaseEnum):
 
 class AdjustmentMethod(BaseEnum):
     BenjaminiHochberg = "benjamini_hochberg"
+    HolmBonferroni = "holm_bonferroni"
 
 
 class AnalysisType(BaseEnum):

--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -108,11 +108,12 @@ class AncombcResults(StatsResults):
     """A dataclass for storing the results of an ANCOM-BC differential abundance test.
 
     - `main_results`: `pd.DataFrame` containing ANCOM-BC test results for each taxon, including
-    log2-fold change (with standard error), W-statistic, p-value, adjusted p-value, and whether or
-    not the result is statistically significant. See `skbio.stats.composition.ancombc` for details.
+    log2-fold change (with standard error), W-statistic, p-value, adjusted p-value (i.e. q-value),
+    and whether or not the result is statistically significant. See
+    `skbio.stats.composition.ancombc` for details.
     - `global_results`: `pd.DataFrame` containing global ANCOM-BC test results for each taxon,
-    including W-statistic, p-value, adjusted p-value, and whether or not the result is statistically
-    significant. See `skbio.stats.composition.ancombc` for details.
+    including W-statistic, p-value, adjusted p-value (i.e. q-value), and whether or not the result
+    is statistically significant. See `skbio.stats.composition.ancombc` for details.
     - `reference_group`: Group name used as the reference. All other groups are compared to this
     reference group.
     - `adjustment_method`: method used to adjust p-values to control the false discovery rate
@@ -704,10 +705,13 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
     ) -> AncombcResults:
         """Perform a test for differentially abundant taxa using ANCOM-BC.
 
-        Readcounts are normalized and zeros are replaced using multiplicative replacement. Results
-        indicate taxa that are significantly different in abundance across the grouping variable of
-        interest, as well as each taxon's log2-fold change (with standard error), W-statistic,
-        p-value, and adjusted p-value.
+        Zeros are replaced using multiplicative replacement if `metric` is normalized
+        (i.e. proportionalized) data, otherwise a pseudocount of 1 is added if `metric` is
+        unnormalized (i.e. count) data.
+
+        Results indicate taxa that are significantly different in abundance across the grouping
+        variable of interest, as well as each taxon's log2-fold change (with standard error),
+        W-statistic, p-value, and adjusted p-value (i.e. q-value).
 
         This method is **experimental** and breaking API changes may occur.
 
@@ -722,7 +726,7 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
             to this reference group. If not specified, the first alphabetically sorted group name
             will be used as the reference.
 
-        metric: :class:`~onecodex.lib.enums.Metric`, optional
+        metric : :class:`~onecodex.lib.enums.Metric`, optional
             The taxonomic abundance metric to use. See :class:`~onecodex.lib.enums.Metric`
             for definitions.
 
@@ -815,10 +819,14 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
         # Filter the taxa dataframe to match the remaining IDs in the metadata dataframe
         taxa_df = taxa_df.loc[metadata_df.index]
 
-        # Need to use pseudocounts or `multi_replace()` because ANCOM-BC can't handle zeros
-        multi_replace_df = pd.DataFrame(
-            multi_replace(taxa_df), columns=taxa_df.columns, index=taxa_df.index
-        )
+        # ANCOM-BC can't handle zeros. Use multiplicative replacement for normalized
+        # (i.e. proportionalized) data, or a pseudocount for unnormalized (i.e. count) data.
+        if metric.is_normalized:
+            zero_replaced_df = pd.DataFrame(
+                multi_replace(taxa_df), columns=taxa_df.columns, index=taxa_df.index
+            )
+        else:
+            zero_replaced_df = taxa_df + 1
 
         # Use a safe internal column name for the patsy formula so that it works as both a
         # valid formula term and a metadata column lookup (skbio's `grouping` parameter is
@@ -828,8 +836,9 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
         while ancombc_col in metadata_df.columns:
             ancombc_col = f"_{ancombc_col}_"
         ancombc_metadata = metadata_df.rename(columns={group_by_column_name: ancombc_col})
+
         ancombc_results = ancombc(
-            multi_replace_df,
+            zero_replaced_df,
             ancombc_metadata,
             formula=ancombc_col,
             grouping=ancombc_col if include_global_test else None,
@@ -842,14 +851,23 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
             main_results, global_results = ancombc_results
             global_results = global_results.rename_axis(index={"FeatureID": "Taxon"})
 
-        # Rename the __ancombc_variable__ value in the Covariate column back to the original column
-        # name, and reformat the value to be easier to read
-        main_results = main_results.rename_axis(index={"FeatureID": "Taxon"}).rename(
-            index=lambda covariate: self._rename_ancombc_covariate(
+        main_results = main_results.rename_axis(index={"FeatureID": "Taxon"})
+
+        # Add a Comparison column with human-readable descriptions (e.g.
+        # "group: b vs a (reference)"), and rename __ancombc_variable__ back to the group-by
+        # column name in the Covariate column
+        comparisons = main_results.index.get_level_values("Covariate").map(
+            lambda covariate: self._human_readable_comparison(
                 covariate, ancombc_col, group_by_column_name, reference_group
+            )
+        )
+        main_results = main_results.rename(
+            index=lambda covariate: self._restore_ancombc_covariate(
+                covariate, ancombc_col, group_by_column_name
             ),
             level="Covariate",
         )
+        main_results.insert(0, "Comparison", comparisons.values)
 
         return AncombcResults(
             main_results=main_results,
@@ -896,7 +914,23 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
                 "filtering."
             )
 
-    def _rename_ancombc_covariate(
+    def _match_ancombc_covariate(self, covariate: str, ancombc_col: str) -> re.Match | None:
+        return re.fullmatch(rf"{re.escape(ancombc_col)}\[T\.(.+)\]", covariate)
+
+    def _restore_ancombc_covariate(
+        self,
+        covariate: str,
+        ancombc_col: str,
+        group_by_column_name: str,
+    ) -> str:
+        # Format is "__ancombc_variable__[T.<group_name>]". Restore to
+        # "<group_by_column_name>[T.<group_name>]"
+        m = self._match_ancombc_covariate(covariate, ancombc_col)
+        if m:
+            return f"{group_by_column_name}[T.{m.group(1)}]"
+        return covariate
+
+    def _human_readable_comparison(
         self,
         covariate: str,
         ancombc_col: str,
@@ -905,7 +939,7 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
     ) -> str:
         # Format is "__ancombc_variable__[T.<group_name>]". Reformat to
         # "<group_by_column_name>: <group_name> vs <reference_group> (reference)"
-        m = re.fullmatch(rf"{re.escape(ancombc_col)}\[T\.(.+)\]", covariate)
+        m = self._match_ancombc_covariate(covariate, ancombc_col)
         if m:
             return f"{group_by_column_name}: {m.group(1)} vs {reference_group} (reference)"
         return covariate

--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -834,7 +834,7 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
             formula=ancombc_col,
             grouping=ancombc_col if include_global_test else None,
             alpha=alpha,
-            p_adjust="fdr_bh",
+            p_adjust="holm-bonferroni",
         )
         main_results = ancombc_results
         global_results = None
@@ -856,7 +856,7 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
             global_results=global_results,
             reference_group=reference_group,
             alpha=alpha,
-            adjustment_method=AdjustmentMethod.BenjaminiHochberg,
+            adjustment_method=AdjustmentMethod.HolmBonferroni,
             sample_size=len(metadata_df),
             group_by_variable=group_by_column_name,
             group_sizes=self._get_group_sizes(metadata_df, group_by_column_name),

--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -779,7 +779,7 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
         taxa_df = self._rename_tax_ids(taxa_df)
 
         # `multi_replace()` will error on rows that are all zeros
-        metadata_df = self._drop_samples_with_zero_abundance(metadata_df, taxa_df)
+        metadata_df = self._drop_samples_with_all_zeros(metadata_df, taxa_df, metric)
 
         # Drop groups of size < 2
         # NOTE: it's important to do this filtering *after* the other filters in case those filters
@@ -824,7 +824,9 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
         # valid formula term and a metadata column lookup (skbio's `grouping` parameter is
         # used for both). Using patsy's quoting, e.g. `Q('foo bar')`, doesn't work with the
         # `grouping` parameter.
-        ancombc_col = "__ancombc_group__"
+        ancombc_col = "__ancombc_variable__"
+        while ancombc_col in metadata_df.columns:
+            ancombc_col = f"_{ancombc_col}_"
         ancombc_metadata = metadata_df.rename(columns={group_by_column_name: ancombc_col})
         ancombc_results = ancombc(
             multi_replace_df,
@@ -840,7 +842,7 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
             main_results, global_results = ancombc_results
             global_results = global_results.rename_axis(index={"FeatureID": "Taxon"})
 
-        # Rename the __ancombc_group__ value in the Covariate column back to the original column
+        # Rename the __ancombc_variable__ value in the Covariate column back to the original column
         # name, and reformat the value to be easier to read
         main_results = main_results.rename_axis(index={"FeatureID": "Taxon"}).rename(
             index=lambda covariate: self._rename_ancombc_covariate(
@@ -867,8 +869,8 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
             else tax_id
         )
 
-    def _drop_samples_with_zero_abundance(
-        self, metadata_df: pd.DataFrame, taxa_df: pd.DataFrame
+    def _drop_samples_with_all_zeros(
+        self, metadata_df: pd.DataFrame, taxa_df: pd.DataFrame, metric: Metric
     ) -> pd.DataFrame:
         prev_count = len(metadata_df)
         metadata_df = metadata_df.loc[(taxa_df != 0).any(axis=1)]
@@ -876,8 +878,8 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
         if num_dropped > 0:
             warnings.warn(
                 f"{num_dropped} sample{'s were' if num_dropped > 1 else ' was'} excluded from the "
-                f"test as {'they' if num_dropped > 1 else 'it'} had zero abundance across all "
-                f"taxa.",
+                f"test as {'they' if num_dropped > 1 else 'it'} had zero {metric} values across "
+                f"all taxa.",
                 StatsWarning,
             )
         return metadata_df
@@ -901,7 +903,7 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
         group_by_column_name: str,
         reference_group: str,
     ) -> str:
-        # Format is "__ancombc_group__[T.<group_name>]". Reformat to
+        # Format is "__ancombc_variable__[T.<group_name>]". Reformat to
         # "<group_by_column_name>: <group_name> vs <reference_group> (reference)"
         m = re.fullmatch(rf"{re.escape(ancombc_col)}\[T\.(.+)\]", covariate)
         if m:

--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import itertools
+import re
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
@@ -25,13 +26,10 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, kw_only=True)
 class StatsResults:
-    statistic: float
-    pvalue: float
     alpha: float
     sample_size: int
     group_by_variable: str
     group_sizes: dict[str, int]
-    posthoc: Optional[PosthocResults] = None
 
     @property
     def groups(self) -> set[str]:
@@ -39,7 +37,14 @@ class StatsResults:
 
 
 @dataclass(frozen=True, kw_only=True)
-class AlphaDiversityStatsResults(StatsResults):
+class DiversityStatsResults(StatsResults):
+    statistic: float
+    pvalue: float
+    posthoc: Optional[PosthocResults] = None
+
+
+@dataclass(frozen=True, kw_only=True)
+class AlphaDiversityStatsResults(DiversityStatsResults):
     """A dataclass for storing the results of an alpha diversity stats test.
 
     - `test`: stats test that was performed
@@ -59,7 +64,7 @@ class AlphaDiversityStatsResults(StatsResults):
 
 
 @dataclass(frozen=True, kw_only=True)
-class BetaDiversityStatsResults(StatsResults):
+class BetaDiversityStatsResults(DiversityStatsResults):
     """A dataclass for storing the results of a beta diversity test.
 
     - `test`: stats test that was performed
@@ -96,6 +101,31 @@ class PosthocResults:
     adjusted_pvalues: pd.DataFrame
     pvalues: Optional[pd.DataFrame] = None
     statistics: Optional[pd.DataFrame] = None
+
+
+@dataclass(frozen=True, kw_only=True)
+class AncombcResults(StatsResults):
+    """A dataclass for storing the results of an ANCOM-BC differential abundance test.
+
+    - `main_results`: `pd.DataFrame` containing ANCOM-BC test results for each taxon, including
+    log2-fold change (with standard error), W-statistic, p-value, adjusted p-value, and whether or
+    not the result is statistically significant. See `skbio.stats.composition.ancombc` for details.
+    - `global_results`: `pd.DataFrame` containing global ANCOM-BC test results for each taxon,
+    including W-statistic, p-value, adjusted p-value, and whether or not the result is statistically
+    significant. See `skbio.stats.composition.ancombc` for details.
+    - `reference_group`: Group name used as the reference. All other groups are compared to this
+    reference group.
+    - `adjustment_method`: method used to adjust p-values to control the false discovery rate
+    - `alpha`: p-value threshold used to determine statistical significance
+    - `sample_size`: number of samples used in the test after filtering
+    - `group_by_variable`: name of the variable used to group samples by
+    - `group_sizes`: dict mapping group name to sample size in each group
+    """
+
+    main_results: pd.DataFrame
+    global_results: pd.DataFrame | None = None
+    reference_group: str
+    adjustment_method: AdjustmentMethod
 
 
 class StatsMixin(DistanceMixin, BaseSampleCollection):
@@ -220,7 +250,6 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
         # Drop groups of size < 2
         # NOTE: it's important to do this filtering *after* the other filters in case those filters
         # change the group sizes.
-
         df = self._drop_group_sizes_smaller_than(df, group_by_column_name, 2)
 
         self._assert_min_num_groups(df, group_by_column_name, 2)
@@ -339,6 +368,12 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
                 f"`group_by` must have exactly {exact_num_groups} groups to test between after "
                 f"filtering (found {num_groups})."
             )
+
+    def _get_group_sizes(self, df: pd.DataFrame, group_by_column_name: str) -> dict[str, int]:
+        return {
+            name: len(group_df)
+            for name, group_df in df.groupby(group_by_column_name, observed=True)
+        }
 
     def _get_group_sizes_and_alpha_diversity_values(
         self, df: pd.DataFrame, metric: str, group_by_column_name: str
@@ -578,7 +613,7 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
         from scipy.stats import false_discovery_control
         from skbio.stats.distance import permanova
 
-        group_sizes = {name: len(group_df) for name, group_df in df.groupby(group_by_column_name)}
+        group_sizes = self._get_group_sizes(df, group_by_column_name)
         result = permanova(dm, df, column=group_by_column_name, permutations=num_permutations)
 
         posthoc = None
@@ -655,3 +690,220 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
             group_sizes=group_sizes,
             posthoc=posthoc,
         )
+
+    def _ancombc(
+        self,
+        *,
+        group_by: str | tuple[str, ...] | list[str],
+        reference_group: str | None = None,
+        metric: Metric = Metric.Auto,
+        rank: Rank = Rank.Auto,
+        alpha: float = 0.05,
+        include_global_test: bool = False,
+        require_classification_version_match: bool = True,
+    ) -> AncombcResults:
+        """Perform a test for differentially abundant taxa using ANCOM-BC.
+
+        Readcounts are normalized and zeros are replaced using multiplicative replacement. Results
+        indicate taxa that are significantly different in abundance across the grouping variable of
+        interest, as well as each taxon's log2-fold change (with standard error), W-statistic,
+        p-value, and adjusted p-value.
+
+        This method is **experimental** and breaking API changes may occur.
+
+        Parameters
+        ----------
+        group_by : str or tuple of str or list of str
+            Metadata variable to group samples by. At least two groups are required. If `group_by`
+            is a tuple or list, field values are joined with an underscore character ("_").
+
+        reference_group : str, optional
+            Metadata variable group name to use as the reference. All other groups will be compared
+            to this reference group. If not specified, the first alphabetically sorted group name
+            will be used as the reference.
+
+        metric: :class:`~onecodex.lib.enums.Metric`, optional
+            The taxonomic abundance metric to use. See :class:`~onecodex.lib.enums.Metric`
+            for definitions.
+
+        rank : :class:`~onecodex.lib.enums.Rank`, optional
+            Analysis will be restricted to abundances of taxa at the specified level.
+            See :class:`~onecodex.lib.enums.Rank` for details.
+
+        alpha : float, optional
+            Threshold to determine statistical significance (e.g. p < `alpha`). Must be between 0
+            and 1 (exclusive).
+
+        include_global_test : bool, optional
+            If ``True``, include global ANCOM-BC results in addition to the main results. A global
+            test can only be run if there are at least 3 groups.
+
+        require_classification_version_match : bool, optional
+            If ``True``, require the same primary classification job ID across all samples included
+            in the test.
+
+        Returns
+        -------
+        :class:`~onecodex.stats.AncombcResults`
+
+        See Also
+        --------
+        skbio.stats.composition.ancombc
+        skbio.stats.composition.multi_replace
+
+        """
+        import pandas as pd
+        from skbio.stats.composition import ancombc, multi_replace
+
+        self._assert_valid_alpha(alpha)
+        metric, rank = self._parse_classification_config_args(metric=metric, rank=rank)
+
+        # Munge the metadata first in case there's any errors
+        group_by = self._tuplize(group_by)
+        metadata_results = self._metadata_fetch(
+            [group_by],
+            results_df=self.to_classification_df(rank=rank, metric=metric),
+            coerce_missing_composite_fields=False,
+        )
+        metadata_df = metadata_results.df
+        group_by_column_name = metadata_results.renamed_fields[group_by]
+
+        # Drop samples with missing group_by data
+        metadata_df = self._drop_missing_data(metadata_df, group_by_column_name, "group_by")
+
+        # Drop samples missing abundance data
+        if metric.is_abundance_metric:
+            metadata_df = self._drop_classifications_without_abundances(metadata_df)
+
+        taxa_df = self.to_classification_df(rank=rank, metric=metric)
+        taxa_df = self._rename_tax_ids(taxa_df)
+
+        # `multi_replace()` will error on rows that are all zeros
+        metadata_df = self._drop_samples_with_zero_abundance(metadata_df, taxa_df)
+
+        # Drop groups of size < 2
+        # NOTE: it's important to do this filtering *after* the other filters in case those filters
+        # change the group sizes
+        metadata_df = self._drop_group_sizes_smaller_than(metadata_df, group_by_column_name, 2)
+
+        self._assert_min_num_groups(metadata_df, group_by_column_name, 2)
+
+        if require_classification_version_match:
+            self._assert_single_database_version(metadata_df)
+
+        group_names = sorted(metadata_df[group_by_column_name].unique())
+        if reference_group:
+            if reference_group not in group_names:
+                raise StatsException(
+                    f"`reference_group` must be a group name defined by `group_by`. Valid group "
+                    f"names after filtering: {', '.join(group_names)}"
+                )
+        else:
+            reference_group = metadata_df[group_by_column_name].min()
+
+        # Reference group must be the first group
+        group_names.remove(reference_group)
+        group_names = [reference_group] + group_names
+        metadata_df[group_by_column_name] = pd.Categorical(
+            metadata_df[group_by_column_name], categories=group_names, ordered=True
+        )
+
+        # ANCOM-BC can only run a global test if there's at least 3 groups
+        if include_global_test:
+            self._assert_min_num_groups_for_global_test(metadata_df, group_by_column_name)
+
+        # Filter the taxa dataframe to match the remaining IDs in the metadata dataframe
+        taxa_df = taxa_df.loc[metadata_df.index]
+
+        # Need to use pseudocounts or `multi_replace()` because ANCOM-BC can't handle zeros
+        multi_replace_df = pd.DataFrame(
+            multi_replace(taxa_df), columns=taxa_df.columns, index=taxa_df.index
+        )
+
+        # Use a safe internal column name for the patsy formula so that it works as both a
+        # valid formula term and a metadata column lookup (skbio's `grouping` parameter is
+        # used for both). Using patsy's quoting, e.g. `Q('foo bar')`, doesn't work with the
+        # `grouping` parameter.
+        ancombc_col = "__ancombc_group__"
+        ancombc_metadata = metadata_df.rename(columns={group_by_column_name: ancombc_col})
+        ancombc_results = ancombc(
+            multi_replace_df,
+            ancombc_metadata,
+            formula=ancombc_col,
+            grouping=ancombc_col if include_global_test else None,
+            alpha=alpha,
+            p_adjust="fdr_bh",
+        )
+        main_results = ancombc_results
+        global_results = None
+        if include_global_test:
+            main_results, global_results = ancombc_results
+            global_results = global_results.rename_axis(index={"FeatureID": "Taxon"})
+
+        # Rename the __ancombc_group__ value in the Covariate column back to the original column
+        # name, and reformat the value to be easier to read
+        main_results = main_results.rename_axis(index={"FeatureID": "Taxon"}).rename(
+            index=lambda covariate: self._rename_ancombc_covariate(
+                covariate, ancombc_col, group_by_column_name, reference_group
+            ),
+            level="Covariate",
+        )
+
+        return AncombcResults(
+            main_results=main_results,
+            global_results=global_results,
+            reference_group=reference_group,
+            alpha=alpha,
+            adjustment_method=AdjustmentMethod.BenjaminiHochberg,
+            sample_size=len(metadata_df),
+            group_by_variable=group_by_column_name,
+            group_sizes=self._get_group_sizes(metadata_df, group_by_column_name),
+        )
+
+    def _rename_tax_ids(self, taxa_df: pd.DataFrame) -> pd.DataFrame:
+        return taxa_df.rename(
+            columns=lambda tax_id: f"{self.taxonomy['name'][tax_id]} ({tax_id})"
+            if tax_id in self.taxonomy["name"]
+            else tax_id
+        )
+
+    def _drop_samples_with_zero_abundance(
+        self, metadata_df: pd.DataFrame, taxa_df: pd.DataFrame
+    ) -> pd.DataFrame:
+        prev_count = len(metadata_df)
+        metadata_df = metadata_df.loc[(taxa_df != 0).any(axis=1)]
+        num_dropped = prev_count - len(metadata_df)
+        if num_dropped > 0:
+            warnings.warn(
+                f"{num_dropped} sample{'s were' if num_dropped > 1 else ' was'} excluded from the "
+                f"test as {'they' if num_dropped > 1 else 'it'} had zero abundance across all "
+                f"taxa.",
+                StatsWarning,
+            )
+        return metadata_df
+
+    def _assert_min_num_groups_for_global_test(
+        self, metadata_df: pd.DataFrame, group_by_column_name: str
+    ):
+        try:
+            self._assert_min_num_groups(metadata_df, group_by_column_name, 3)
+        except StatsException:
+            # Raise a more specific error message
+            raise StatsException(
+                "`include_global_test=True` may only be used if there are at least 3 groups after "
+                "filtering."
+            )
+
+    def _rename_ancombc_covariate(
+        self,
+        covariate: str,
+        ancombc_col: str,
+        group_by_column_name: str,
+        reference_group: str,
+    ) -> str:
+        # Format is "__ancombc_group__[T.<group_name>]". Reformat to
+        # "<group_by_column_name>: <group_name> vs <reference_group> (reference)"
+        m = re.fullmatch(rf"{re.escape(ancombc_col)}\[T\.(.+)\]", covariate)
+        if m:
+            return f"{group_by_column_name}: {m.group(1)} vs {reference_group} (reference)"
+        return covariate

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -17,24 +17,33 @@ from onecodex.lib.enums import (
     PosthocStatsTest,
 )
 from onecodex.models.collection import SampleCollection
-from onecodex.stats import AlphaDiversityStatsResults, BetaDiversityStatsResults
+from onecodex.stats import (
+    AlphaDiversityStatsResults,
+    AncombcResults,
+    BetaDiversityStatsResults,
+)
+
+ANCOMBC_MAIN_RESULTS_COLUMNS = {"Log2(FC)", "SE", "W", "pvalue", "qvalue", "Signif"}
+ANCOMBC_MAIN_RESULTS_INDEX_NAMES = ["Taxon", "Covariate"]
+ANCOMBC_GLOBAL_RESULTS_INDEX_NAME = "Taxon"
+ANCOMBC_GLOBAL_RESULTS_COLUMNS = {"W", "pvalue", "qvalue", "Signif"}
 
 
-@pytest.mark.parametrize("method", ["alpha_diversity_stats", "beta_diversity_stats"])
+@pytest.mark.parametrize("method", ["alpha_diversity_stats", "beta_diversity_stats", "_ancombc"])
 @pytest.mark.parametrize("alpha", [-1, 0, 1, 1.1, 2])
 def test_invalid_alpha(samples, method, alpha):
     with pytest.raises(StatsException, match="`alpha` must be between 0 and 1"):
         getattr(samples, method)(group_by="wheat", alpha=alpha)
 
 
-@pytest.mark.parametrize("method", ["alpha_diversity_stats", "beta_diversity_stats"])
+@pytest.mark.parametrize("method", ["alpha_diversity_stats", "beta_diversity_stats", "_ancombc"])
 @pytest.mark.parametrize("fields", [1, 4.2, False, b"", (42,), [-1.0], ("wheat", 43)])
 def test_invalid_metadata_fields(samples, method, fields):
     with pytest.raises(OneCodexException, match="type str"):
         getattr(samples, method)(group_by=fields)
 
 
-@pytest.mark.parametrize("method", ["alpha_diversity_stats", "beta_diversity_stats"])
+@pytest.mark.parametrize("method", ["alpha_diversity_stats", "beta_diversity_stats", "_ancombc"])
 @pytest.mark.parametrize(
     "group_by,num_groups", [("col1", 1), (("col1", "col2"), 0), (["col1", "col2"], 0)]
 )
@@ -63,6 +72,7 @@ def test_missing_group_by_data(samples, method, group_by, num_groups):
             },
         ),
         ("beta_diversity_stats", {"metric": Metric.AbundanceWChildren}),
+        ("_ancombc", {"metric": Metric.AbundanceWChildren}),
     ],
 )
 def test_samples_missing_abundances(samples_without_abundances, method, kwargs):
@@ -87,6 +97,7 @@ def test_samples_missing_abundances(samples_without_abundances, method, kwargs):
             },
         ),
         ("beta_diversity_stats", {"metric": Metric.ReadcountWChildren}),
+        ("_ancombc", {"metric": Metric.ReadcountWChildren}),
     ],
 )
 def test_samples_missing_abundance_readcount_metric(samples_without_abundances, method, kwargs):
@@ -101,7 +112,7 @@ def test_samples_missing_abundance_readcount_metric(samples_without_abundances, 
         getattr(samples_without_abundances, method)(group_by="col", **kwargs)
 
 
-@pytest.mark.parametrize("method", ["alpha_diversity_stats", "beta_diversity_stats"])
+@pytest.mark.parametrize("method", ["alpha_diversity_stats", "beta_diversity_stats", "_ancombc"])
 @pytest.mark.parametrize(
     "values,num_groups",
     [(["one_value", "one_value", "one_value"], 1), (["all", "different", "values"], 0)],
@@ -117,7 +128,7 @@ def test_not_enough_groups(samples, method, values, num_groups):
         getattr(samples, method)(group_by="col", rank="genus")
 
 
-@pytest.mark.parametrize("method", ["alpha_diversity_stats", "beta_diversity_stats"])
+@pytest.mark.parametrize("method", ["alpha_diversity_stats", "beta_diversity_stats", "_ancombc"])
 @pytest.mark.parametrize("require_classification_version_match", [True, False])
 @pytest.mark.filterwarnings("ignore:.*multiple analysis types.*:UserWarning")
 def test_require_classification_version_match(
@@ -464,3 +475,203 @@ def test_permanova(samples):
 )
 def test_stats_results_groups(results, expected_groups):
     assert results.groups == expected_groups
+
+
+def test_rename_tax_ids(samples):
+    taxa_df = pd.DataFrame(
+        {"tax1": [10, 20], "tax2": [30, 40], "unknown": [50, 60]}, index=["s1", "s2"]
+    )
+
+    with mock.patch.object(
+        type(samples),
+        "taxonomy",
+        new_callable=mock.PropertyMock,
+        return_value={"name": {"tax1": "Bacteroides", "tax2": "Prevotella"}},
+    ):
+        result = samples._rename_tax_ids(taxa_df)
+
+    assert list(result.columns) == ["Bacteroides (tax1)", "Prevotella (tax2)", "unknown"]
+    assert result.values.tolist() == taxa_df.values.tolist()
+
+
+def test_drop_samples_with_zero_abundance(samples):
+    metadata_df = pd.DataFrame({"group": ["a", "b", "c"]}, index=["s1", "s2", "s3"])
+    taxa_df = pd.DataFrame({"t1": [1, 0, 3], "t2": [4, 0, 6]}, index=["s1", "s2", "s3"])
+
+    with pytest.warns(StatsWarning, match="1 sample was excluded.*zero abundance"):
+        result = samples._drop_samples_with_zero_abundance(metadata_df, taxa_df)
+
+    assert list(result.index) == ["s1", "s3"]
+
+
+def test_drop_samples_with_zero_abundance_none_dropped(samples):
+    metadata_df = pd.DataFrame({"group": ["a", "b"]}, index=["s1", "s2"])
+    taxa_df = pd.DataFrame({"t1": [1, 2], "t2": [3, 4]}, index=["s1", "s2"])
+
+    result = samples._drop_samples_with_zero_abundance(metadata_df, taxa_df)
+
+    assert list(result.index) == ["s1", "s2"]
+
+
+def test_assert_min_num_groups_for_global_test(samples):
+    df = pd.DataFrame({"group": ["a", "b", "a", "b"]})
+
+    with pytest.raises(StatsException, match="include_global_test.*at least 3 groups"):
+        samples._assert_min_num_groups_for_global_test(df, "group")
+
+
+def _assert_ancombc_covariates(
+    main_results, group_by_variable, reference_group, non_reference_groups
+):
+    covariates = set(main_results.index.get_level_values("Covariate").unique())
+    expected_covariates = {"Intercept"} | {
+        f"{group_by_variable}: {g} vs {reference_group} (reference)" for g in non_reference_groups
+    }
+    assert covariates == expected_covariates
+
+
+def test_ancombc(ocx, api_data, samples):
+    samples.extend([ocx.Samples.get("cc18208d98ad48b3"), ocx.Samples.get("5445740666134eee")])
+
+    for sample, group in zip(samples, ["a", "b", "a", "b", "a"]):
+        sample.metadata.custom["group"] = group
+
+    results = samples._ancombc(group_by="group", metric="readcount_w_children", rank="genus")
+
+    assert isinstance(results, AncombcResults)
+    assert results.reference_group == "a"
+    assert results.alpha == 0.05
+    assert results.adjustment_method == AdjustmentMethod.BenjaminiHochberg
+    assert results.sample_size == 5
+    assert results.group_by_variable == "group"
+    assert results.group_sizes == {"a": 3, "b": 2}
+    assert results.global_results is None
+    assert set(results.main_results.columns) == ANCOMBC_MAIN_RESULTS_COLUMNS
+    assert results.main_results.index.names == ANCOMBC_MAIN_RESULTS_INDEX_NAMES
+    assert len(results.main_results) > 0
+    _assert_ancombc_covariates(results.main_results, "group", "a", ["b"])
+
+
+def test_ancombc_composite_group_by(ocx, api_data, samples):
+    samples.extend([ocx.Samples.get("cc18208d98ad48b3"), ocx.Samples.get("5445740666134eee")])
+
+    for sample, c1, c2 in zip(samples, ["x", "x", "y", "y", "x"], ["1", "1", "2", "2", "1"]):
+        sample.metadata.custom["col1"] = c1
+        sample.metadata.custom["col2"] = c2
+
+    results = samples._ancombc(
+        group_by=("col1", "col2"), metric="readcount_w_children", rank="genus"
+    )
+
+    assert results.group_by_variable == "col1_col2"
+    assert results.group_sizes == {"x_1": 3, "y_2": 2}
+    assert results.reference_group == "x_1"
+    assert set(results.main_results.columns) == ANCOMBC_MAIN_RESULTS_COLUMNS
+    assert results.main_results.index.names == ANCOMBC_MAIN_RESULTS_INDEX_NAMES
+    _assert_ancombc_covariates(results.main_results, "col1_col2", "x_1", ["y_2"])
+
+
+def test_ancombc_explicit_reference_group(ocx, api_data, samples):
+    samples.extend([ocx.Samples.get("cc18208d98ad48b3"), ocx.Samples.get("5445740666134eee")])
+
+    for sample, group in zip(samples, ["a", "b", "a", "b", "a"]):
+        sample.metadata.custom["group"] = group
+
+    results = samples._ancombc(
+        group_by="group",
+        reference_group="b",
+        metric="readcount_w_children",
+        rank="genus",
+    )
+
+    assert results.reference_group == "b"
+    _assert_ancombc_covariates(results.main_results, "group", "b", ["a"])
+
+
+def test_ancombc_invalid_reference_group(ocx, api_data, samples):
+    samples.extend([ocx.Samples.get("cc18208d98ad48b3"), ocx.Samples.get("5445740666134eee")])
+
+    for sample, group in zip(samples, ["a", "b", "a", "b", "a"]):
+        sample.metadata.custom["group"] = group
+
+    with pytest.raises(StatsException, match="reference_group.*group name"):
+        samples._ancombc(
+            group_by="group",
+            reference_group="nonexistent",
+            metric="readcount_w_children",
+            rank="genus",
+        )
+
+
+def test_ancombc_with_global_test(ocx, api_data, samples):
+    samples.extend(
+        [
+            ocx.Samples.get("cc18208d98ad48b3"),
+            ocx.Samples.get("5445740666134eee"),
+            ocx.Samples.get("0ecac25ec0004fe4"),
+        ]
+    )
+
+    for sample, group in zip(samples, ["a", "b", "c", "a", "b", "c"]):
+        sample.metadata.custom["group"] = group
+
+    with pytest.warns(UserWarning):
+        results = samples._ancombc(
+            group_by="group",
+            include_global_test=True,
+            metric="readcount_w_children",
+            rank="genus",
+            require_classification_version_match=False,
+        )
+
+    assert results.reference_group == "a"
+    assert results.group_sizes == {"a": 2, "b": 2, "c": 2}
+    assert set(results.main_results.columns) == ANCOMBC_MAIN_RESULTS_COLUMNS
+    assert results.main_results.index.names == ANCOMBC_MAIN_RESULTS_INDEX_NAMES
+    _assert_ancombc_covariates(results.main_results, "group", "a", ["b", "c"])
+    assert results.global_results is not None
+    assert results.global_results.index.name == ANCOMBC_GLOBAL_RESULTS_INDEX_NAME
+    assert set(results.global_results.columns) == ANCOMBC_GLOBAL_RESULTS_COLUMNS
+
+
+def test_ancombc_global_test_too_few_groups(ocx, api_data, samples):
+    samples.extend([ocx.Samples.get("cc18208d98ad48b3"), ocx.Samples.get("5445740666134eee")])
+
+    for sample, group in zip(samples, ["a", "b", "a", "b", "a"]):
+        sample.metadata.custom["group"] = group
+
+    with pytest.raises(StatsException, match="include_global_test.*at least 3 groups"):
+        samples._ancombc(
+            group_by="group",
+            include_global_test=True,
+            metric="readcount_w_children",
+            rank="genus",
+        )
+
+
+def test_ancombc_three_groups(ocx, api_data, samples):
+    samples.extend(
+        [
+            ocx.Samples.get("cc18208d98ad48b3"),
+            ocx.Samples.get("5445740666134eee"),
+            ocx.Samples.get("0ecac25ec0004fe4"),
+        ]
+    )
+
+    for sample, group in zip(samples, ["a", "b", "c", "a", "b", "c"]):
+        sample.metadata.custom["group"] = group
+
+    with pytest.warns(UserWarning):
+        results = samples._ancombc(
+            group_by="group",
+            metric="readcount_w_children",
+            rank="genus",
+            require_classification_version_match=False,
+        )
+
+    assert results.reference_group == "a"
+    assert results.sample_size == 6
+    assert results.group_sizes == {"a": 2, "b": 2, "c": 2}
+    assert set(results.main_results.columns) == ANCOMBC_MAIN_RESULTS_COLUMNS
+    assert results.main_results.index.names == ANCOMBC_MAIN_RESULTS_INDEX_NAMES
+    _assert_ancombc_covariates(results.main_results, "group", "a", ["b", "c"])

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -541,7 +541,7 @@ def test_ancombc(ocx, api_data, samples):
     assert isinstance(results, AncombcResults)
     assert results.reference_group == "a"
     assert results.alpha == 0.05
-    assert results.adjustment_method == AdjustmentMethod.BenjaminiHochberg
+    assert results.adjustment_method == AdjustmentMethod.HolmBonferroni
     assert results.sample_size == 5
     assert results.group_by_variable == "group"
     assert results.group_sizes == {"a": 3, "b": 2}

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -494,21 +494,21 @@ def test_rename_tax_ids(samples):
     assert result.values.tolist() == taxa_df.values.tolist()
 
 
-def test_drop_samples_with_zero_abundance(samples):
+def test_drop_samples_with_all_zeros(samples):
     metadata_df = pd.DataFrame({"group": ["a", "b", "c"]}, index=["s1", "s2", "s3"])
     taxa_df = pd.DataFrame({"t1": [1, 0, 3], "t2": [4, 0, 6]}, index=["s1", "s2", "s3"])
 
     with pytest.warns(StatsWarning, match="1 sample was excluded.*zero abundance"):
-        result = samples._drop_samples_with_zero_abundance(metadata_df, taxa_df)
+        result = samples._drop_samples_with_all_zeros(metadata_df, taxa_df, Metric.Abundance)
 
     assert list(result.index) == ["s1", "s3"]
 
 
-def test_drop_samples_with_zero_abundance_none_dropped(samples):
+def test_drop_samples_with_all_zeros_none_dropped(samples):
     metadata_df = pd.DataFrame({"group": ["a", "b"]}, index=["s1", "s2"])
     taxa_df = pd.DataFrame({"t1": [1, 2], "t2": [3, 4]}, index=["s1", "s2"])
 
-    result = samples._drop_samples_with_zero_abundance(metadata_df, taxa_df)
+    result = samples._drop_samples_with_all_zeros(metadata_df, taxa_df, Metric.Abundance)
 
     assert list(result.index) == ["s1", "s2"]
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -23,7 +23,7 @@ from onecodex.stats import (
     BetaDiversityStatsResults,
 )
 
-ANCOMBC_MAIN_RESULTS_COLUMNS = {"Log2(FC)", "SE", "W", "pvalue", "qvalue", "Signif"}
+ANCOMBC_MAIN_RESULTS_COLUMNS = {"Comparison", "Log2(FC)", "SE", "W", "pvalue", "qvalue", "Signif"}
 ANCOMBC_MAIN_RESULTS_INDEX_NAMES = ["Taxon", "Covariate"]
 ANCOMBC_GLOBAL_RESULTS_INDEX_NAME = "Taxon"
 ANCOMBC_GLOBAL_RESULTS_COLUMNS = {"W", "pvalue", "qvalue", "Signif"}
@@ -525,9 +525,15 @@ def _assert_ancombc_covariates(
 ):
     covariates = set(main_results.index.get_level_values("Covariate").unique())
     expected_covariates = {"Intercept"} | {
-        f"{group_by_variable}: {g} vs {reference_group} (reference)" for g in non_reference_groups
+        f"{group_by_variable}[T.{g}]" for g in non_reference_groups
     }
     assert covariates == expected_covariates
+
+    comparisons = set(main_results["Comparison"].unique())
+    expected_comparisons = {"Intercept"} | {
+        f"{group_by_variable}: {g} vs {reference_group} (reference)" for g in non_reference_groups
+    }
+    assert comparisons == expected_comparisons
 
 
 def test_ancombc(ocx, api_data, samples):

--- a/tests/wasm_test_runner/index.js
+++ b/tests/wasm_test_runner/index.js
@@ -43,6 +43,7 @@ async function main() {
         "scikit_bio-0.7.1.post7-cp313-cp313-pyodide_2025_0_wasm32.whl",
         deps=False,
     )
+    await micropip.install("array_api_compat")  # required scikit-bio dependency
 
     for package in project_cfg["dependency-groups"]["dev"]:
         if should_install(package):
@@ -73,7 +74,6 @@ async function main() {
             return NoOp()
 
     mocked_modules = [
-        "array_api_compat",
         "biom",
         "filelock",
         "h5py",


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Added ANCOM-BC differential abundance test via `SampleCollection._ancombc()`. This method is currently **experimental** and breaking API changes may occur.

- Multiple metadata grouping variables are supported (e.g. secondary, tertiary, ...)
- An explicit reference group may be specified
- A global ANCOM-BC test may be run in addition to the main results (only available if there are at least 3 groups)
- Abundance metric, rank, and alpha are parametrized

Plots will be included in a future PR.

Closes DEV-11520

### Example: 2 groups

<img width="992" height="480" alt="Screenshot 2026-04-14 at 2 07 41 PM" src="https://github.com/user-attachments/assets/6da7733e-05bc-4ba9-8f32-2b30d7285c2b" />

### Example: >2 groups, with secondary group by

<img width="996" height="649" alt="Screenshot 2026-04-14 at 2 09 15 PM" src="https://github.com/user-attachments/assets/04d3a3e8-27d5-4f2d-8211-ee4d9e855abc" />
<img width="995" height="444" alt="Screenshot 2026-04-14 at 2 09 34 PM" src="https://github.com/user-attachments/assets/736def63-7b26-4edd-9be1-e6d61b895ae5" />

## Related PRs
- [x] This PR is independent