### PR TITLE
Add Workflows model and CLI command

### DIFF
--- a/onecodex/api.py
+++ b/onecodex/api.py
@@ -69,6 +69,7 @@ class Api(object):
             FunctionalProfiles as _FunctionalProfiles,
             Panels as _Panels,
             Mlsts as _Mlsts,
+            Workflows as _Workflows,
             Users as _Users,
             Projects as _Projects,
             Tags as _Tags,
@@ -89,6 +90,7 @@ class Api(object):
         FunctionalProfiles: Type[_FunctionalProfiles]
         Panels: Type[_Panels]
         Mlsts: Type[_Mlsts]
+        Workflows: Type[_Workflows]
         Users: Type[_Users]
         Projects: Type[_Projects]
         Tags: Type[_Tags]

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -408,6 +408,16 @@ def panels(ctx, panels):
     cli_resource_fetcher(ctx, "panels", panels)
 
 
+@onecodex.command("workflows")
+@click.pass_context
+@click.argument("workflows", nargs=-1, required=False)
+@telemetry
+@login_required
+def workflows(ctx, workflows):
+    """Retrieve performed workflow results."""
+    cli_resource_fetcher(ctx, "workflows", workflows)
+
+
 @onecodex.command("samples")
 @click.pass_context
 @click.argument("samples", nargs=-1, required=False)

--- a/onecodex/models/__init__.py
+++ b/onecodex/models/__init__.py
@@ -5,6 +5,7 @@ from onecodex.models.analysis import (
     FunctionalProfiles,
     Mlsts,
     Panels,
+    Workflows,
 )
 from onecodex.models.collection import SampleCollection
 from onecodex.models.genome import AnnotationSets, Assemblies, Genomes, Taxa
@@ -39,6 +40,7 @@ register_model(Alignments)
 register_model(FunctionalProfiles)
 register_model(Panels)
 register_model(Mlsts)
+register_model(Workflows)
 register_model(Users)
 register_model(Projects)
 register_model(Tags)
@@ -59,6 +61,7 @@ Alignments.model_rebuild()
 FunctionalProfiles.model_rebuild()
 Panels.model_rebuild()
 Mlsts.model_rebuild()
+Workflows.model_rebuild()
 Users.model_rebuild()
 Projects.model_rebuild()
 Tags.model_rebuild()
@@ -81,6 +84,7 @@ __all__ = [
     "FunctionalProfiles",
     "Panels",
     "Mlsts",
+    "Workflows",
     "Analyses",
     "Jobs",
     "Documents",

--- a/onecodex/models/analysis.py
+++ b/onecodex/models/analysis.py
@@ -17,6 +17,7 @@ from onecodex.models.schemas.analysis import (
     FunctionalRunSchema,
     MlstSchema,
     PanelSchema,
+    WorkflowSchema,
 )
 from onecodex.models.schemas.misc import FileDetailSchema
 
@@ -471,3 +472,13 @@ class Mlsts(_AnalysesBase, MlstSchema):
             return self._results()
         else:
             raise NotImplementedError("MLST results only available as JSON at this time.")
+
+
+class Workflows(_AnalysesBase, WorkflowSchema):
+    _resource_path = "/api/v1/workflows"
+
+    def results(self, json=True):
+        if json is True:
+            return self._results()
+        else:
+            raise NotImplementedError("Workflow results only available as JSON at this time.")

--- a/onecodex/models/schemas/analysis.py
+++ b/onecodex/models/schemas/analysis.py
@@ -60,3 +60,7 @@ class PanelSchema(BaseAnalysisSchema):
 
 class MlstSchema(BaseAnalysisSchema):
     pass
+
+
+class WorkflowSchema(BaseAnalysisSchema):
+    pass

--- a/tests/data/api/v1/workflows/abcde12345fedcba/results/index.json
+++ b/tests/data/api/v1/workflows/abcde12345fedcba/results/index.json
@@ -1,0 +1,1 @@
+{"workflowResults": {"summary": {"status": "complete"}, "steps": [{"name": "step_one", "status": "complete"}]}}

--- a/tests/data/api/v1/workflows/index.json
+++ b/tests/data/api/v1/workflows/index.json
@@ -1,0 +1,1 @@
+[{"$uri": "/api/v1/workflows/abcde12345fedcba", "complete": true, "created_at": "2025-04-12T10:00:00.000000-07:00", "error_msg": "", "job": {"$ref": "/api/v1/jobs/e1218d2d144e465e"}, "sample": {"$ref": "/api/v1/samples/002f55a11aae4b8f"}, "success": true, "cost": null, "dependencies": [], "draft": false}]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,6 +121,12 @@ def test_panel_instances(runner, api_data, mocked_creds_file):
     assert result.exit_code == 0
 
 
+# Workflows
+def test_workflow_instances(runner, api_data, mocked_creds_file):
+    result = runner.invoke(Cli, ["workflows"])
+    assert result.exit_code == 0
+
+
 # Samples
 def test_samples(runner, api_data, mocked_creds_file):
     r0 = runner.invoke(Cli, ["samples"])

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,23 @@
+from onecodex.models import Workflows
+
+
+def test_query_for_workflows(ocx, api_data):
+    sample_id = "002f55a11aae4b8f"
+    workflow = ocx.Workflows.where(sample=sample_id)
+    assert isinstance(workflow[0], Workflows)
+
+    workflows = ocx.Workflows.all()
+    assert len(workflows) == 1
+
+
+def test_workflows_results(ocx, api_data):
+    workflow_id = "abcde12345fedcba"
+    workflow = Workflows.get(workflow_id)
+
+    assert isinstance(workflow, Workflows)
+
+    result = workflow.results()
+
+    assert "workflowResults" in result
+    assert result["workflowResults"]["summary"]["status"] == "complete"
+    assert result["workflowResults"]["steps"][0]["name"] == "step_one"


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Mirrors Mlsts/Panels as another Analyses sub-resource backed by /api/v1/workflows, and exposes a `onecodex workflows` CLI command.

Closes DEV-9711

## Related PRs
- [x] This PR is independent