### PR TITLE
Bugfix: plot_bargraph errors out if result df is empty

### DIFF
--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -170,8 +170,9 @@ class VizBargraphMixin(BaseSampleCollection):
             df = df.loc[:, df.mean().sort_values(ascending=False).iloc[:top_n].index]
 
         if include_other:
-            # It needs to be a list and not an index
-            df_index = list(df.index)
+            row_totals_by_name = {}
+            for (_, row), row_total in zip(df.iterrows(), row_totals):
+                row_totals_by_name[row.name] = row_total
 
             def apply_callback(row):
                 # if there are no abundances in the dataframe, df.apply will yield
@@ -181,7 +182,7 @@ class VizBargraphMixin(BaseSampleCollection):
                 if row.name is None or row.name in empty_rows:
                     return 0.0
 
-                total = row_totals[df_index.index(row.name)]
+                total = row_totals_by_name[row.name]
                 return total - row.sum()
 
             df["Other"] = df.apply(

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -161,8 +161,7 @@ class VizBargraphMixin(BaseSampleCollection):
             threshold = None
 
         # We will need this when calculating "Other" column
-        # Do not iterate over it. It should be access only in `apply_callback`
-        row_totals = iter(df.sum(axis=1))
+        row_totals = list(df.sum(axis=1))
 
         if threshold:
             df = df.loc[:, df.max() >= threshold]
@@ -171,14 +170,19 @@ class VizBargraphMixin(BaseSampleCollection):
             df = df.loc[:, df.mean().sort_values(ascending=False).iloc[:top_n].index]
 
         if include_other:
+            # It needs to be a list and not an index
+            df_index = list(df.index)
 
             def apply_callback(row):
-                total = next(row_totals)
                 # if there are no abundances in the dataframe, df.apply will yield
                 # a single item that has `None` as its name. Therefore, we must
                 # check if row.name is None AND whether or not the row name is
                 # in empty_rows
-                return 0.0 if (row.name is None or row.name in empty_rows) else total - row.sum()
+                if row.name is None or row.name in empty_rows:
+                    return 0.0
+
+                total = row_totals[df_index.index(row.name)]
+                return total - row.sum()
 
             df["Other"] = df.apply(
                 apply_callback,

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,7 +1,8 @@
 import math
+from datetime import datetime
+
 import mock
 import pytest
-from datetime import datetime
 
 pytest.importorskip("numpy")  # noqa
 pytest.importorskip("pandas")  # noqa
@@ -10,16 +11,20 @@ import altair as alt
 import numpy as np
 import pandas as pd
 
-from onecodex.lib.enums import Metric, Link, Rank
-from onecodex.exceptions import OneCodexException, PlottingException
+from onecodex.exceptions import (
+    OneCodexException,
+    OneCodexUserWarning,
+    PlottingException,
+    PlottingWarning,
+)
+from onecodex.lib.enums import Link, Metric, Rank
 from onecodex.models.collection import SampleCollection
 from onecodex.utils import has_missing_values
 from onecodex.viz._primitives import (
-    interleave_palette,
     get_classification_url,
     get_ncbi_taxonomy_browser_url,
+    interleave_palette,
 )
-from onecodex.exceptions import OneCodexUserWarning, PlottingWarning
 
 
 def assert_expected_legend_title(chart, title):
@@ -1078,3 +1083,17 @@ def test_plot_bargraph_to_calc_total_if_metric_is_not_normalized(samples):
     df = chart.data
     other_values = df[df["tax_id"] == "Other"]["Readcount"]
     assert all([x >= 0.0 for x in other_values])
+
+
+# Regression test for DEV-11620
+def test_plot_bargraph_to_calc_total_errors_out_if_df_is_empty(samples):
+    class EmptySamplesCollection(SampleCollection):
+        def to_classification_df(self, *args, **kwargs):
+            df = super().to_classification_df(*args, **kwargs)
+            return df.drop(df.index[1:]).drop(columns=df.columns)
+
+    empty_samples = EmptySamplesCollection(objects=samples)
+    chart = empty_samples.plot_bargraph(return_chart=True, metric=Metric.AbundanceWChildren)
+
+    df = chart.data
+    assert df[df["tax_id"] == "Other"]["Relative Abundance"] == 0.0

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1096,4 +1096,7 @@ def test_plot_bargraph_to_calc_total_errors_out_if_df_is_empty(samples):
     chart = empty_samples.plot_bargraph(return_chart=True, metric=Metric.AbundanceWChildren)
 
     df = chart.data
-    assert df[df["tax_id"] == "Other"]["Relative Abundance"] == 0.0
+    values = list(df[df["tax_id"] == "Other"]["Relative Abundance"])
+
+    assert len(values) == 1
+    assert values[0] == 0.0


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description

If `df` is "almost empty" then `df.apply` may be still called (for some pandas internal reasons) even if there are zero rows and `row_totals` are empty iterator. Thus causing `StopIterator` error.

## Related PRs
- [x] This PR is independent