### PR TITLE
Disallow numeric group by variable in ANCOM-BC

### DIFF
--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -891,6 +891,8 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
         if require_classification_version_match:
             self._assert_single_database_version(metadata_df)
 
+        self._assert_categorical_group_by(metadata_df, group_by_column_name)
+
         group_names = sorted(metadata_df[group_by_column_name].unique())
         if reference_group:
             if reference_group not in group_names:
@@ -1004,6 +1006,16 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
                 StatsWarning,
             )
         return metadata_df
+
+    def _assert_categorical_group_by(self, df: pd.DataFrame, group_by_column_name: str):
+        try:
+            df[group_by_column_name].astype("float64")
+        except (ValueError, TypeError):
+            return
+        raise StatsException(
+            f"The `group_by` variable ({group_by_column_name!r}) has all numeric values after "
+            f"filtering, which is not currently supported. Please select a categorical variable."
+        )
 
     def _assert_min_num_groups_for_global_test(
         self, metadata_df: pd.DataFrame, group_by_column_name: str

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -701,6 +701,16 @@ def test_ancombc_three_groups(ocx, api_data, samples):
     _assert_ancombc_covariates(results.main_results, "group", "a", ["b", "c"])
 
 
+def test_ancombc_numeric_group_by_raises(ocx, api_data, samples):
+    samples.extend([ocx.Samples.get("cc18208d98ad48b3"), ocx.Samples.get("5445740666134eee")])
+
+    for sample, group in zip(samples, ["1", "2", "1", "2", "1"]):
+        sample.metadata.custom["group"] = group
+
+    with pytest.raises(StatsException, match="numeric values.*categorical variable"):
+        samples._ancombc(group_by="group", metric="readcount_w_children", rank="genus")
+
+
 def _make_ancombc_results(rows):
     """Build an AncombcResults from (Taxon, Covariate, Comparison, Log2FC, Signif) tuples."""
     index = pd.MultiIndex.from_tuples([(r[0], r[1]) for r in rows], names=["Taxon", "Covariate"])


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
`_ancombc()` now raises a `StatsException` if the selected group by variable is numeric.

scikit-bio's `ancombc()` converts the variable to `float64` (even if passed as a string), and uses linear regression instead of categorical pairwise group comparisons. The output format is also a bit different when using a numeric variable. For now, restrict the test to only allow categorical variables.

In the future, we might want to allow users to specify whether the variable is categorical or numeric. I explored some hacks to get that to work, and it's *possible* but pretty complicated.

Closes DEV-11581

## Related PRs
- [x] This PR is independent