### PR TITLE
Add `ocx.Jobs.run`

### DIFF
--- a/onecodex/models/analysis.py
+++ b/onecodex/models/analysis.py
@@ -44,6 +44,7 @@ class _AnalysesBase(OneCodexBase):
     }
     sample: Union["Samples", ApiRef]  # noqa: F821
     job: Union["Jobs", ApiRef]  # noqa: F821
+    dependencies: Union[list["Analyses"], list[ApiRef]] = []  # noqa: F821
     error_msg: Optional[str] = None
 
     def __hash__(self) -> int:

--- a/onecodex/models/misc.py
+++ b/onecodex/models/misc.py
@@ -79,25 +79,107 @@ class Jobs(OneCodexBase, JobSchema):
         self,
         sample: "Samples",
         job_args: dict[str, Any] | None = None,
-        dependency_overrides: list[DependencyOverride] | None = None,
+        dependency_overrides: "list[Analyses | DependencyOverride] | None" = None,
         populate_default_arguments: bool = True,
     ) -> "Analyses":
+        """Run this job against a sample and return the resulting analysis.
+
+        Parameters
+        ----------
+        sample : `Samples`
+            The sample to run this job against.
+        job_args : `dict`, optional
+            Job arguments, validated server-side against the job's
+            ``job_args_schema``. Values are coerced from strings per the schema
+            (e.g. an ``integer`` field accepts ``"20"``). Passing arguments that
+            do not match the schema raises `OneCodexException` with the
+            server's validation message.
+        dependency_overrides : `list[Analyses | DependencyOverride]`, optional
+            Override one or more of the job's declared dependencies with
+            existing analyses. Pass an `Analyses` directly to swap in the
+            parent run while keeping the job-declared (or default) output
+            path. Wrap in `DependencyOverride` only when you also need to set
+            a custom ``download_path``.
+        populate_default_arguments : `bool`, default True
+            If True, the server fills in defaults for any args not provided in
+            ``job_args``. Set False to require every arg to be supplied
+            explicitly.
+
+        Returns
+        -------
+        `Analyses`
+            The newly-created analysis. Note: if an analysis with identical
+            inputs already exists, the server may return the existing one
+            rather than starting a new run.
+
+        Raises
+        ------
+        OneCodexException
+            If the server rejects the request (e.g. invalid ``job_args``,
+            permission denied, or unknown sample/dependency). The exception
+            message contains the server's explanation.
+
+        Examples
+        --------
+        Basic usage::
+
+            job = ocx.Jobs.get("47c4fe23588640a9")
+            sample = ocx.Samples.get("7428cca4a3a04a8e")
+            analysis = job.run(sample)
+
+        With job arguments::
+
+            analysis = job.run(sample, {"min_quality": "20", "adapter": "AGATC"})
+
+        Inspect the job's argument schema first::
+
+            job.job_args_schema  # JSON schema describing accepted args
+
+        Override a dependency to reuse a prior analysis::
+
+            prior = ocx.Analyses.get("abc123def4567890")
+            analysis = job.run(sample, dependency_overrides=[prior])
+
+        Override with a custom output path::
+
+            from onecodex.models.misc import DependencyOverride
+
+            analysis = job.run(
+                sample,
+                dependency_overrides=[
+                    DependencyOverride(analysis=prior, download_path="results/parent.tsv"),
+                ],
+            )
+        """
         from onecodex.models.analysis import Analyses
 
         url = f"{self._api._base_url}{self._resource_path}/{self.id}/run"
