### PR TITLE
Add ANCOM-BC to Custom Plots module

### DIFF
--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -130,6 +130,10 @@ class AncombcResults(StatsResults):
     reference_group: str
     adjustment_method: AdjustmentMethod
 
+    @property
+    def significant_main_results(self) -> pd.DataFrame:
+        return self.main_results.query('Covariate != "Intercept" & Signif == True')
+
     def plot(
         self,
         title: str | None = None,
@@ -166,8 +170,7 @@ class AncombcResults(StatsResults):
         """
         import altair as alt
 
-        df = self.main_results.query('Covariate != "Intercept" & Signif == True')
-
+        df = self.significant_main_results
         if len(df) == 0:
             raise PlottingException(
                 "ANCOM-BC did not detect any statistically significant results."
@@ -931,14 +934,21 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
             ancombc_col = f"_{ancombc_col}_"
         ancombc_metadata = metadata_df.rename(columns={group_by_column_name: ancombc_col})
 
-        ancombc_results = ancombc(
-            zero_replaced_df,
-            ancombc_metadata,
-            formula=ancombc_col,
-            grouping=ancombc_col if include_global_test else None,
-            alpha=alpha,
-            p_adjust="holm-bonferroni",
-        )
+        try:
+            ancombc_results = ancombc(
+                zero_replaced_df,
+                ancombc_metadata,
+                formula=ancombc_col,
+                grouping=ancombc_col if include_global_test else None,
+                alpha=alpha,
+                p_adjust="holm-bonferroni",
+            )
+        except ValueError as e:
+            raise StatsException(
+                f"ANCOM-BC failed — this can happen when sample sizes are too small or data "
+                f"lack sufficient variation: {e}"
+            )
+
         main_results = ancombc_results
         global_results = None
         if include_global_test:

--- a/onecodex/viz/_custom_plots/collection.py
+++ b/onecodex/viz/_custom_plots/collection.py
@@ -238,14 +238,14 @@ class SampleCollection(BaseSampleCollection):
             result.params = params
         return result
 
-    def _run_with_plot_error_handling(self, fn: Callable[[], PlotResults]) -> PlotResults:
+    def _run_with_plot_error_handling(self, plot_fn: Callable[[], PlotResults]) -> PlotResults:
         import altair as alt
 
         with warnings.catch_warnings(record=True) as captured_warnings:
             warnings.simplefilter("always", PlottingWarning)
 
             try:
-                result = fn()
+                result = plot_fn()
             except (ValidationError, PlottingException, NoTaxaException) as e:
                 return PlotResults(error=str(e))
             except alt.MaxRowsError:

--- a/onecodex/viz/_custom_plots/collection.py
+++ b/onecodex/viz/_custom_plots/collection.py
@@ -233,21 +233,25 @@ class SampleCollection(BaseSampleCollection):
         return functional_results
 
     def plot(self, params: PlotParams) -> PlotResults:
+        result = self._run_with_plot_error_handling(lambda: self._plot(params))
+        if result.params is None:
+            result.params = params
+        return result
+
+    def _run_with_plot_error_handling(self, fn: Callable[[], PlotResults]) -> PlotResults:
         import altair as alt
 
-        result = None
         with warnings.catch_warnings(record=True) as captured_warnings:
             warnings.simplefilter("always", PlottingWarning)
 
             try:
-                result = self._plot(params)
+                result = fn()
             except (ValidationError, PlottingException, NoTaxaException) as e:
-                # Expected user error
-                return PlotResults(params=params, error=str(e))
+                return PlotResults(error=str(e))
             except alt.MaxRowsError:
                 return PlotResults(
-                    params=params,
-                    error="The selected dataset is too large to plot. Please try a different plot type or select a fewer number of samples.",
+                    error="The selected dataset is too large to plot. Please try a different plot "
+                    "type or select a fewer number of samples.",
                 )
 
         for warning in captured_warnings:
@@ -587,6 +591,15 @@ class SampleCollection(BaseSampleCollection):
                 plot_repr=None,
             )
             stats_results.plot_results = self.plot(plot_params)
+        elif (
+            params.stats_type == StatsType.Ancombc
+            and len(stats_results.ancombc_results.significant_main_results) > 0
+        ):
+            stats_results.plot_results = self._run_with_plot_error_handling(
+                lambda: PlotResults(
+                    chart=stats_results.ancombc_results.plot(return_chart=True).to_dict()
+                )
+            )
 
         return stats_results
 
@@ -622,6 +635,14 @@ class SampleCollection(BaseSampleCollection):
                     rank=params.rank,
                 )
                 return StatsResults(params=params, beta_diversity_results=beta_diversity_results)
+            case StatsType.Ancombc:
+                ancombc_results = self._ancombc(
+                    group_by=group_by,
+                    reference_group=params.reference_group,
+                    metric=params.metric,
+                    rank=params.rank,
+                )
+                return StatsResults(params=params, ancombc_results=ancombc_results)
             case _:
                 raise OneCodexException(f"Unknown stats type: {params.stats_type}")
 

--- a/onecodex/viz/_custom_plots/enums.py
+++ b/onecodex/viz/_custom_plots/enums.py
@@ -24,6 +24,7 @@ class ExportFormat(BaseEnum):
 class StatsType(BaseEnum):
     AlphaDiversity = "alpha_diversity"
     BetaDiversity = "beta_diversity"
+    Ancombc = "ancombc"
 
 
 class SuggestionType(BaseEnum):

--- a/onecodex/viz/_custom_plots/models.py
+++ b/onecodex/viz/_custom_plots/models.py
@@ -14,7 +14,12 @@ from onecodex.lib.enums import (
     AlphaDiversityMetric,
     BetaDiversityMetric,
 )
-from onecodex.stats import AlphaDiversityStatsResults, BetaDiversityStatsResults, PosthocResults
+from onecodex.stats import (
+    AlphaDiversityStatsResults,
+    AncombcResults,
+    BetaDiversityStatsResults,
+    PosthocResults,
+)
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -67,11 +72,12 @@ class StatsParams(BaseParams):
     stats_type: StatsType = StatsType.AlphaDiversity
     group_by: str  # `group_by` is required by all stats tests
     paired_by: str | None = None
+    reference_group: str | None = None
 
 
 @dataclass(kw_only=True)
 class PlotResults:
-    params: PlotParams
+    params: PlotParams | None = None
     chart: dict | None = None
     x_axis_label_links: dict[str, str] = field(default_factory=dict)
     error: str | None = None
@@ -80,7 +86,7 @@ class PlotResults:
 
     def to_dict(self) -> dict:
         return {
-            "params": self.params.model_dump(),
+            "params": self.params.model_dump() if self.params is not None else None,
             "chart": self.chart,
             "x_axis_label_links": self.x_axis_label_links,
             "error": self.error,
@@ -94,6 +100,7 @@ class StatsResults:
     params: StatsParams
     alpha_diversity_results: AlphaDiversityStatsResults | None = None
     beta_diversity_results: BetaDiversityStatsResults | None = None
+    ancombc_results: AncombcResults | None = None
     plot_results: PlotResults | None = None
     error: str | None = None
 
@@ -108,6 +115,11 @@ class StatsResults:
             "beta_diversity_results": (
                 _beta_diversity_results_to_dict(self.beta_diversity_results)
                 if self.beta_diversity_results is not None
+                else None
+            ),
+            "ancombc_results": (
+                _ancombc_results_to_dict(self.ancombc_results)
+                if self.ancombc_results is not None
                 else None
             ),
             "plot_results": self.plot_results.to_dict() if self.plot_results is not None else None,
@@ -161,4 +173,21 @@ def _posthoc_df_to_dict(df: pd.DataFrame) -> dict[str, dict[str, float]]:
     return {
         str(row_name): {str(col_name): value for col_name, value in row.items()}
         for row_name, row in df.iterrows()
+    }
+
+
+def _ancombc_results_to_dict(results: AncombcResults) -> dict:
+    return {
+        "main_results": results.main_results.reset_index().to_dict(orient="records"),
+        "global_results": (
+            results.global_results.reset_index().to_dict(orient="records")
+            if results.global_results is not None
+            else None
+        ),
+        "reference_group": results.reference_group,
+        "adjustment_method": str(results.adjustment_method),
+        "alpha": results.alpha,
+        "sample_size": results.sample_size,
+        "group_by_variable": results.group_by_variable,
+        "group_sizes": results.group_sizes,
     }

--- a/onecodex/viz/_custom_plots/models.py
+++ b/onecodex/viz/_custom_plots/models.py
@@ -77,7 +77,7 @@ class StatsParams(BaseParams):
 
 @dataclass(kw_only=True)
 class PlotResults:
-    params: PlotParams | None = None
+    params: PlotParams | None = None  # should only be None for ANCOM-BC results plots
     chart: dict | None = None
     x_axis_label_links: dict[str, str] = field(default_factory=dict)
     error: str | None = None

--- a/tests/test_custom_plots.py
+++ b/tests/test_custom_plots.py
@@ -841,14 +841,20 @@ def _make_ancombc_main_results():
     index = pd.MultiIndex.from_tuples(
         [
             ("Taxon A", "Intercept"),
-            ("Taxon A", "cohort: B vs A (reference)"),
+            ("Taxon A", "cohort[T.B]"),
             ("Taxon B", "Intercept"),
-            ("Taxon B", "cohort: B vs A (reference)"),
+            ("Taxon B", "cohort[T.B]"),
         ],
         names=["Taxon", "Covariate"],
     )
     return pd.DataFrame(
         {
+            "Comparison": [
+                "Intercept",
+                "cohort: B vs A (reference)",
+                "Intercept",
+                "cohort: B vs A (reference)",
+            ],
             "Log2(FC)": [0.0, 1.5, 0.0, -2.0],
             "SE": [0.1, 0.2, 0.1, 0.3],
             "W": [0.0, 7.5, 0.0, -6.7],
@@ -974,13 +980,12 @@ def test_stats_to_dict_ancombc():
     assert isinstance(records, list)
     assert len(records) == 4
     assert all(
-        {"Taxon", "Covariate", "Log2(FC)", "SE", "W", "pvalue", "qvalue", "Signif"} == set(r.keys())
+        {"Taxon", "Covariate", "Comparison", "Log2(FC)", "SE", "W", "pvalue", "qvalue", "Signif"}
+        == set(r.keys())
         for r in records
     )
     sig_record = next(
-        r
-        for r in records
-        if r["Taxon"] == "Taxon A" and r["Covariate"] == "cohort: B vs A (reference)"
+        r for r in records if r["Taxon"] == "Taxon A" and r["Covariate"] == "cohort[T.B]"
     )
     assert sig_record["Log2(FC)"] == 1.5
     assert sig_record["Signif"] is True

--- a/tests/test_custom_plots.py
+++ b/tests/test_custom_plots.py
@@ -1,5 +1,6 @@
 import io
 import json
+import mock
 import uuid
 
 import numpy as np
@@ -20,7 +21,12 @@ from onecodex.lib.enums import (
     PosthocStatsTest,
     Rank,
 )
-from onecodex.stats import AlphaDiversityStatsResults, BetaDiversityStatsResults, PosthocResults
+from onecodex.stats import (
+    AlphaDiversityStatsResults,
+    AncombcResults,
+    BetaDiversityStatsResults,
+    PosthocResults,
+)
 from onecodex.viz._custom_plots.collection import SampleCollection, Samples
 from onecodex.viz._custom_plots.enums import ExportFormat, PlotRepr, PlotType, StatsType
 from onecodex.viz._custom_plots.metadata import _get_metadata_field_value
@@ -829,3 +835,162 @@ def test_stats_to_dict_with_posthoc():
     assert posthoc_dict["statistics"]["g1"]["g2"] == 5.0
     assert posthoc_dict["statistics"]["g2"]["g3"] == 4.0
     assert np.isnan(posthoc_dict["statistics"]["g1"]["g1"])
+
+
+def _make_ancombc_main_results():
+    index = pd.MultiIndex.from_tuples(
+        [
+            ("Taxon A", "Intercept"),
+            ("Taxon A", "cohort: B vs A (reference)"),
+            ("Taxon B", "Intercept"),
+            ("Taxon B", "cohort: B vs A (reference)"),
+        ],
+        names=["Taxon", "Covariate"],
+    )
+    return pd.DataFrame(
+        {
+            "Log2(FC)": [0.0, 1.5, 0.0, -2.0],
+            "SE": [0.1, 0.2, 0.1, 0.3],
+            "W": [0.0, 7.5, 0.0, -6.7],
+            "pvalue": [1.0, 0.001, 1.0, 0.002],
+            "qvalue": [1.0, 0.002, 1.0, 0.004],
+            "Signif": [False, True, False, True],
+        },
+        index=index,
+    )
+
+
+def _make_ancombc_global_results():
+    index = pd.Index(["Taxon A", "Taxon B"], name="Taxon")
+    return pd.DataFrame(
+        {
+            "W": [5.0, 3.0],
+            "pvalue": [0.01, 0.03],
+            "qvalue": [0.02, 0.06],
+            "Signif": [True, False],
+        },
+        index=index,
+    )
+
+
+def test_stats_ancombc(stats_sample_collection):
+    params = StatsParams(
+        group_by="cohort",
+        stats_type=StatsType.Ancombc,
+        metric=Metric.ReadcountWChildren,
+        rank=Rank.Genus,
+    )
+
+    result = stats_sample_collection.stats(params)
+
+    assert result.error is None
+    assert result.plot_results is None  # no plot if there's no significant results
+    assert result.alpha_diversity_results is None
+    assert result.beta_diversity_results is None
+    assert isinstance(result.ancombc_results, AncombcResults)
+    assert result.ancombc_results.group_sizes == {"A": 2, "B": 2}
+    assert result.ancombc_results.sample_size == 4
+    assert result.ancombc_results.reference_group == "A"
+    assert result.ancombc_results.group_by_variable == "cohort"
+
+
+def test_stats_ancombc_reference_group(stats_sample_collection):
+    params = StatsParams(
+        group_by="cohort",
+        stats_type=StatsType.Ancombc,
+        metric=Metric.ReadcountWChildren,
+        rank=Rank.Genus,
+        reference_group="B",
+    )
+
+    result = stats_sample_collection.stats(params)
+
+    assert result.error is None
+    assert result.ancombc_results.reference_group == "B"
+
+
+def test_stats_ancombc_generates_plot_when_significant(stats_sample_collection):
+    main_results = _make_ancombc_main_results()
+    ancombc_results = AncombcResults(
+        main_results=main_results,
+        reference_group="A",
+        adjustment_method=AdjustmentMethod.BenjaminiHochberg,
+        alpha=0.05,
+        sample_size=10,
+        group_by_variable="cohort",
+        group_sizes={"A": 5, "B": 5},
+    )
+    params = StatsParams(
+        group_by="cohort",
+        stats_type=StatsType.Ancombc,
+        metric=Metric.ReadcountWChildren,
+        rank=Rank.Species,
+    )
+    mock_stats_results = StatsResults(params=params, ancombc_results=ancombc_results)
+
+    with mock.patch.object(
+        type(stats_sample_collection), "_stats", return_value=mock_stats_results
+    ):
+        result = stats_sample_collection.stats(params)
+
+    assert result.error is None
+    assert isinstance(result.plot_results, PlotResults)
+    assert result.plot_results.error is None
+    assert isinstance(result.plot_results.chart, dict)
+
+
+def test_stats_to_dict_ancombc():
+    main_results = _make_ancombc_main_results()
+    global_results = _make_ancombc_global_results()
+    ancombc_results = AncombcResults(
+        main_results=main_results,
+        global_results=global_results,
+        reference_group="A",
+        adjustment_method=AdjustmentMethod.BenjaminiHochberg,
+        alpha=0.05,
+        sample_size=10,
+        group_by_variable="cohort",
+        group_sizes={"A": 5, "B": 5},
+    )
+    params = StatsParams(group_by="cohort", stats_type=StatsType.Ancombc)
+    result = StatsResults(params=params, ancombc_results=ancombc_results)
+
+    d = result.to_dict()
+
+    assert d["error"] is None
+    assert d["alpha_diversity_results"] is None
+    assert d["beta_diversity_results"] is None
+    assert d["params"]["stats_type"] == "ancombc"
+
+    ancombc = d["ancombc_results"]
+    assert ancombc["reference_group"] == "A"
+    assert ancombc["adjustment_method"] == "benjamini_hochberg"
+    assert ancombc["alpha"] == 0.05
+    assert ancombc["sample_size"] == 10
+    assert ancombc["group_by_variable"] == "cohort"
+    assert ancombc["group_sizes"] == {"A": 5, "B": 5}
+
+    records = ancombc["main_results"]
+    assert isinstance(records, list)
+    assert len(records) == 4
+    assert all(
+        {"Taxon", "Covariate", "Log2(FC)", "SE", "W", "pvalue", "qvalue", "Signif"} == set(r.keys())
+        for r in records
+    )
+    sig_record = next(
+        r
+        for r in records
+        if r["Taxon"] == "Taxon A" and r["Covariate"] == "cohort: B vs A (reference)"
+    )
+    assert sig_record["Log2(FC)"] == 1.5
+    assert sig_record["Signif"] is True
+
+    global_records = ancombc["global_results"]
+    assert isinstance(global_records, list)
+    assert len(global_records) == 2
+    assert all(
+        {"Taxon", "W", "pvalue", "qvalue", "Signif"} == set(r.keys()) for r in global_records
+    )
+    taxon_a = next(r for r in global_records if r["Taxon"] == "Taxon A")
+    assert taxon_a["W"] == 5.0
+    assert taxon_a["Signif"] is True


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Added ANCOM-BC to `onecodex.viz._custom_plots`:

- Run via top-level `stats()` function
- A plot is generated only if there are significant results
- Results are suitable for Javascript

Closes DEV-11540

## Related PRs
- [x] Please see the following related PRs:
  - https://github.com/onecodex/onecodex/pull/616
  - https://github.com/onecodex/onecodex/pull/617