### PR TITLE
Set legend title for ancombc plots

### DIFF
--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -204,6 +204,7 @@ class AncombcResults(StatsResults):
             y=alt.Y("Taxon:O", title="Taxon", axis=alt.Axis(labelLimit=400)),
             color=alt.Color(
                 "Difference from reference:N",
+                title="Difference from reference",
                 scale=alt.Scale(domain=color_domain, range=color_range),
             ),
             tooltip=["Taxon", "Taxon ID", "Comparison", "Log2(FC)", "pvalue", "qvalue"],


### PR DESCRIPTION
## Status
- [X] **Ready**

## Description
This PR ensures that the chart schema generated for ANCOM-BC plots has a `title` property which is required for changing the label without affecting the data visualisation.

## Related PRs
- [X] This PR is independent