-        payload: dict[str, str | dict | list | bool] = {
+        payload: dict[str, Any] = {
             "sample": sample.id,
             "job_args": job_args,
             "populate_default_arguments": populate_default_arguments,
         }
         if dependency_overrides:
+            normalized = [
+                dep
+                if isinstance(dep, DependencyOverride)
+                else DependencyOverride(analysis=dep, download_path=None)
+                for dep in dependency_overrides
+            ]
             payload["dependencies"] = [
                 {"analysis": dep.analysis.id, "download_path": dep.download_path}
-                for dep in dependency_overrides
+                for dep in normalized
             ]
 
         resp = self._client.post(url, json=payload)
-        resp.raise_for_status()
+        if not resp.ok:
+            try:
+                message = resp.json().get("message")
+            except ValueError:
+                message = None
+            raise OneCodexException(
+                message or f"Error running job {self.id}: HTTP {resp.status_code}"
+            )
         if "$ref" not in resp.json():
             raise OneCodexException(f"Invalid response when running job {self.id}")
 

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -629,8 +629,10 @@ def test_jobs_run_no_args(ocx, api_data, custom_mock_requests):
     with custom_mock_requests({f"POST::api/v1/jobs/{job_id}/run": run_callback}):
         job = ocx.Jobs.get(job_id)
         sample = ocx.Samples.get(sample_id)
-        job.run(sample)
+        analysis = job.run(sample)
 
+    assert isinstance(analysis, onecodex.models.Analyses)
+    assert analysis.id == analysis_id
     assert captured["body"] == {
         "sample": sample_id,
         "job_args": None,
@@ -656,8 +658,10 @@ def test_jobs_run_no_populate_default_arguments(ocx, api_data, custom_mock_reque
     with custom_mock_requests({f"POST::api/v1/jobs/{job_id}/run": run_callback}):
         job = ocx.Jobs.get(job_id)
         sample = ocx.Samples.get(sample_id)
-        job.run(sample, populate_default_arguments=False)
+        analysis = job.run(sample, populate_default_arguments=False)
 
+    assert isinstance(analysis, onecodex.models.Analyses)
+    assert analysis.id == analysis_id
     assert captured["body"] == {
         "sample": sample_id,
         "job_args": None,
@@ -688,7 +692,7 @@ def test_jobs_run_with_dependency_overrides(ocx, api_data, custom_mock_requests)
     with custom_mock_requests({f"POST::api/v1/jobs/{job_id}/run": run_callback}):
         job = ocx.Jobs.get(job_id)
         sample = ocx.Samples.get(sample_id)
-        job.run(
+        analysis = job.run(
             sample,
             dependency_overrides=[
                 DependencyOverride(analysis=dep_analysis, download_path="/results/out.txt"),
@@ -696,6 +700,8 @@ def test_jobs_run_with_dependency_overrides(ocx, api_data, custom_mock_requests)
             ],
         )
 
+    assert isinstance(analysis, onecodex.models.Analyses)
+    assert analysis.id == analysis_id
     assert captured["body"] == {
         "sample": sample_id,
         "job_args": None,
@@ -705,6 +711,37 @@ def test_jobs_run_with_dependency_overrides(ocx, api_data, custom_mock_requests)
             {"analysis": dep_analysis_id, "download_path": None},
         ],
     }
+
+
+def test_jobs_run_with_bare_analyses_dependencies(ocx, api_data, custom_mock_requests):
+    job_id = "47c4fe23588640a9"
+    sample_id = "7428cca4a3a04a8e"
+    analysis_id = "593601a797914cbf"
+    dep_analysis_id = "abc123def4567890"
+
+    dep_analysis = ocx.Analyses.get(dep_analysis_id)
+
+    captured = {}
+
+    def run_callback(request):
+        captured["body"] = json.loads(request.body)
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps({"$ref": f"/api/v1/analyses/{analysis_id}"}),
+        )
+
+    with custom_mock_requests({f"POST::api/v1/jobs/{job_id}/run": run_callback}):
+        job = ocx.Jobs.get(job_id)
+        sample = ocx.Samples.get(sample_id)
+        # Pass an Analyses directly — equivalent to DependencyOverride(analysis, None)
+        analysis = job.run(sample, dependency_overrides=[dep_analysis])
+
+    assert isinstance(analysis, onecodex.models.Analyses)
+    assert analysis.id == analysis_id
+    assert captured["body"]["dependencies"] == [
+        {"analysis": dep_analysis_id, "download_path": None},
+    ]
 
 
 def test_jobs_run_invalid_response(ocx, api_data, custom_mock_requests):
@@ -722,8 +759,6 @@ def test_jobs_run_invalid_response(ocx, api_data, custom_mock_requests):
 
 
 def test_jobs_run_http_error(ocx, api_data, custom_mock_requests):
-    import requests
-
     job_id = "47c4fe23588640a9"
     sample_id = "7428cca4a3a04a8e"
 
@@ -733,8 +768,26 @@ def test_jobs_run_http_error(ocx, api_data, custom_mock_requests):
     with custom_mock_requests({f"POST::api/v1/jobs/{job_id}/run": run_callback}):
         job = ocx.Jobs.get(job_id)
         sample = ocx.Samples.get(sample_id)
-        with pytest.raises(requests.HTTPError):
+        with pytest.raises(OneCodexException, match="boom"):
             job.run(sample, {})
+
+
+def test_jobs_run_invalid_arguments(ocx, api_data, custom_mock_requests):
+    job_id = "47c4fe23588640a9"
+    sample_id = "7428cca4a3a04a8e"
+
+    def run_callback(request):
+        return (
+            400,
+            {"Content-Type": "application/json"},
+            json.dumps({"message": "Invalid run parameters: min_quality must be an integer"}),
+        )
+
+    with custom_mock_requests({f"POST::api/v1/jobs/{job_id}/run": run_callback}):
+        job = ocx.Jobs.get(job_id)
+        sample = ocx.Samples.get(sample_id)
+        with pytest.raises(OneCodexException, match="min_quality must be an integer"):
+            job.run(sample, {"min_quality": "not-a-number"})
 
 
 def test_analyses_refresh(ocx, custom_mock_requests):


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

Add the ability to run jobs (workflows) using the client library:

```python
sample = ocx.Samples.get(...)

job = ocx.Jobs.get(...")

analysis = job.run(sample=sample, job_args={'FOO': 'bar'})
```

## Related PRs

- [x] This PR is independent

## TODOs

- [x] Tests
- [x] Documentation
