### PR TITLE
Drop samples without abundances before dropping NaN alpha diversity values

### DIFF
--- a/onecodex/distance.py
+++ b/onecodex/distance.py
@@ -41,7 +41,7 @@ class DistanceMixin(BaseSampleCollection, TaxonomyMixin):
 
         Returns
         -------
-        pandas.DataFrame, a distance matrix.
+        pandas.DataFrame of computed alpha diversity values
         """
         import pandas as pd
         import skbio.diversity

--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -185,14 +185,25 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
         )
 
         df = metadata_results.df
-        magic_fields = metadata_results.renamed_fields
-        group_by_column_name = magic_fields[group_by]
-        paired_by_column_name = magic_fields.get(paired_by, None)
+        group_by_column_name = metadata_results.renamed_fields[group_by]
+        paired_by_column_name = metadata_results.renamed_fields.get(paired_by, None)
+
+        # Drop samples with missing group_by data
+        df = self._drop_missing_data(df, group_by_column_name, "group_by")
+
+        if paired_by_column_name:
+            # Drop samples with missing paired_by data
+            df = self._drop_missing_data(df, paired_by_column_name, "paired_by")
+
+        # Drop samples missing abundance data
+        if metric.is_abundance_metric:
+            df = self._drop_classifications_without_abundances(df)
 
         # Compute alpha diversity
-        df.loc[:, diversity_metric] = self.alpha_diversity(
+        alpha_diversity_df = self.alpha_diversity(
             diversity_metric=diversity_metric, metric=metric, rank=rank
         )
+        df.loc[:, diversity_metric] = alpha_diversity_df.loc[df.index, diversity_metric]
 
         # Drop NaN alpha diversity values
         prev_count = len(df)
@@ -206,21 +217,9 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
                 StatsWarning,
             )
 
-        # Drop samples with missing group_by data
-        df = self._drop_missing_data(df, group_by_column_name, "group_by")
-
-        if paired_by_column_name:
-            # Drop samples with missing paired_by data
-            df = self._drop_missing_data(df, paired_by_column_name, "paired_by")
-
-        # Drop samples missing abundance data
-        if metric.is_abundance_metric:
-            df = self._drop_classifications_without_abundances(df)
-
         # Drop groups of size < 2
         # NOTE: it's important to do this filtering *after* the other filters in case those filters
         # change the group sizes.
-
         df = self._drop_group_sizes_smaller_than(df, group_by_column_name, 2)
 
         self._assert_min_num_groups(df, group_by_column_name, 2)
@@ -531,8 +530,7 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
             coerce_missing_composite_fields=False,
         )
         df = metadata_results.df
-        magic_fields = metadata_results.renamed_fields
-        group_by_column_name = magic_fields[group_by]
+        group_by_column_name = metadata_results.renamed_fields[group_by]
 
         # Drop samples with missing group_by data
         df = self._drop_missing_data(df, group_by_column_name, "group_by")

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -150,6 +150,23 @@ def test_alpha_diversity_stats_invalid_paired_by(samples, paired_by):
         samples.alpha_diversity_stats(group_by="wheat", paired_by=paired_by)
 
 
+def test_alpha_diversity_stats_samples_missing_abundances_dropped_before_nan_values(
+    samples_without_abundances,
+):
+    """Samples without abundances are dropped before dropping NaN alpha diversity values"""
+    for sample, col in zip(samples_without_abundances, ["a", "b", "a"]):
+        sample.metadata.custom["col"] = col
+
+    with pytest.warns(StatsWarning, match="3 samples were excluded.*missing abundance"):
+        with pytest.raises(StatsException, match="`group_by` must have at least 2 groups.*found 0"):
+            samples_without_abundances.alpha_diversity_stats(
+                group_by="col",
+                # shannon must be passed to properly test this case
+                diversity_metric=AlphaDiversityMetric.Shannon,
+                metric=Metric.AbundanceWChildren,
+            )
+
+
 def test_alpha_diversity_stats_missing_alpha_diversity_values(samples):
     for sample, val in zip(samples, ["a", "b", "a"]):
         sample.metadata.custom["col"] = val


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
`alpha_diversity_stats()` now drops samples without abundances (if an abundance metric is requested) *before* dropping NaN alpha diversity values. This change provides a more informative warning message than the previous warning that was raised.

Closes DEV-11572

## Related PRs
- [x] This PR is independent