### PR TITLE
Add `await_completion` to `ocx.Analyses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `Analyses.await_completion()` blocks until an analysis reaches a terminal
+  state using adaptive polling.
+- `onecodex await <analysis_id>` CLI command, with `--timeout`,
+  `--initial-interval`, and `--max-interval` options.
+
 ## [v1.0.2] - 2026-05-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Analyses.await_completion()` blocks until an analysis reaches a terminal
   state using adaptive polling.
-- `onecodex await <analysis_id>` CLI command, with `--timeout`,
-  `--initial-interval`, and `--max-interval` options.
+- `onecodex analyses await <analysis_id>` CLI command, with `--timeout`,
+  `--initial-interval`, and `--max-interval` options. Also available as
+  `onecodex await <analysis_id>` for backward compatibility.
 
 ## [v1.0.2] - 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -130,12 +130,14 @@ onecodex panels 0123456789abcdef 0987654321fdecba
 
 ### Awaiting an analysis
 
-To block until an analysis reaches a terminal state, use the `await` subcommand. Polling starts at a few seconds and backs off, so failures surface quickly while long-running jobs don't get hammered:
+To block until an analysis reaches a terminal state, use the `analyses await` subcommand. Polling starts at a few seconds and backs off, so failures surface quickly while long-running jobs don't get hammered:
 
 ```shell
-onecodex await 0123456789abcdef
-onecodex await 0123456789abcdef --timeout 600
+onecodex analyses await 0123456789abcdef
+onecodex analyses await 0123456789abcdef --timeout 600
 ```
+
+The top-level `onecodex await <analysis_id>` is kept as an alias for backward compatibility.
 
 The command exits non-zero if the analysis finishes unsuccessfully or times out.
 
@@ -203,7 +205,7 @@ The CLI exposes the same functionality:
 
 ```shell
 onecodex jobs run <job_id> <sample_id> -a min_quality=30
-onecodex await <analysis_id>
+onecodex analyses await <analysis_id>
 
 # Or block in a single step:
 onecodex jobs run <job_id> <sample_id> --arg min_quality=30 --await

--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ The CLI exposes the same functionality:
 ```shell
 onecodex jobs run <job_id> <sample_id> -a min_quality=30
 onecodex await <analysis_id>
+
+# Or block in a single step:
+onecodex jobs run <job_id> <sample_id> --arg min_quality=30 --await
 ```
 
 For long-running analyses, `await_completion()` polls until the analysis reaches a terminal state (`complete=True`). The cadence backs off over time, so failures surface in seconds while longer jobs poll on the order of minutes:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ onecodex samples
 onecodex panels 0123456789abcdef 0987654321fdecba
 ```
 
+### Awaiting an analysis
+
+To block until an analysis reaches a terminal state, use the `await` subcommand. Polling starts at a few seconds and backs off, so failures surface quickly while long-running jobs don't get hammered:
+
+```shell
+onecodex await 0123456789abcdef
+onecodex await 0123456789abcdef --timeout 600
+```
+
+The command exits non-zero if the analysis finishes unsuccessfully or times out.
+
 # Using the Python client library
 
 ## Initialization
