### PR TITLE
Dockerfile: don't require PYTHONPATH to be set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,17 +13,17 @@ RUN mkdir -p onecodex \
  && printf '__version__ = "0.0.0"\n' > onecodex/version.py \
  && touch onecodex/__init__.py
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --target=/packages ".[all]"
+    uv pip install --system ".[all]"
 
 # Source layer: install just the project on top of the cached deps.
 RUN rm -rf onecodex
 COPY onecodex/ ./onecodex/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --target=/packages --no-deps --force-reinstall .
+    uv pip install --system --no-deps --force-reinstall .
 
 # Trim test suites and bytecode caches shipped inside wheels. Avoid name=test
 # or name=testing — both collide with real modules (e.g. numpy.testing).
-RUN find /packages -depth -type d \
+RUN find /usr/local/lib/python3.11/site-packages -depth -type d \
         \( -name tests -o -name __pycache__ \) \
         -exec rm -rf {} +
 
@@ -32,8 +32,7 @@ FROM python:3.11-slim-bookworm
 RUN groupadd --system --gid 65532 nonroot \
  && useradd  --system --uid 65532 --gid 65532 --home /home/nonroot --create-home --shell /sbin/nologin nonroot
 
-COPY --from=builder /packages /packages
-ENV PYTHONPATH=/packages
+COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 
 USER nonroot
 WORKDIR /home/nonroot


### PR DESCRIPTION
## Status
- [x] **Ready**

## Description
Packages are installed system-wide instead of under `/packages`. `/packages` was previously needed for the distroless base.

## Related PRs
- [x] This PR is independent