### PR TITLE
Add ANCOM-BC results plots

### DIFF
--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 from onecodex.distance import DistanceMixin
-from onecodex.exceptions import OneCodexException, StatsException, StatsWarning
+from onecodex.exceptions import OneCodexException, PlottingException, StatsException, StatsWarning
 from onecodex.lib.enums import (
     Metric,
     Rank,
@@ -18,8 +18,10 @@ from onecodex.lib.enums import (
     PosthocStatsTest,
 )
 from onecodex.models.base_sample_collection import BaseSampleCollection
+from onecodex.viz._primitives import prepare_props
 
 if TYPE_CHECKING:
+    import altair as alt
     import pandas as pd
     import skbio
 
@@ -127,6 +129,98 @@ class AncombcResults(StatsResults):
     global_results: pd.DataFrame | None = None
     reference_group: str
     adjustment_method: AdjustmentMethod
+
+    def plot(
+        self,
+        title: str | None = None,
+        width: int | str | None = None,
+        height: int | str | None = None,
+        return_chart: bool = False,
+    ) -> alt.FacetChart | None:
+        """Plot ANCOM-BC results as bargraphs faceted by group.
+
+        A bargraph of log2-fold change is generated for each significantly different taxon, faceted
+        by group.
+
+        Parameters
+        ----------
+        title : str, optional
+            Text label at the top of the chart.
+
+        width : int or str, optional
+            The width of the chart. Can be `"container"` for responsive sizing.
+
+        height : int or str, optional
+            The height of the chart. Can be `"container"` for responsive sizing.
+
+        return_chart : bool, optional
+            When `True`, return an `altair.FacetChart` object instead of displaying the resulting
+            chart in the current notebook.
+
+        Returns
+        -------
+        alt.FacetChart or None
+            If `return_chart` is `True`, the Altair chart is returned, otherwise `None` is returned
+            and the chart is displayed in the current notebook.
+
+        """
+        import altair as alt
+
+        df = self.main_results.query('Covariate != "Intercept" & Signif == True')
+
+        if len(df) == 0:
+            raise PlottingException(
+                "ANCOM-BC did not detect any statistically significant results."
+            )
+
+        df = df.reset_index()
+
+        df["Difference from reference"] = "No change"
+        df.loc[(df["Log2(FC)"] < 0), "Difference from reference"] = "Decreased"
+        df.loc[(df["Log2(FC)"] > 0), "Difference from reference"] = "Increased"
+
+        color_domain = ["Decreased", "Increased"]
+        color_range = ["#CC3300", "#0033CC"]
+
+        # Symmetric x-axis domain around zero, with a minimum extent of ±0.5. Log2(FC) of 0.5 is
+        # sometimes considered "biologically relevant", which is why we use this minimum threshold.
+        x_extent = max(df["Log2(FC)"].abs().max(), 0.5)
+
+        base = alt.Chart(df)
+
+        bars = base.mark_bar().encode(
+            x=alt.X("Log2(FC):Q", title="Log2(FC)", scale=alt.Scale(domain=[-x_extent, x_extent])),
+            y=alt.Y("Taxon:O", title="Taxon"),
+            color=alt.Color(
+                "Difference from reference:N",
+                scale=alt.Scale(domain=color_domain, range=color_range),
+            ),
+            tooltip=["Taxon", "Comparison", "Log2(FC)", "pvalue", "qvalue"],
+        )
+
+        # Dashed vertical reference line at x=0
+        rule = base.mark_rule(color="black", strokeDash=[5, 5]).encode(x=alt.datum(0))
+
+        inner_props = prepare_props(width=width, height=height)
+        if "height" not in inner_props:
+            # By default, make each bar's height uniform across facets (even if facets have a
+            # different number of bars)
+            inner_props["height"] = alt.Step(10)
+
+        chart = (
+            alt.layer(bars, rule)
+            .properties(**inner_props)
+            .facet(
+                row=alt.Row(
+                    "Comparison:N", title=None, header=alt.Header(labelOrient="top", labelAngle=0)
+                )
+            )
+            .resolve_scale(x="independent", y="independent")
+        )
+
+        chart = chart.properties(**prepare_props(title=title))
+
+        return chart if return_chart else chart.display()
 
 
 class StatsMixin(DistanceMixin, BaseSampleCollection):

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -3,11 +3,12 @@ import pytest
 
 pytest.importorskip("pandas")  # noqa
 
+import altair as alt
 import numpy as np
 import pandas as pd
 import skbio
 
-from onecodex.exceptions import OneCodexException, StatsException, StatsWarning
+from onecodex.exceptions import OneCodexException, PlottingException, StatsException, StatsWarning
 from onecodex.lib.enums import (
     AdjustmentMethod,
     AlphaDiversityMetric,
@@ -681,3 +682,102 @@ def test_ancombc_three_groups(ocx, api_data, samples):
     assert set(results.main_results.columns) == ANCOMBC_MAIN_RESULTS_COLUMNS
     assert results.main_results.index.names == ANCOMBC_MAIN_RESULTS_INDEX_NAMES
     _assert_ancombc_covariates(results.main_results, "group", "a", ["b", "c"])
+
+
+def _make_ancombc_results(rows):
+    """Build an AncombcResults from (Taxon, Covariate, Comparison, Log2FC, Signif) tuples."""
+    index = pd.MultiIndex.from_tuples([(r[0], r[1]) for r in rows], names=["Taxon", "Covariate"])
+    main_results = pd.DataFrame(
+        [
+            {
+                "Comparison": r[2],
+                "Log2(FC)": r[3],
+                "SE": 0.3,
+                "W": 2.0,
+                "pvalue": 0.01,
+                "qvalue": 0.02,
+                "Signif": r[4],
+            }
+            for r in rows
+        ],
+        index=index,
+    )
+    return AncombcResults(
+        main_results=main_results,
+        reference_group="ref",
+        adjustment_method=AdjustmentMethod.BenjaminiHochberg,
+        alpha=0.05,
+        sample_size=10,
+        group_by_variable="group",
+        group_sizes={"ref": 5, "treat": 5},
+    )
+
+
+def test_ancombc_results_plot():
+    rows = [
+        ("TaxonA", "Intercept", "Intercept", 1.0, True),
+        ("TaxonB", "Intercept", "Intercept", -0.5, False),
+        ("TaxonA", "group[T.b]", "group: b vs ref (reference)", 1.5, True),
+        ("TaxonA", "group[T.c]", "group: c vs ref (reference)", -0.9, True),
+        ("TaxonB", "group[T.b]", "group: b vs ref (reference)", -1.0, True),
+        ("TaxonB", "group[T.c]", "group: c vs ref (reference)", 0.3, False),
+    ]
+    results = _make_ancombc_results(rows)
+    chart = results.plot(return_chart=True)
+    spec = chart.to_dict()
+    data = pd.DataFrame(spec["datasets"][spec["data"]["name"]])
+
+    assert isinstance(chart, alt.FacetChart)
+
+    # Faceted by Comparison with independent x and y scales
+    assert spec["facet"]["row"]["field"] == "Comparison"
+    assert spec["resolve"]["scale"]["x"] == "independent"
+    assert spec["resolve"]["scale"]["y"] == "independent"
+
+    # Default height uses step sizing
+    assert spec["spec"]["height"] == {"step": 10}
+
+    # Intercept rows are excluded
+    assert "Intercept" not in data["Comparison"].values
+
+    # Non-significant rows are excluded
+    assert set(data["Taxon"][data["Comparison"] == "group: c vs ref (reference)"]) == {"TaxonA"}
+
+    # Both non-Intercept comparisons are present
+    assert set(data["Comparison"].unique()) == {
+        "group: b vs ref (reference)",
+        "group: c vs ref (reference)",
+    }
+
+    # Color encoding
+    bars = spec["spec"]["layer"][0]
+    assert bars["encoding"]["color"]["field"] == "Difference from reference"
+    assert len(bars["encoding"]["color"]["scale"]["domain"]) == 2
+    assert len(bars["encoding"]["color"]["scale"]["range"]) == 2
+
+
+def test_ancombc_results_plot_no_significant_results():
+    rows = [
+        ("TaxonA", "Intercept", "Intercept", 1.0, True),
+        ("TaxonA", "group[T.treat]", "group: treat vs ref (reference)", 0.2, False),
+    ]
+    results = _make_ancombc_results(rows)
+
+    with pytest.raises(PlottingException, match="any statistically significant results"):
+        results.plot(return_chart=True)
+
+
+def test_ancombc_results_plot_props():
+    rows = [
+        ("TaxonA", "Intercept", "Intercept", 1.0, True),
+        ("TaxonA", "group[T.treat]", "group: treat vs ref (reference)", 1.2, True),
+    ]
+    results = _make_ancombc_results(rows)
+
+    spec_no_title = results.plot(return_chart=True).to_dict()
+    assert "title" not in spec_no_title
+
+    spec = results.plot(title="My Title", width=400, height=200, return_chart=True).to_dict()
+    assert spec["title"] == "My Title"
+    assert spec["spec"]["width"] == 400
+    assert spec["spec"]["height"] == 200


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Added `AncombcResults.plot()` method, which generates a bargraph of log2-fold change for each significantly different taxon, faceted by group.

Closes DEV-11520

<img width="996" height="289" alt="Screenshot 2026-04-14 at 2 36 30 PM" src="https://github.com/user-attachments/assets/05ebbe15-a4cf-4263-9905-dcfdb9360d27" />

## Related PRs
- [x] Please see the following related PRs: https://github.com/onecodex/onecodex/pull/616