### PR TITLE
Display taxon names without IDs in ANCOM-BC plot y-axis labels

### DIFF
--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -178,6 +178,13 @@ class AncombcResults(StatsResults):
 
         df = df.reset_index()
 
+        # Extract taxon IDs from the "Name (id)" format into a separate column for tooltips,
+        # and keep only the name for y-axis labels. When Taxon is just an ID (no parenthesized
+        # suffix), use the raw value as both the label and the Taxon ID.
+        taxon_parts = df["Taxon"].str.extract(r"^(.*?)\s+\(([^)]+)\)$")
+        df["Taxon ID"] = taxon_parts[1].fillna(df["Taxon"])
+        df["Taxon"] = taxon_parts[0].fillna(df["Taxon"])
+
         df["Difference from reference"] = "No change"
         df.loc[(df["Log2(FC)"] < 0), "Difference from reference"] = "Decreased"
         df.loc[(df["Log2(FC)"] > 0), "Difference from reference"] = "Increased"
@@ -193,12 +200,12 @@ class AncombcResults(StatsResults):
 
         bars = base.mark_bar().encode(
             x=alt.X("Log2(FC):Q", title="Log2(FC)", scale=alt.Scale(domain=[-x_extent, x_extent])),
-            y=alt.Y("Taxon:O", title="Taxon"),
+            y=alt.Y("Taxon:O", title="Taxon", axis=alt.Axis(labelLimit=400)),
             color=alt.Color(
                 "Difference from reference:N",
                 scale=alt.Scale(domain=color_domain, range=color_range),
             ),
-            tooltip=["Taxon", "Comparison", "Log2(FC)", "pvalue", "qvalue"],
+            tooltip=["Taxon", "Taxon ID", "Comparison", "Log2(FC)", "pvalue", "qvalue"],
         )
 
         # Dashed vertical reference line at x=0

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -732,12 +732,12 @@ def _make_ancombc_results(rows):
 
 def test_ancombc_results_plot():
     rows = [
-        ("TaxonA", "Intercept", "Intercept", 1.0, True),
-        ("TaxonB", "Intercept", "Intercept", -0.5, False),
-        ("TaxonA", "group[T.b]", "group: b vs ref (reference)", 1.5, True),
-        ("TaxonA", "group[T.c]", "group: c vs ref (reference)", -0.9, True),
-        ("TaxonB", "group[T.b]", "group: b vs ref (reference)", -1.0, True),
-        ("TaxonB", "group[T.c]", "group: c vs ref (reference)", 0.3, False),
+        ("Taxon A (123)", "Intercept", "Intercept", 1.0, True),
+        ("Taxon B (456)", "Intercept", "Intercept", -0.5, False),
+        ("Taxon A (123)", "group[T.b]", "group: b vs ref (reference)", 1.5, True),
+        ("Taxon A (123)", "group[T.c]", "group: c vs ref (reference)", -0.9, True),
+        ("Taxon B (456)", "group[T.b]", "group: b vs ref (reference)", -1.0, True),
+        ("Taxon B (456)", "group[T.c]", "group: c vs ref (reference)", 0.3, False),
     ]
     results = _make_ancombc_results(rows)
     chart = results.plot(return_chart=True)
@@ -758,7 +758,15 @@ def test_ancombc_results_plot():
     assert "Intercept" not in data["Comparison"].values
 
     # Non-significant rows are excluded
-    assert set(data["Taxon"][data["Comparison"] == "group: c vs ref (reference)"]) == {"TaxonA"}
+    assert set(data["Taxon"][data["Comparison"] == "group: c vs ref (reference)"]) == {"Taxon A"}
+
+    # Taxon IDs are stripped from y-axis labels (Taxon column) and placed in Taxon ID column
+    assert set(data["Taxon"].unique()) == {"Taxon A", "Taxon B"}
+    assert set(data["Taxon ID"].unique()) == {"123", "456"}
+
+    # Y-axis label limit is increased
+    bars = spec["spec"]["layer"][0]
+    assert bars["encoding"]["y"]["axis"]["labelLimit"] == 400
 
     # Both non-Intercept comparisons are present
     assert set(data["Comparison"].unique()) == {
@@ -767,7 +775,6 @@ def test_ancombc_results_plot():
     }
 
     # Color encoding
-    bars = spec["spec"]["layer"][0]
     assert bars["encoding"]["color"]["field"] == "Difference from reference"
     assert len(bars["encoding"]["color"]["scale"]["domain"]) == 2
     assert len(bars["encoding"]["color"]["scale"]["range"]) == 2
@@ -775,8 +782,8 @@ def test_ancombc_results_plot():
 
 def test_ancombc_results_plot_no_significant_results():
     rows = [
-        ("TaxonA", "Intercept", "Intercept", 1.0, True),
-        ("TaxonA", "group[T.treat]", "group: treat vs ref (reference)", 0.2, False),
+        ("Taxon A (123)", "Intercept", "Intercept", 1.0, True),
+        ("Taxon A (123)", "group[T.treat]", "group: treat vs ref (reference)", 0.2, False),
     ]
     results = _make_ancombc_results(rows)
 
@@ -786,8 +793,8 @@ def test_ancombc_results_plot_no_significant_results():
 
 def test_ancombc_results_plot_props():
     rows = [
-        ("TaxonA", "Intercept", "Intercept", 1.0, True),
-        ("TaxonA", "group[T.treat]", "group: treat vs ref (reference)", 1.2, True),
+        ("Taxon A (123)", "Intercept", "Intercept", 1.0, True),
+        ("Taxon A (123)", "group[T.treat]", "group: treat vs ref (reference)", 1.2, True),
     ]
     results = _make_ancombc_results(rows)
 
@@ -798,3 +805,19 @@ def test_ancombc_results_plot_props():
     assert spec["title"] == "My Title"
     assert spec["spec"]["width"] == 400
     assert spec["spec"]["height"] == 200
+
+
+def test_ancombc_results_plot_taxon_id_only():
+    """When Taxon is just an ID (no 'Name (id)' format), use it as both label and Taxon ID."""
+    rows = [
+        ("12345", "Intercept", "Intercept", 1.0, True),
+        ("12345", "group[T.treat]", "group: treat vs ref (reference)", 1.5, True),
+        ("67890", "group[T.treat]", "group: treat vs ref (reference)", -0.8, True),
+    ]
+    results = _make_ancombc_results(rows)
+    chart = results.plot(return_chart=True)
+    spec = chart.to_dict()
+    data = pd.DataFrame(spec["datasets"][spec["data"]["name"]])
+
+    assert set(data["Taxon"].unique()) == {"12345", "67890"}
+    assert set(data["Taxon ID"].unique()) == {"12345", "67890"}


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Move taxon IDs out of y-axis labels and into hoverable tooltips so the labels are shorter. Increase the y-axis label limit from 200px to 400px to accommodate longer taxonomic names.

Closes DEV-11583

<img width="998" height="292" alt="Screenshot 2026-04-17 at 3 01 55 PM" src="https://github.com/user-attachments/assets/75fa16ba-2ea6-4c28-9ceb-07dc796601c6" />

## Related PRs
- [x] This PR is independent