@@ -157,6 +168,53 @@ sample_analysis = ocx.Classifications.get("1d9491c5c31345b6")   # Fetch an indiv
 sample_analysis.results()  # Returns classification results as JSON object
 sample_analysis.table()    # Returns a pandas dataframe
 ```
+
+## Running Workflows
+
+You can launch a job (workflow) against an uploaded sample directly from the Python client. `Jobs.run()` returns the freshly-created `Analyses` instance, which you can then poll for completion.
+
+```python
+job = ocx.Jobs.get("0123456789abcdef")     # or look up by name with .where()
+sample = ocx.Samples.get("fedcba9876543210")
+
+analysis = job.run(sample, job_args={"min_quality": 30})
+analysis.await_completion()                # block until the job finishes
+
+if analysis.success:
+    results = analysis.results()
+else:
+    print(f"Job failed: {analysis.error_msg}")
+```
+
+To re-use the output of a previous run as an input to a new one, pass `dependency_overrides`:
+
+```python
+from onecodex.models.misc import DependencyOverride
+
+prior = ocx.Analyses.get("abcdef0123456789")
+analysis = job.run(
+    sample,
+    job_args={"k": 31},
+    dependency_overrides=[DependencyOverride(analysis=prior)],
+)
+```
+
+The CLI exposes the same functionality:
+
+```shell
+onecodex jobs run <job_id> <sample_id> -a min_quality=30
+onecodex await <analysis_id>
+```
+
+For long-running analyses, `await_completion()` polls until the analysis reaches a terminal state (`complete=True`). The cadence backs off over time, so failures surface in seconds while longer jobs poll on the order of minutes:
+
+```python
+analysis = ocx.Analyses.get("0123456789abcdef")
+analysis.await_completion()                # block indefinitely
+analysis.await_completion(timeout=600)     # raise TimeoutError after 10 minutes
+```
+
+The method refreshes `analysis` in place and returns it; check `analysis.success` to see whether it finished cleanly. `analysis.refresh()` is also available if you just need to re-fetch the current state without blocking.
 
 In addition to methods on individual instances of a given resource (e.g., a `Sample` or an `Analysis`), the library also provides methods for aggregating sets of samples or analyses:
 

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -341,6 +341,54 @@ def analyses(ctx, analyses):
     cli_resource_fetcher(ctx, "analyses", analyses)
 
 
+@onecodex.command("await")
+@click.argument("analysis_id", nargs=1, required=True)
+@click.option(
+    "--timeout",
+    type=float,
+    default=None,
+    help="Maximum number of seconds to wait. Waits indefinitely if not set.",
+)
+@click.option(
+    "--initial-interval",
+    type=float,
+    default=3.0,
+    show_default=True,
+    help="Seconds between the first polls.",
+)
+@click.option(
+    "--max-interval",
+    type=float,
+    default=120.0,
+    show_default=True,
+    help="Upper bound on the polling interval after backoff.",
+)
+@click.pass_context
+@pretty_errors
+@telemetry
+@login_required
+def analyses_await(ctx, analysis_id, timeout, initial_interval, max_interval):
+    """Poll an analysis until it reaches a terminal state."""
+    analysis = ctx.obj["API"].Analyses.get(analysis_id)
+    if not analysis:
+        raise click.ClickException(f"Could not find analysis {analysis_id} (404 status code)")
+
+    try:
+        analysis.await_completion(
+            timeout=timeout,
+            initial_interval=initial_interval,
+            max_interval=max_interval,
+        )
+    except TimeoutError as exc:
+        raise click.ClickException(str(exc))
+
+    click.echo(f"Analysis {analysis.id} complete (success={analysis.success}).")
+    if analysis.error_msg:
+        click.echo(f"Error: {analysis.error_msg}", err=True)
+    if analysis.success is False:
+        ctx.exit(1)
+
+
 @onecodex.command("classifications")
 @click.option("--read-level", "readlevel", is_flag=True, help=OPTION_HELP["readlevel"])
 @click.option(

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -345,29 +345,34 @@ def analyses(ctx, analyses):
 @click.argument("analysis_id", nargs=1, required=True)
 @click.option(
     "--timeout",
+    "timeout_seconds",
     type=float,
     default=None,
     help="Maximum number of seconds to wait. Waits indefinitely if not set.",
 )
 @click.option(
     "--initial-interval",
-    type=float,
-    default=3.0,
+    "initial_interval_seconds",
+    type=click.IntRange(min=5),
+    default=5,
     show_default=True,
-    help="Seconds between the first polls.",
+    help="Seconds between the first polls (minimum 5).",
 )
 @click.option(
     "--max-interval",
-    type=float,
-    default=120.0,
+    "max_interval_seconds",
+    type=click.IntRange(min=5),
+    default=120,
     show_default=True,
-    help="Upper bound on the polling interval after backoff.",
+    help="Upper bound (in seconds) on the polling interval after backoff (minimum 5).",
 )
 @click.pass_context
 @pretty_errors
 @telemetry
 @login_required
-def analyses_await(ctx, analysis_id, timeout, initial_interval, max_interval):
+def analyses_await(
+    ctx, analysis_id, timeout_seconds, initial_interval_seconds, max_interval_seconds
+):
     """Poll an analysis until it reaches a terminal state."""
     analysis = ctx.obj["API"].Analyses.get(analysis_id)
     if not analysis:
@@ -375,9 +380,9 @@ def analyses_await(ctx, analysis_id, timeout, initial_interval, max_interval):
 
     try:
         analysis.await_completion(
-            timeout=timeout,
-            initial_interval=initial_interval,
-            max_interval=max_interval,
+            timeout=timeout_seconds,
+            initial_interval=initial_interval_seconds,
+            max_interval=max_interval_seconds,
         )
     except TimeoutError as exc:
         raise click.ClickException(str(exc))

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -736,11 +736,26 @@ def jobs_group():
     default=True,
     help="Populate job arguments with their defaults on the server (default: enabled).",
 )
+@click.option(
+    "--await",
+    "await_completion",
+    is_flag=True,
+    default=False,
+    help="Block until the new analysis reaches a terminal state.",
+)
 @click.pass_context
 @pretty_errors
 @telemetry
 @login_required
-def jobs_run(ctx, job_id, sample_id, args, dependency_overrides, populate_default_arguments):
+def jobs_run(
+    ctx,
+    job_id,
+    sample_id,
+    args,
+    dependency_overrides,
+    populate_default_arguments,
+    await_completion,
+):
     """Run a OneCodex job with optional arguments."""
     from onecodex.models.misc import DependencyOverride
 
@@ -776,4 +791,12 @@ def jobs_run(ctx, job_id, sample_id, args, dependency_overrides, populate_defaul
         populate_default_arguments=populate_default_arguments,
     )
     click.echo(f"Job run created successfully. New analysis ID: {run.id}")
-    click.echo(f"Get its status using `onecodex analyses {run.id}`", err=True)
+    if await_completion:
+        run.await_completion()
+        click.echo(f"Analysis {run.id} complete (success={run.success}).")
+        if run.error_msg:
+            click.echo(f"Error: {run.error_msg}", err=True)
+        if run.success is False:
+            ctx.exit(1)
+    else:
+        click.echo(f"Get its status using `onecodex analyses {run.id}`", err=True)

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -331,17 +331,43 @@ assets.add_command(assets_list, "list")
 
 
 # resources
-@onecodex.command("analyses")
+class _AnalysesGroup(click.Group):
+    """Group that preserves ``analyses [ID]...`` while still dispatching subcommands.
+
+    Click's variadic ``nargs=-1`` argument on a group would otherwise eat the subcommand
+    name. We split args manually: if any arg matches a registered subcommand, dispatch to
+    it; otherwise treat the full arg list as analysis IDs for the group callback.
+    """
+
+    def parse_args(self, ctx, args):
+        for i, a in enumerate(args):
+            if a in self.commands:
+                # Temporarily strip the variadic Argument so MultiCommand's normal
+                # subcommand dispatch works; supply the captured IDs ourselves.
+                ids = tuple(args[:i])
+                variadic = [p for p in self.params if getattr(p, "name", None) == "analyses"]
+                self.params = [p for p in self.params if p not in variadic]
+                try:
+                    rest = super().parse_args(ctx, args[i:])
+                finally:
+                    self.params.extend(variadic)
+                ctx.params["analyses"] = ids
+                return rest
+        return click.Command.parse_args(self, ctx, args)
+
+
+@onecodex.group("analyses", cls=_AnalysesGroup, invoke_without_command=True)
 @click.argument("analyses", nargs=-1, required=False)
 @click.pass_context
 @telemetry
 @login_required
 def analyses(ctx, analyses):
     """Retrieve performed analyses."""
-    cli_resource_fetcher(ctx, "analyses", analyses)
+    if ctx.invoked_subcommand is None:
+        cli_resource_fetcher(ctx, "analyses", analyses)
 
 
-@onecodex.command("await")
+@click.command("await")
 @click.argument("analysis_id", nargs=1, required=True)
 @click.option(
     "--timeout",
@@ -392,6 +418,10 @@ def analyses_await(
         click.echo(f"Error: {analysis.error_msg}", err=True)
     if analysis.success is False:
         ctx.exit(1)
+
+
+onecodex.add_command(analyses_await, "await")
+analyses.add_command(analyses_await, "await")
 
 
 @onecodex.command("classifications")

--- a/onecodex/models/analysis.py
+++ b/onecodex/models/analysis.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os.path
+import time
 from functools import lru_cache
 from typing import IO, TYPE_CHECKING, List, Optional, Union
 
@@ -55,6 +56,73 @@ class _AnalysesBase(OneCodexBase):
         if not isinstance(other, _AnalysesBase):
             return NotImplemented
         return self.id == other.id
+
+    def refresh(self) -> None:
+        """Fetch the current state from the API and update this object's state fields in-place."""
+        resp = self._client.get(f"{self._api._base_url}{self._resource_path}/{self.id}?expand=all")
+        resp.raise_for_status()
+        new_obj = self.__class__.model_validate(resp.json())
+        for field, value in new_obj:
+            setattr(self, field, value)
+        self._snapshot = self._object_snapshot()
+
+    def await_completion(
+        self,
+        timeout: Optional[float] = None,
+        initial_interval: float = 3.0,
+        max_interval: float = 120.0,
+        backoff: float = 1.5,
+    ) -> "_AnalysesBase":
+        """Poll the API until the analysis reaches a terminal state.
+
+        An analysis is considered terminal when ``complete`` is True. The method refreshes
+        ``self`` in place and returns it.
+
+        Parameters
+        ----------
+        timeout : float, optional
+            Maximum number of seconds to wait. ``None`` (default) waits indefinitely.
+        initial_interval : float, optional
+            Seconds to wait between the first polls. Defaults to 3 seconds so failures
+            surface quickly.
+        max_interval : float, optional
+            Upper bound on the polling interval as it backs off. Defaults to 120 seconds.
+        backoff : float, optional
+            Multiplier applied to the interval after each poll. Defaults to 1.5.
+
+        Returns
+        -------
+        self : the analysis, refreshed to its terminal state.
+
+        Raises
+        ------
+        TimeoutError
+            If ``timeout`` elapses before the analysis completes.
+        """
+        if initial_interval <= 0 or max_interval <= 0:
+            raise ValueError("Polling intervals must be positive.")
+        if backoff < 1:
+            raise ValueError("backoff must be >= 1.")
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        interval = initial_interval
+
+        self.refresh()
+        while not self.complete:
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"Analysis {self.id} did not complete within {timeout} seconds."
+                    )
+                sleep_for = min(interval, remaining)
+            else:
+                sleep_for = interval
+            time.sleep(sleep_for)
+            interval = min(interval * backoff, max_interval)
+            self.refresh()
+
+        return self
 
     def results(self, json: bool = True):
         """Fetch the results of an Analyses resource.
@@ -207,16 +275,6 @@ class _AnalysesBase(OneCodexBase):
 
 class Analyses(_AnalysesBase, AnalysisSchema):
     _resource_path = "/api/v1/analyses"
-
-    # Consider putting this in OneCodexBase
-    def refresh(self) -> None:
-        """Fetch the current state from the API and update this object's state fields in-place."""
-        resp = self._client.get(f"{self._api._base_url}{self._resource_path}/{self.id}?expand=all")
-        resp.raise_for_status()
-        new_obj = self.__class__.model_validate(resp.json())
-        for field, value in new_obj:
-            setattr(self, field, value)
-        self._snapshot = self._object_snapshot()
 
 
 class Alignments(_AnalysesBase, AlignmentSchema):

--- a/onecodex/models/analysis.py
+++ b/onecodex/models/analysis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os.path
 import time
 from functools import lru_cache
-from typing import IO, TYPE_CHECKING, List, Optional, Union
+from typing import IO, TYPE_CHECKING, ClassVar, List, Optional, Union
 
 import click
 import requests
@@ -66,11 +66,13 @@ class _AnalysesBase(OneCodexBase):
             setattr(self, field, value)
         self._snapshot = self._object_snapshot()
 
+    MIN_POLL_INTERVAL_SECONDS: ClassVar[int] = 5
+
     def await_completion(
         self,
         timeout: Optional[float] = None,
-        initial_interval: float = 3.0,
-        max_interval: float = 120.0,
+        initial_interval: int = 5,
+        max_interval: int = 120,
         backoff: float = 1.5,
     ) -> "_AnalysesBase":
         """Poll the API until the analysis reaches a terminal state.
@@ -82,11 +84,12 @@ class _AnalysesBase(OneCodexBase):
         ----------
         timeout : float, optional
             Maximum number of seconds to wait. ``None`` (default) waits indefinitely.
-        initial_interval : float, optional
-            Seconds to wait between the first polls. Defaults to 3 seconds so failures
-            surface quickly.
-        max_interval : float, optional
-            Upper bound on the polling interval as it backs off. Defaults to 120 seconds.
+        initial_interval : int, optional
+            Seconds to wait between the first polls. Must be at least
+            ``MIN_POLL_INTERVAL_SECONDS`` (5). Defaults to 5.
+        max_interval : int, optional
+            Upper bound on the polling interval as it backs off. Must be at least
+            ``MIN_POLL_INTERVAL_SECONDS`` (5). Defaults to 120 seconds.
         backoff : float, optional
             Multiplier applied to the interval after each poll. Defaults to 1.5.
 
@@ -99,8 +102,13 @@ class _AnalysesBase(OneCodexBase):
         TimeoutError
             If ``timeout`` elapses before the analysis completes.
         """
-        if initial_interval <= 0 or max_interval <= 0:
-            raise ValueError("Polling intervals must be positive.")
+        if (
+            initial_interval < self.MIN_POLL_INTERVAL_SECONDS
+            or max_interval < self.MIN_POLL_INTERVAL_SECONDS
+        ):
+            raise ValueError(
+                f"Polling intervals must be >= {self.MIN_POLL_INTERVAL_SECONDS} seconds."
+            )
         if backoff < 1:
             raise ValueError("backoff must be >= 1.")
 

--- a/onecodex/models/misc.py
+++ b/onecodex/models/misc.py
@@ -97,7 +97,20 @@ class Jobs(OneCodexBase, JobSchema):
             ]
 
         resp = self._client.post(url, json=payload)
-        resp.raise_for_status()
+        if not resp.ok:
+            try:
+                body = resp.json()
+            except ValueError:
+                body = None
+            detail = None
+            if isinstance(body, dict):
+                detail = body.get("message") or body.get("msg")
+            if not detail:
+                detail = (resp.text or "").strip() or None
+            msg = f"Job run failed ({resp.status_code})"
+            if detail:
+                msg = f"{msg}: {detail}"
+            raise OneCodexException(msg)
         if "$ref" not in resp.json():
             raise OneCodexException(f"Invalid response when running job {self.id}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -592,6 +592,13 @@ def custom_mock_requests():
     yield mock_requests
 
 
+@pytest.fixture(autouse=True)
+def _mask_credentials_env(monkeypatch):
+    """Mask developer-set credentials so tests never accidentally use real auth."""
+    monkeypatch.delenv("ONE_CODEX_API_KEY", raising=False)
+    monkeypatch.delenv("ONE_CODEX_BEARER_TOKEN", raising=False)
+
+
 @pytest.fixture(scope="function")
 def runner():
     runner = CliRunner(

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -722,18 +722,16 @@ def test_jobs_run_invalid_response(ocx, api_data, custom_mock_requests):
 
 
 def test_jobs_run_http_error(ocx, api_data, custom_mock_requests):
-    import requests
-
     job_id = "47c4fe23588640a9"
     sample_id = "7428cca4a3a04a8e"
 
     def run_callback(request):
-        return (500, {"Content-Type": "application/json"}, json.dumps({"message": "boom"}))
+        return (400, {"Content-Type": "application/json"}, json.dumps({"message": "bad arg foo"}))
 
     with custom_mock_requests({f"POST::api/v1/jobs/{job_id}/run": run_callback}):
         job = ocx.Jobs.get(job_id)
         sample = ocx.Samples.get(sample_id)
-        with pytest.raises(requests.HTTPError):
+        with pytest.raises(OneCodexException, match="bad arg foo"):
             job.run(sample, {})
 
 

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -839,7 +839,7 @@ def test_analyses_await_completion(ocx, custom_mock_requests):
     with custom_mock_requests({f"GET::api/v1/analyses/{analysis_id}": get_callback}):
         with mock.patch("onecodex.models.analysis.time.sleep", side_effect=sleeps.append):
             analysis = ocx.Analyses.get(analysis_id)
-            result = analysis.await_completion(initial_interval=1.0, backoff=2.0, max_interval=4.0)
+            result = analysis.await_completion(initial_interval=5, backoff=2.0, max_interval=20)
 
     assert result is analysis
     assert analysis.complete is True
@@ -847,7 +847,7 @@ def test_analyses_await_completion(ocx, custom_mock_requests):
     assert bodies == []
     # Analyses.get consumes body 1; await_completion's refresh loop consumes bodies 2-4
     # (incomplete, incomplete, complete) with one sleep after each non-terminal response.
-    assert sleeps == [1.0, 2.0]
+    assert sleeps == [5, 10]
 
 
 def test_analyses_await_completion_timeout(ocx, custom_mock_requests):
@@ -883,7 +883,7 @@ def test_analyses_await_completion_timeout(ocx, custom_mock_requests):
             with mock.patch("onecodex.models.analysis.time.sleep", side_effect=fake_sleep):
                 analysis = ocx.Analyses.get(analysis_id)
                 with pytest.raises(TimeoutError):
-                    analysis.await_completion(timeout=5.0, initial_interval=1.0, backoff=1.0)
+                    analysis.await_completion(timeout=10.0, initial_interval=5, backoff=1.0)
 
 
 def test_sample_preupload(ocx, upload_mocks, api_data):

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -810,6 +810,82 @@ def test_analyses_refresh_http_error(ocx, custom_mock_requests):
         assert analysis.success is False
 
 
+def test_analyses_await_completion(ocx, custom_mock_requests):
+    analysis_id = "593601a797914cbf"
+    base_payload = {
+        "$uri": f"/api/v1/analyses/{analysis_id}",
+        "analysis_type": "classification",
+        "created_at": "2015-09-25T17:27:30.622286-07:00",
+        "job": {"$ref": "/api/v1/jobs/e4b1ab37ff554c53"},
+        "sample": {"$ref": "/api/v1/samples/7428cca4a3a04a8e"},
+        "cost": None,
+        "dependencies": [],
+        "draft": False,
+        "job_args": {},
+    }
+    bodies = [
+        {**base_payload, "complete": False, "success": False, "error_msg": None},
+        {**base_payload, "complete": False, "success": False, "error_msg": None},
+        {**base_payload, "complete": False, "success": False, "error_msg": None},
+        {**base_payload, "complete": True, "success": True, "error_msg": None},
+    ]
+
+    def get_callback(request):
+        body = bodies.pop(0)
+        return (200, {"Content-Type": "application/json"}, json.dumps(body))
+
+    sleeps = []
+
+    with custom_mock_requests({f"GET::api/v1/analyses/{analysis_id}": get_callback}):
+        with mock.patch("onecodex.models.analysis.time.sleep", side_effect=sleeps.append):
+            analysis = ocx.Analyses.get(analysis_id)
+            result = analysis.await_completion(initial_interval=1.0, backoff=2.0, max_interval=4.0)
+
+    assert result is analysis
+    assert analysis.complete is True
+    assert analysis.success is True
+    assert bodies == []
+    # Analyses.get consumes body 1; await_completion's refresh loop consumes bodies 2-4
+    # (incomplete, incomplete, complete) with one sleep after each non-terminal response.
+    assert sleeps == [1.0, 2.0]
+
+
+def test_analyses_await_completion_timeout(ocx, custom_mock_requests):
+    analysis_id = "593601a797914cbf"
+    payload = {
+        "$uri": f"/api/v1/analyses/{analysis_id}",
+        "analysis_type": "classification",
+        "created_at": "2015-09-25T17:27:30.622286-07:00",
+        "complete": False,
+        "success": False,
+        "error_msg": None,
+        "job": {"$ref": "/api/v1/jobs/e4b1ab37ff554c53"},
+        "sample": {"$ref": "/api/v1/samples/7428cca4a3a04a8e"},
+        "cost": None,
+        "dependencies": [],
+        "draft": False,
+        "job_args": {},
+    }
+
+    def get_callback(request):
+        return (200, {"Content-Type": "application/json"}, json.dumps(payload))
+
+    fake_now = [0.0]
+
+    def fake_monotonic():
+        return fake_now[0]
+
+    def fake_sleep(seconds):
+        fake_now[0] += seconds
+
+    with custom_mock_requests({f"GET::api/v1/analyses/{analysis_id}": get_callback}):
+        with mock.patch("onecodex.models.analysis.time.monotonic", side_effect=fake_monotonic):
+            with mock.patch("onecodex.models.analysis.time.sleep", side_effect=fake_sleep):
+                analysis = ocx.Analyses.get(analysis_id)
+                with pytest.raises(TimeoutError):
+                    analysis.await_completion(timeout=5.0, initial_interval=1.0, backoff=1.0)
+
+
 def test_sample_preupload(ocx, upload_mocks, api_data):
     projects = ocx.Projects.where(project_name="One Codex Project")
     sample_id = ocx.Samples.preupload(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,7 +91,7 @@ def test_analyses_await(runner, custom_mock_requests, mocked_creds_file, monkeyp
 
     with custom_mock_requests({f"GET::api/v1/analyses/{analysis_id}": get_callback}):
         with mock.patch("onecodex.models.analysis.time.sleep"):
-            result = runner.invoke(Cli, ["await", analysis_id, "--initial-interval", "0.01"])
+            result = runner.invoke(Cli, ["await", analysis_id, "--initial-interval", "5"])
 
     assert result.exit_code == 0, result.output
     assert f"Analysis {analysis_id} complete" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import os
 import os.path
 
@@ -63,6 +64,38 @@ def test_analyses(runner, api_data, mocked_creds_file):
     assert r1.exit_code == 0
     assert API_DATA["GET::api/v1/analyses/593601a797914cbf"]["$uri"] in r0.output
     assert API_DATA["GET::api/v1/analyses/593601a797914cbf"]["$uri"] in r1.output
+
+
+def test_analyses_await(runner, custom_mock_requests, mocked_creds_file, monkeypatch):
+    analysis_id = "593601a797914cbf"
+    base_payload = {
+        "$uri": f"/api/v1/analyses/{analysis_id}",
+        "analysis_type": "classification",
+        "created_at": "2015-09-25T17:27:30.622286-07:00",
+        "job": {"$ref": "/api/v1/jobs/e4b1ab37ff554c53"},
+        "sample": {"$ref": "/api/v1/samples/7428cca4a3a04a8e"},
+        "cost": None,
+        "dependencies": [],
+        "draft": False,
+        "job_args": {},
+    }
+    bodies = [
+        {**base_payload, "complete": False, "success": False, "error_msg": None},
+        {**base_payload, "complete": False, "success": False, "error_msg": None},
+        {**base_payload, "complete": True, "success": True, "error_msg": None},
+    ]
+
+    def get_callback(request):
+        body = bodies.pop(0)
+        return (200, {"Content-Type": "application/json"}, json.dumps(body))
+
+    with custom_mock_requests({f"GET::api/v1/analyses/{analysis_id}": get_callback}):
+        with mock.patch("onecodex.models.analysis.time.sleep"):
+            result = runner.invoke(Cli, ["await", analysis_id, "--initial-interval", "0.01"])
+
+    assert result.exit_code == 0, result.output
+    assert f"Analysis {analysis_id} complete" in result.output
+    assert "success=True" in result.output
 
 
 # Classifications


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description

- Add `analysis.await_completion()` to poll for an analysis
- Add `onecodex await` to CLI
- Add `--await` to `onecodex jobs run`
- Move `ocx.Analyses.refresh` to `ocx.AnalysesBase.refresh` so that all analysis subclasses have it
- Add "Running Workflows" section to `README.md`
- Remove `ONE_CODEX_API_KEY` and `ONE_CODEX_BEARER_TOKEN` from environment when running tests

I snuck these two fixes in as well:

- `onecodex jobs run` now prints API error messages
- `onecodex.Jobs.run` now raises a `OneCodexException` if the API response is not okay. The exception's message includes the API response (useful for surfacing argument validation errors)

## Related PRs

- [x] This PR is independent

## TODOs


- [x] Tests
