### PR TITLE
Fix: don't stub package in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!onecodex
+!pyproject.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ RUN rm -rf onecodex
 COPY onecodex/ ./onecodex/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system --no-deps --force-reinstall .
+
+# Precompile .pyc up-front. The runtime user can't write to /packages, so
+# without this every cold start re-parses every .py.
+RUN python -m compileall -q -j 0 /packages
+
 FROM python:3.11-slim-bookworm
 
 RUN groupadd --system --gid 65532 nonroot \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,6 @@ RUN rm -rf onecodex
 COPY onecodex/ ./onecodex/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system --no-deps --force-reinstall .
-
-# Trim test suites and bytecode caches shipped inside wheels. Avoid name=test
-# or name=testing — both collide with real modules (e.g. numpy.testing).
-RUN find /usr/local/lib/python3.11/site-packages -depth -type d \
-        \( -name tests -o -name __pycache__ \) \
-        -exec rm -rf {} +
-
 FROM python:3.11-slim-bookworm
 
 RUN groupadd --system --gid 65532 nonroot \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,8 @@ ENV UV_LINK_MODE=copy \
 
 WORKDIR /app
 
-# Dependency layer: install only third-party deps. A package stub lets us
-# resolve the project metadata without invalidating this layer on source edits.
 COPY pyproject.toml README.md ./
-RUN mkdir -p onecodex \
- && printf '__version__ = "0.0.0"\n' > onecodex/version.py \
- && touch onecodex/__init__.py
+
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system ".[all]"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,10 @@ ENV UV_LINK_MODE=copy \
     UV_NO_INSTALLER_METADATA=1
 
 WORKDIR /app
-
-COPY pyproject.toml README.md ./
+COPY . .
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system ".[all]"
-
-# Source layer: install just the project on top of the cached deps.
-RUN rm -rf onecodex
-COPY onecodex/ ./onecodex/
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system --no-deps --force-reinstall .
 
 # Precompile .pyc up-front. This reduces start time by about ~260ms
 RUN python -m compileall -q -j 0 /packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ COPY . .
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system ".[all]"
 
-# Precompile .pyc up-front. This reduces start time by about ~260ms
-RUN python -m compileall -q -j 0 /packages
-
 FROM python:3.11-slim-bookworm
 
 RUN groupadd --system --gid 65532 nonroot \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ COPY onecodex/ ./onecodex/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system --no-deps --force-reinstall .
 
-# Precompile .pyc up-front. The runtime user can't write to /packages, so
-# without this every cold start re-parses every .py.
+# Precompile .pyc up-front. This reduces start time by about ~260ms
 RUN python -m compileall -q -j 0 /packages
 
 FROM python:3.11-slim-bookworm


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description

Fix: Stubbing `__init__.py` broke this common pattern

```python
import onecodex
ocx = onecodex.Api()
# AttributeError: module 'onecodex' has no attribute 'Api'
```

## Related PRs

- [x] This PR is independent


## TODOs

NA