### PR TITLE
ANCOM-BC plot label and doc fixes

### DIFF
--- a/onecodex/stats.py
+++ b/onecodex/stats.py
@@ -120,7 +120,7 @@ class AncombcResults(StatsResults):
     - `reference_group`: Group name used as the reference. All other groups are compared to this
     reference group.
     - `adjustment_method`: method used to adjust p-values to control the false discovery rate
-    - `alpha`: p-value threshold used to determine statistical significance
+    - `alpha`: q-value threshold used to determine statistical significance
     - `sample_size`: number of samples used in the test after filtering
     - `group_by_variable`: name of the variable used to group samples by
     - `group_sizes`: dict mapping group name to sample size in each group
@@ -201,7 +201,7 @@ class AncombcResults(StatsResults):
 
         bars = base.mark_bar().encode(
             x=alt.X("Log2(FC):Q", title="Log2(FC)", scale=alt.Scale(domain=[-x_extent, x_extent])),
-            y=alt.Y("Taxon:O", title="Taxon", axis=alt.Axis(labelLimit=400)),
+            y=alt.Y("Taxon:O", title="Taxon"),
             color=alt.Color(
                 "Difference from reference:N",
                 title="Difference from reference",
@@ -840,7 +840,7 @@ class StatsMixin(DistanceMixin, BaseSampleCollection):
             See :class:`~onecodex.lib.enums.Rank` for details.
 
         alpha : float, optional
-            Threshold to determine statistical significance (e.g. p < `alpha`). Must be between 0
+            Threshold to determine statistical significance (e.g. q <= `alpha`). Must be between 0
             and 1 (exclusive).
 
         include_global_test : bool, optional

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -774,10 +774,6 @@ def test_ancombc_results_plot():
     assert set(data["Taxon"].unique()) == {"Taxon A", "Taxon B"}
     assert set(data["Taxon ID"].unique()) == {"123", "456"}
 
-    # Y-axis label limit is increased
-    bars = spec["spec"]["layer"][0]
-    assert bars["encoding"]["y"]["axis"]["labelLimit"] == 400
-
     # Both non-Intercept comparisons are present
     assert set(data["Comparison"].unique()) == {
         "group: b vs ref (reference)",
@@ -785,6 +781,7 @@ def test_ancombc_results_plot():
     }
 
     # Color encoding
+    bars = spec["spec"]["layer"][0]
     assert bars["encoding"]["color"]["field"] == "Difference from reference"
     assert len(bars["encoding"]["color"]["scale"]["domain"]) == 2
     assert len(bars["encoding"]["color"]["scale"]["range"]) == 2


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
- Remove y-axis label limit from ANCOM-BC plot. Altair overlaps the y-axis title with longer labels, so it's better to just rely on default label truncation
- Fix ANCOM-BC `alpha` docs to reference q-values and `<= alpha` instead of `< alpha`

## Related PRs
- [x] This PR is independent