### PR TITLE
Update ANCOM-BC plot colors to use OCX palette

### DIFF
--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -18,6 +18,7 @@ from onecodex.lib.enums import (
     PosthocStatsTest,
 )
 from onecodex.models.base_sample_collection import BaseSampleCollection
+from onecodex.viz import OCX_DARK_BLUE, OCX_RED
 from onecodex.viz._primitives import prepare_props
 
 if TYPE_CHECKING:
@@ -183,7 +184,7 @@ class AncombcResults(StatsResults):
         df.loc[(df["Log2(FC)"] > 0), "Difference from reference"] = "Increased"
 
         color_domain = ["Decreased", "Increased"]
-        color_range = ["#CC3300", "#0033CC"]
+        color_range = [OCX_RED, OCX_DARK_BLUE]
 
         # Symmetric x-axis domain around zero, with a minimum extent of ±0.5. Log2(FC) of 0.5 is
         # sometimes considered "biologically relevant", which is why we use this minimum threshold.

--- a/onecodex/viz/__init__.py
+++ b/onecodex/viz/__init__.py
@@ -12,10 +12,12 @@ from onecodex.viz._functional import VizFunctionalHeatmapMixin
 
 
 OCX_DARK_GREEN = "#128887"
+OCX_DARK_BLUE = "#16347B"
+OCX_RED = "#DD3A3A"
 
 DEFAULT_PALETTES = {
     "ocx": [
-        "#16347B",
+        OCX_DARK_BLUE,
         "#0072C7",
         "#01ACEC",
         "#97E9FC",
@@ -32,7 +34,7 @@ DEFAULT_PALETTES = {
         "#FCE34D",
         "#FEF2A3",
         "#950303",
-        "#DD3A3A",
+        OCX_RED,
         "#FF8D8B",
         "#FFD5CB",
         "#771354",


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Closes DEV-11579

<img width="994" height="298" alt="Screenshot 2026-04-17 at 2 21 27 PM" src="https://github.com/user-attachments/assets/fdf90772-e1c0-4e5a-8568-595ad912ea34" />

## Related PRs
- [x] This PR is independent