### PR TITLE
Add function to list user assets

### DIFF
--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -1,11 +1,13 @@
 from __future__ import print_function
-import click
+
 import copy
-from functools import partial
 import logging
 import os
 import time
 import warnings
+from functools import partial
+
+import click
 
 from onecodex.api import Api
 from onecodex.auth import (
@@ -15,30 +17,29 @@ from onecodex.auth import (
     login_required,
     login_required_experimental_api,
 )
+from onecodex.input_helpers import (
+    auto_detect_pairs,
+    concatenate_multilane_files,
+    concatenate_ont_groups,
+)
 from onecodex.lib.upload import DEFAULT_THREADS
 from onecodex.metadata_upload import validate_appendables
-from onecodex.scripts import subset_reads, export_functional_metric, interleave
+from onecodex.scripts import export_functional_metric, interleave, subset_reads
 from onecodex.utils import (
-    click_path_autocomplete_helper,
-    cli_resource_fetcher,
-    CliLogFormatter,
-    download_file_helper,
-    valid_api_key,
     OPTION_HELP,
-    progressbar,
+    CliLogFormatter,
+    cli_resource_fetcher,
+    click_path_autocomplete_helper,
+    download_file_helper,
     pprint,
     pretty_errors,
+    progressbar,
     run_via_threadpool,
     telemetry,
     use_tempdir,
-)
-from onecodex.input_helpers import (
-    auto_detect_pairs,
-    concatenate_ont_groups,
-    concatenate_multilane_files,
+    valid_api_key,
 )
 from onecodex.version import __version__
-
 
 # set the context for getting -h also
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -282,7 +283,52 @@ def assets_upload(ctx, max_threads, file, name):
     )
 
 
+@click.command("list", help="List assets available to you")
+@click.option("--json", is_flag=True, default=False, help="Output JSON instead of prettified table")
+@click.pass_context
+@telemetry
+@login_required_experimental_api
+def assets_list(ctx, json):
+    assets_data = cli_resource_fetcher(ctx, "assets", [], print_results=json)
+    if json:
+        return
+
+    if not assets_data:
+        click.echo("You haven't uploaded any assets yet.")
+        return
+
+    formatters = ["%-18s", "%-34s", "%-12s", "%-12s"]
+    table = [
+        ["ID", "Filename", "Status", "Created On"],
+        ["-" * 16, "-" * 32, "-" * 10, "-" * 10],
+    ]
+
+    assets_data = sorted(
+        assets_data,
+        reverse=True,
+        key=lambda x: time.mktime(x.created_at.timetuple()),
+    )
+
+    for asset in assets_data:
+        fname = asset.filename
+        table.append(
+            [
+                asset.uuid,
+                fname if len(fname) <= 32 else fname[:29] + "...",
+                asset.status,
+                asset.created_at.strftime("%Y-%m-%d"),
+            ]
+        )
+
+    for row in table:
+        formatted_row = []
+        for formatter, content in zip(formatters, row):
+            formatted_row.append(formatter % content)
+        click.echo("".join(formatted_row))
+
+
 assets.add_command(assets_upload, "upload")
+assets.add_command(assets_list, "list")
 
 
 # resources

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -306,7 +306,7 @@ def assets_list(ctx, json):
     assets_data = sorted(
         assets_data,
         reverse=True,
-        key=lambda x: time.mktime(x.created_at.timetuple()),
+        key=lambda x: x.created_at.timestamp(),
     )
 
     for asset in assets_data:

--- a/tests/data/api/v1/assets/index.json
+++ b/tests/data/api/v1/assets/index.json
@@ -1,0 +1,44 @@
+[
+    {
+        "$uri": "/api/v1/assets/057268a2ba9f6d7a",
+        "created_at": "2023-11-15T18:33:18.884095+00:00",
+        "filename": "test_asset.json",
+        "name": "test_asset.json",
+        "organization_id": 19,
+        "s3_uri": "s3://example-bucket/test_asset.json",
+        "status": "available",
+        "uploaded_by": {
+            "$uri": "/api/v1/users/4ada56103d9a48b8",
+            "email": "user@onecodex.com"
+        },
+        "uuid": "057268a2ba9f6d7a"
+    },
+    {
+        "$uri": "/api/v1/assets/78f7827cb8e7c323",
+        "created_at": "2023-12-13T00:46:00.700443+00:00",
+        "filename": "results.txt",
+        "name": "results.txt",
+        "organization_id": 19,
+        "s3_uri": "s3://example-bucket/results.txt",
+        "status": "available",
+        "uploaded_by": {
+            "$uri": "/api/v1/users/4ada56103d9a48b8",
+            "email": "user@onecodex.com"
+        },
+        "uuid": "78f7827cb8e7c323"
+    },
+    {
+        "$uri": "/api/v1/assets/de2995c92e569569",
+        "created_at": "2024-03-04T09:10:11.000000+00:00",
+        "filename": "reference_genome.fa.gz",
+        "name": "reference_genome.fa.gz",
+        "organization_id": 19,
+        "s3_uri": "s3://example-bucket/reference_genome.fa.gz",
+        "status": "pending",
+        "uploaded_by": {
+            "$uri": "/api/v1/users/4ada56103d9a48b8",
+            "email": "user@onecodex.com"
+        },
+        "uuid": "de2995c92e569569"
+    }
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,9 @@
-from click.testing import CliRunner
-import mock
 import os
 import os.path
+
+import mock
 import pytest
+from click.testing import CliRunner
 from testfixtures import Replace
 
 from onecodex import Cli
@@ -86,6 +87,32 @@ def test_documents_table(runner, api_data, mocked_creds_file):
     result = runner.invoke(Cli, ["documents", "list", "--json"])
     assert len(result.stdout.split("\n")) == 258  # shorter because we ignore extra fields
     assert "OneCodexTakeHome" in result.stdout
+
+
+# Assets
+@pytest.mark.filterwarnings("ignore:Experimental API mode enabled:UserWarning")
+def test_assets_table(runner, api_data, mocked_creds_file):
+    result = runner.invoke(Cli, ["assets", "list"])
+    assert result.exit_code == 0
+    assert "ID" in result.stdout
+    assert "Status" in result.stdout
+    assert "057268a2ba9f6d7a" in result.stdout
+    assert "reference_genome.fa.gz" in result.stdout
+    assert "available" in result.stdout
+    assert "pending" in result.stdout
+
+    result = runner.invoke(Cli, ["assets", "list", "--json"])
+    assert result.exit_code == 0
+    assert "057268a2ba9f6d7a" in result.stdout
+    assert "reference_genome.fa.gz" in result.stdout
+
+
+@pytest.mark.filterwarnings("ignore:Experimental API mode enabled:UserWarning")
+def test_assets_list_empty(runner, custom_mock_requests, mocked_creds_file):
+    with custom_mock_requests({"GET::api/v1/assets": []}):
+        result = runner.invoke(Cli, ["assets", "list"])
+        assert result.exit_code == 0
+        assert "haven't uploaded any assets" in result.stdout
 
 
 # Panels


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
This PR introduces a new cli command, `onecodex assets list`, which lists assets a user has access to. The functionality is largely a clone of the `documents list` command, including a `--json` flag for JSON formatted output.

## Related PRs
- [x] This PR is independent
