### PR TITLE
Add job creating and updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -18,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `onecodex analyses logs <analysis_id>` CLI command, with `--tail` to limit
   the number of log lines returned (defaults to 1000). Only available for
   custom workflow runs.
+- `Jobs.create()` and `Jobs.update()` for creating and updating custom jobs
+  from the Python client. `assets=[...]` accepts `Assets` instances directly;
+  `dependencies=[{"job": parent_job, "output_dir": "..."}]` accepts `Jobs`
+  instances directly.
+- `onecodex jobs create` and `onecodex jobs update <job_id>` CLI commands.
+
+### Changed
+
+- `ApiRef` now accepts any object with a `field_uri` attribute (e.g. resource
+  model instances), in addition to the existing `$ref`/`$uri` dict shapes. This
+  lets users pass fetched resources directly into create/update calls.
+- `OneCodexBase.create()` now validates kwargs against the schema declared in
+  `_allowed_methods["create"]` (when one is set), mirroring how `update()`
+  already worked. Surfaces server error messages instead of failing on
+  response parsing.
 
 ## [v1.0.2] - 2026-05-06
 
@@ -73,6 +89,7 @@ collection.to_df()
 ```
 
 ### Added
+
 - `metric` is now an argument for all plot and stats functions. By default, it is `auto`, which is determined by `SampleCollection.automatic_metric` based on existing logic
 - `SampleCollection.__repr__` has been updated to differentiate it from lists: `<SampleCollection[Samples] length=60 : [<Samples 0b2d0b5397324841: "SRR4408293.fastq">, ...`
 - Added type annotations to `onecodex.Api()` so that models are now known to static analyzers (e.g., `ocx.Samples`)
@@ -80,17 +97,20 @@ collection.to_df()
 - `SampleCollection.automatic_metric` now returns the best `onecodex.enums.Metric` value to use based on the contained results
 
 ### Changed
+
 - You can change plotting metrics without re-instantiating the `SampleCollection`
 - In alpha- and beta-diversity related functions (e.g., `plot_mds`), the argument `metric` was changed to either `diversity_metric` or `distance_metric`. The `metric` argument in those functions now corresponds to the abundance metric (see `onecodex.enums.Metric`)
 - `onecodex.notebooks.report` functions no longer raise a `OneCodexException` if used outside of IPython.
 
 ### Removed
+
 - `ClassificationDataframe.ocx` has been removed
 - `SampleCollection()` no longer takes `metric` or `normalize` arguments. Those have been merged into a single `metric=` argument that takes a string or `onecodex.enums.Metric` enum value, which is now passed into dataframe and plotting functions directly
 - `normalize` has been removed. Normalized metrics are now available as individual `Metric` enum values
 - Removed `test-python3-w-simple-json` from CI. It randomly started breaking. We don't think we need it anymore since we've moved away from Potion
 
 ### Fixed
+
 - `readcount` being used instead of the intended metric when clustering samples for PCA/Heatmap when plotting from a `SampleCollection`
 - Plot title and table export column names have been updated to be more specific and match custom plots
 
@@ -215,7 +235,7 @@ collection.to_df()
 - Adds alpha diversity stats tests, which are run via `SampleCollection.alpha_diversity_stats()`
 - Adds support for Python 3.12
 - BIOM export now includes canonical taxonomic lineage
-- Adds documentation via GitHub Pages at https://onecodex.github.io/onecodex/
+- Adds documentation via GitHub Pages at <https://onecodex.github.io/onecodex/>
 - Adds support for concatenating ONT files
 
 ### Changed
@@ -479,28 +499,28 @@ collection.to_df()
 
 ### Added
 
--   Adds more pythonic support for truthy/falsey values to SampleCollection.filter()
--   Adds support for passing lists to the various sort_x and sort_y plotting arguments
--   Adds a property to SampleCollection to track whether we think the collection is all WGS/metagenomic data
--   Adds support for specifying weighted_unifrac and unweighted_unifrac as metrics in the SampleCollection.beta_diversity() method
--   Adds support for calculating alpha and beta diversities on normalized data. This is important since we'll now be using abundances by default for most datasets
--   Adds support for specifying chart width and height directly in the plot\_\* functions
--   Adds option to plot "Other" bars on bargraphs with normalized read counts and abundances
--   Adds option to plot "No \<level\>" bars on bargraphs with abundances
--   Adds abundance rollups so we can use abundances at all taxonomic ranks
--   Adds a project column to the metadata DataFrame of a SampleCollection
+- Adds more pythonic support for truthy/falsey values to SampleCollection.filter()
+- Adds support for passing lists to the various sort_x and sort_y plotting arguments
+- Adds a property to SampleCollection to track whether we think the collection is all WGS/metagenomic data
+- Adds support for specifying weighted_unifrac and unweighted_unifrac as metrics in the SampleCollection.beta_diversity() method
+- Adds support for calculating alpha and beta diversities on normalized data. This is important since we'll now be using abundances by default for most datasets
+- Adds support for specifying chart width and height directly in the plot\_\* functions
+- Adds option to plot "Other" bars on bargraphs with normalized read counts and abundances
+- Adds option to plot "No \<level\>" bars on bargraphs with abundances
+- Adds abundance rollups so we can use abundances at all taxonomic ranks
+- Adds a project column to the metadata DataFrame of a SampleCollection
 
 ### Changed
 
--   Changes default alpha diversity metric from simpson to shannon, since shannon is generally a more appropriate default
--   rank="auto" now defaults to species if the field="abundances" or the dataset is metagenomic, instead of genus
--   Switches to using a normalized tree for Weighted Unifrac calculations, which gives us Unifrac values in a [0, 1] range
--   Defaults to using abundances data for metagenomic datasets instead of readcount_w_children
+- Changes default alpha diversity metric from simpson to shannon, since shannon is generally a more appropriate default
+- rank="auto" now defaults to species if the field="abundances" or the dataset is metagenomic, instead of genus
+- Switches to using a normalized tree for Weighted Unifrac calculations, which gives us Unifrac values in a [0, 1] range
+- Defaults to using abundances data for metagenomic datasets instead of readcount_w_children
 
 ### Deprecated
 
--   The `field` kwarg on the `SampleCollection` constructor has been renamed to `metric`. We still support passing either, but show a `DeprecationWarning` when passing `field`
+- The `field` kwarg on the `SampleCollection` constructor has been renamed to `metric`. We still support passing either, but show a `DeprecationWarning` when passing `field`
 
 ### Removed
 
--   Removes support for just specifying `unifrac` as a metric
+- Removes support for just specifying `unifrac` as a metric

--- a/README.md
+++ b/README.md
@@ -223,6 +223,43 @@ onecodex analyses await <analysis_id>
 onecodex jobs run <job_id> <sample_id> --arg min_quality=30 --await
 ```
 
+## Creating and updating jobs
+
+You can create and update custom jobs from the client. Resource references
+(assets, parent jobs) accept fetched model instances directly — no `$ref`
+boilerplate.
+
+```python
+asset = ocx.Assets.upload("reference.fa.gz")
+parent = ocx.Jobs.get("0123456789abcdef")
+
+job = ocx.Jobs.create(
+    name="my-custom-job",
+    script=open("run.sh").read(),
+    image_uri="docker.io/library/python:3.12",
+    job_type="shell_script",
+    cpu=1, ram_gb=1, storage_gb=1,
+    assets=[asset],
+    dependencies=[{"job": parent, "output_dir": "parent_out"}],
+)
+
+job.update(name="renamed", description="now with a description")
+```
+
+The CLI mirrors this:
+
+```shell
+onecodex jobs create \
+    --name my-custom-job \
+    --script ./run.sh \
+    --image-uri docker.io/library/python:3.12 \
+    --cpu 1 --ram-gb 1 --storage-gb 1 \
+    --asset-id <asset_id> \
+    -d <parent_job_id>=parent_out
+
+onecodex jobs update <job_id> --name renamed
+```
+
 For long-running analyses, `await_completion()` polls until the analysis reaches a terminal state (`complete=True`). The cadence backs off over time, so failures surface in seconds while longer jobs poll on the order of minutes:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -225,9 +225,7 @@ onecodex jobs run <job_id> <sample_id> --arg min_quality=30 --await
 
 ## Creating and updating jobs
 
-You can create and update custom jobs from the client. Resource references
-(assets, parent jobs) accept fetched model instances directly — no `$ref`
-boilerplate.
+You can create and update custom jobs from the client.
 
 ```python
 asset = ocx.Assets.upload("reference.fa.gz")

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import copy
+import json
 import logging
 import os
 import time
@@ -846,6 +847,7 @@ def jobs_run(
         populate_default_arguments=populate_default_arguments,
     )
     click.echo(f"Job run created successfully. New analysis ID: {run.id}")
+
     if await_completion:
         run.await_completion()
         click.echo(f"Analysis {run.id} complete (success={run.success}).")
@@ -855,3 +857,276 @@ def jobs_run(
             ctx.exit(1)
     else:
         click.echo(f"Get its status using `onecodex analyses {run.id}`", err=True)
+
+
+JOB_TYPE_CHOICES = ["shell_script", "nextflow"]
+
+
+def _parse_dependency_specs(deps):
+    pairs = []
+    for dep in deps:
+        job_id, sep, output_dir = dep.partition("=")
+        if not sep or not job_id or not output_dir:
+            raise click.BadParameter(
+                f"Expected <job_id>=<output_dir>, got {dep!r}.",
+                param_hint="-d/--dependency",
+            )
+        pairs.append((job_id, output_dir))
+    return pairs
+
+
+def _read_arguments_schema(path):
+    if path is None:
+        return None
+    with open(path) as f:
+        return json.load(f)
+
+
+def _read_script(path):
+    if path is None:
+        return None
+    with open(path) as f:
+        return f.read()
+
+
+def _build_repository(url, tag):
+    if url is None and tag is None:
+        return None
+    if url is None:
+        raise click.BadParameter(
+            "--repository-tag requires --repository-url.",
+            param_hint="--repository-tag",
+        )
+    return {"url": url, "tag": tag}
+
+
+def _job_kwargs_from_options(
+    api,
+    name,
+    script_path,
+    image_uri,
+    job_type,
+    description,
+    cpu,
+    ram_gb,
+    storage_gb,
+    inject_bearer_token,
+    repository_url,
+    repository_tag,
+    assets,
+    dependencies,
+    arguments_schema_path,
+    autorun_on_org_sample_upload=None,
+):
+    asset_objs = [api.Assets.get(aid) for aid in assets] if assets else None
+    dep_objs = (
+        [
+            {"job": api.Jobs.get(jid), "output_dir": out}
+            for jid, out in _parse_dependency_specs(dependencies)
+        ]
+        if dependencies
+        else None
+    )
+    payload = {
+        "name": name,
+        "script": _read_script(script_path),
+        "image_uri": image_uri,
+        "job_type": job_type,
+        "description": description,
+        "cpu": cpu,
+        "ram_gb": ram_gb,
+        "storage_gb": storage_gb,
+        "inject_bearer_token": inject_bearer_token,
+        "repository": _build_repository(repository_url, repository_tag),
+        "assets": asset_objs,
+        "dependencies": dep_objs,
+        "arguments_schema": _read_arguments_schema(arguments_schema_path),
+        "autorun_on_org_sample_upload": autorun_on_org_sample_upload,
+    }
+    return {k: v for k, v in payload.items() if v is not None}
+
+
+_JOB_OPTIONS_COMMON = [
+    click.option("--image-uri", default=None, help="Fully qualified OCI image URI."),
+    click.option(
+        "--job-type",
+        type=click.Choice(JOB_TYPE_CHOICES),
+        default=None,
+        help="Type of job (shell_script or nextflow).",
+    ),
+    click.option("--description", default=None, help="Human-readable description (markdown)."),
+    click.option("--cpu", type=float, default=None, help="CPU cores (shell_script jobs)."),
+    click.option("--ram-gb", type=float, default=None, help="RAM in GB (shell_script jobs)."),
+    click.option(
+        "--storage-gb", type=float, default=None, help="Storage in GB (shell_script jobs)."
+    ),
+    click.option(
+        "--inject-bearer-token/--no-inject-bearer-token",
+        "inject_bearer_token",
+        default=None,
+        help="Inject the user's bearer token into the job environment.",
+    ),
+    click.option("--repository-url", default=None, help="HTTPS URL of the git repository."),
+    click.option("--repository-tag", default=None, help="Git tag for the repository."),
+    click.option(
+        "--asset-id",
+        "assets",
+        multiple=True,
+        metavar="ASSET_ID",
+        help="Asset to associate with the job (repeatable).",
+    ),
+    click.option(
+        "--dependency",
+        "-d",
+        "dependencies",
+        multiple=True,
+        metavar="JOB_ID=OUTPUT_DIR",
+        help="Job dependency, e.g. -d <job_id>=<output_dir>. Repeatable.",
+    ),
+    click.option(
+        "--arguments-schema",
+        "arguments_schema_path",
+        type=click.Path(exists=True, dir_okay=False),
+        default=None,
+        help="Path to a JSON file containing the arguments schema (list of FieldGroup).",
+    ),
+]
+
+
+def _apply_options(options):
+    def decorator(func):
+        for option in reversed(options):
+            func = option(func)
+        return func
+
+    return decorator
+
+
+@jobs_group.command("create")
+@click.option("--name", required=True, help="Human-readable name of the job.")
+@click.option(
+    "--script",
+    "script_path",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="Path to the script file to be executed.",
+)
+@_apply_options(_JOB_OPTIONS_COMMON)
+@click.pass_context
+@pretty_errors
+@telemetry
+@login_required
+def jobs_create(
+    ctx,
+    name,
+    script_path,
+    image_uri,
+    job_type,
+    description,
+    cpu,
+    ram_gb,
+    storage_gb,
+    inject_bearer_token,
+    repository_url,
+    repository_tag,
+    assets,
+    dependencies,
+    arguments_schema_path,
+):
+    """Create a new Job."""
+    if image_uri is None:
+        raise click.BadParameter("--image-uri is required.", param_hint="--image-uri")
+
+    kwargs = _job_kwargs_from_options(
+        api=ctx.obj["API"],
+        name=name,
+        script_path=script_path,
+        image_uri=image_uri,
+        job_type=job_type,
+        description=description,
+        cpu=cpu,
+        ram_gb=ram_gb,
+        storage_gb=storage_gb,
+        inject_bearer_token=inject_bearer_token,
+        repository_url=repository_url,
+        repository_tag=repository_tag,
+        assets=assets,
+        dependencies=dependencies,
+        arguments_schema_path=arguments_schema_path,
+    )
+    job = ctx.obj["API"].Jobs.create(**kwargs)
+    click.echo(f"Created job {job.id}: {job.name}")
+
+
+@jobs_group.command("update")
+@click.argument("job_id", nargs=1, required=True)
+@click.option("--name", default=None, help="Human-readable name of the job.")
+@click.option(
+    "--script",
+    "script_path",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help="Path to the script file to be executed.",
+)
+@_apply_options(_JOB_OPTIONS_COMMON)
+@click.option(
+    "--autorun-on-org-sample-upload/--no-autorun-on-org-sample-upload",
+    "autorun_on_org_sample_upload",
+    default=None,
+    help="Auto-run this job on every newly uploaded org sample (admins only).",
+)
+@click.pass_context
+@pretty_errors
+@telemetry
+@login_required
+def jobs_update(
+    ctx,
+    job_id,
+    name,
+    script_path,
+    image_uri,
+    job_type,
+    description,
+    cpu,
+    ram_gb,
+    storage_gb,
+    inject_bearer_token,
+    repository_url,
+    repository_tag,
+    assets,
+    dependencies,
+    arguments_schema_path,
+    autorun_on_org_sample_upload,
+):
+    """Update an existing Job."""
+    if job_type is not None:
+        # The server-side UpdateJobSchema does not accept job_type.
+        raise click.BadParameter(
+            "--job-type cannot be changed after job creation.", param_hint="--job-type"
+        )
+
+    kwargs = _job_kwargs_from_options(
+        api=ctx.obj["API"],
+        name=name,
+        script_path=script_path,
+        image_uri=image_uri,
+        job_type=None,
+        description=description,
+        cpu=cpu,
+        ram_gb=ram_gb,
+        storage_gb=storage_gb,
+        inject_bearer_token=inject_bearer_token,
+        repository_url=repository_url,
+        repository_tag=repository_tag,
+        assets=assets,
+        dependencies=dependencies,
+        arguments_schema_path=arguments_schema_path,
+        autorun_on_org_sample_upload=autorun_on_org_sample_upload,
+    )
+
+    if not kwargs:
+        raise click.UsageError("No fields provided to update.")
+
+    job = ctx.obj["API"].Jobs.get(job_id)
+    job.update(**kwargs)
+    click.echo(f"Updated job {job.id}: {job.name}")

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -862,8 +862,8 @@ def jobs_run(
 JOB_TYPE_CHOICES = ["shell_script", "nextflow"]
 
 
-def _parse_dependency_specs(deps):
-    pairs = []
+def _parse_dependency_specs(deps: tuple[str, ...]) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
     for dep in deps:
         job_id, sep, output_dir = dep.partition("=")
         if not sep or not job_id or not output_dir:
@@ -875,21 +875,7 @@ def _parse_dependency_specs(deps):
     return pairs
 
 
-def _read_arguments_schema(path):
-    if path is None:
-        return None
-    with open(path) as f:
-        return json.load(f)
-
-
-def _read_script(path):
-    if path is None:
-        return None
-    with open(path) as f:
-        return f.read()
-
-
-def _build_repository(url, tag):
+def _build_repository(url: str | None, tag: str | None) -> dict[str, str | None] | None:
     if url is None and tag is None:
         return None
     if url is None:
@@ -927,9 +913,11 @@ def _job_kwargs_from_options(
         if dependencies
         else None
     )
+    script = open(script_path).read() if script_path else None
+    arguments_schema = json.load(open(arguments_schema_path)) if arguments_schema_path else None
     payload = {
         "name": name,
-        "script": _read_script(script_path),
+        "script": script,
         "image_uri": image_uri,
         "job_type": job_type,
         "description": description,
@@ -940,7 +928,7 @@ def _job_kwargs_from_options(
         "repository": _build_repository(repository_url, repository_tag),
         "assets": asset_objs,
         "dependencies": dep_objs,
-        "arguments_schema": _read_arguments_schema(arguments_schema_path),
+        "arguments_schema": arguments_schema,
         "autorun_on_org_sample_upload": autorun_on_org_sample_upload,
     }
     return {k: v for k, v in payload.items() if v is not None}
@@ -994,6 +982,12 @@ _JOB_OPTIONS_COMMON = [
 
 
 def _apply_options(options):
+    """Apply a shared list of click.option() decorators to a command.
+
+    Reverses the list so help-text order matches the list's declaration order
+    (Click stacks decorators bottom-up).
+    """
+
     def decorator(func):
         for option in reversed(options):
             func = option(func)

--- a/onecodex/models/base.py
+++ b/onecodex/models/base.py
@@ -40,11 +40,16 @@ class ApiRef(PydanticBaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_ref(cls, data):
+        # Accept a URIModel-bearing model instance (anything with a field_uri attribute).
+        field_uri = getattr(data, "field_uri", None)
+        if isinstance(field_uri, str):
+            return {"$ref": field_uri}
         # Special case wherein we autoconvert another model to a $ref and ignore the other fields
-        if "$uri" in data and "$ref" not in data:
-            return {"$ref": data["$uri"]}
-        if "field_uri" in data and "$ref" not in data:
-            return {"$ref": data["field_uri"]}
+        if isinstance(data, dict):
+            if "$uri" in data and "$ref" not in data:
+                return {"$ref": data["$uri"]}
+            if "field_uri" in data and "$ref" not in data:
+                return {"$ref": data["field_uri"]}
         return data
 
     def __init__(self, **data):
@@ -404,7 +409,14 @@ class OneCodexBase(PydanticBaseModel, metaclass=_DirMeta):
     def create(cls, **kwargs):
         if "create" not in cls._allowed_methods:
             raise MethodNotSupported(f"Cannot create {cls.__name__} objects")
-        resp = cls._client.post(f"{cls._api._base_url}{cls._resource_path}", json=kwargs)
+        create_model = cls._allowed_methods["create"]
+        if create_model is not None:
+            payload = create_model.model_validate(kwargs).model_dump(
+                exclude_unset=True, by_alias=True
+            )
+        else:
+            payload = kwargs
+        resp = cls._client.post(f"{cls._api._base_url}{cls._resource_path}", json=payload)
         return cls.model_validate(resp.json())
 
     def update(self, **kwargs):

--- a/onecodex/models/base.py
+++ b/onecodex/models/base.py
@@ -428,6 +428,10 @@ class OneCodexBase(PydanticBaseModel, metaclass=_DirMeta):
         else:
             payload = kwargs
         resp = cls._client.post(f"{cls._api._base_url}{cls._resource_path}", json=payload)
+        if not resp.ok:
+            raise OneCodexException(
+                resp.json().get("message", f"Unknown error creating {cls.__name__}")
+            )
         return cls.model_validate(resp.json())
 
     def update(self, **kwargs):
@@ -454,7 +458,7 @@ class OneCodexBase(PydanticBaseModel, metaclass=_DirMeta):
             json=patch_set.model_dump(exclude_unset=True, by_alias=True),
         )
         # TODO: Nicely format Pydantic error messages here
-        if resp.status_code >= 400:
+        if not resp.ok:
             raise OneCodexException(resp.json().get("message", f"Unknown error updating {self}"))
 
         # Finally, we update the model in-place with the validated server-side response.

--- a/onecodex/models/base.py
+++ b/onecodex/models/base.py
@@ -39,12 +39,23 @@ class ApiRef(PydanticBaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_ref(cls, data):
+    def validate_ref(
+        cls, data: dict[str, str] | PydanticBaseModel
+    ) -> dict[str, str] | PydanticBaseModel:
+        """Coerce common shapes into the canonical `{"$ref": "..."}` form.
+
+        Accepts:
+        - A `URIModel` instance (or anything else with a `field_uri: str` attribute) —
+          lets callers pass fetched objects directly, e.g. `assets=[ocx.Assets.get(id)]`.
+        - A dict carrying `$uri` or `field_uri` instead of `$ref` — covers raw API
+          payloads where a resource is embedded inline rather than referenced.
+        - Any other input is passed through unchanged so normal `$ref` dicts and
+          existing `ApiRef` instances validate as-is.
+        """
         # Accept a URIModel-bearing model instance (anything with a field_uri attribute).
         field_uri = getattr(data, "field_uri", None)
         if isinstance(field_uri, str):
             return {"$ref": field_uri}
-        # Special case wherein we autoconvert another model to a $ref and ignore the other fields
         if isinstance(data, dict):
             if "$uri" in data and "$ref" not in data:
                 return {"$ref": data["$uri"]}

--- a/onecodex/models/misc.py
+++ b/onecodex/models/misc.py
@@ -14,6 +14,8 @@ from onecodex.models.schemas.misc import (
     UserSchema,
     ProjectSchema,
     JobSchema,
+    JobCreateSchema,
+    JobUpdateSchema,
     DocumentSchema,
     AssetSchema,
     AssetUpdateSchema,
@@ -74,6 +76,10 @@ class Projects(OneCodexBase, ProjectSchema):
 
 class Jobs(OneCodexBase, JobSchema):
     _resource_path = "/api/v1/jobs"
+    _allowed_methods = {
+        "create": JobCreateSchema,
+        "update": JobUpdateSchema,
+    }
 
     def run(
         self,

--- a/onecodex/models/schemas/misc.py
+++ b/onecodex/models/schemas/misc.py
@@ -42,7 +42,38 @@ class ProjectSchema(URIModel):
     public: bool = False
 
 
-class JobSchema(URIModel):
+class RepositorySchema(BaseModel):
+    url: str = Field(description="The URL of the git repository (https only).")
+    tag: Optional[str] = Field(default=None, description="The git tag to use for this repository.")
+
+
+class JobDependencyRef(BaseModel):
+    job: ApiRef
+    output_dir: str
+
+
+class _JobMutableFields(BaseModel):
+    """Fields that may be set when creating or updating a Job.
+
+    Optional here so the type is shared between Create/Update/read schemas;
+    subclasses tighten required fields as appropriate.
+    """
+
+    name: Optional[str] = None
+    script: Optional[str] = None
+    image_uri: Optional[str] = None
+    description: Optional[str] = None
+    cpu: Optional[float] = None
+    ram_gb: Optional[float] = None
+    storage_gb: Optional[float] = None
+    inject_bearer_token: Optional[bool] = None
+    repository: Optional[RepositorySchema] = None
+    assets: Optional[list[ApiRef]] = None
+    dependencies: Optional[list[JobDependencyRef]] = None
+    arguments_schema: Optional[list[dict[str, Any]]] = None
+
+
+class JobSchema(URIModel, _JobMutableFields):
     created_at: RFC3339Datetime
     name: str = Field(
         description="The name of the job (this is displayed in the dropdown on the analysis page of the One Codex web application)."
@@ -57,6 +88,7 @@ class JobSchema(URIModel):
     public: bool = Field(
         description="Whether the job is publicly available. For most jobs this will be `true`. Custom, private jobs are also available, and will only be visible to users whose samples (or samples shared with them) have been analyzed using that job."
     )
+    job_type: Optional[str] = None
 
 
 class DocumentSchema(URIModel):
@@ -88,6 +120,21 @@ class CostSchema(BaseModel):
 
 class AssetUpdateSchema(BaseModel):
     name: str
+
+
+class JobCreateSchema(_JobMutableFields):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    script: str
+    image_uri: str
+    job_type: Optional[str] = None
+
+
+class JobUpdateSchema(_JobMutableFields):
+    model_config = ConfigDict(extra="forbid")
+
+    autorun_on_org_sample_upload: Optional[bool] = None
 
 
 class AssetSchema(URIModel):

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -735,6 +735,132 @@ def test_jobs_run_http_error(ocx, api_data, custom_mock_requests):
             job.run(sample, {})
 
 
+def test_jobs_create(ocx, api_data, custom_mock_requests):
+    new_job_id = "0123456789abcdef"
+    captured = {}
+
+    def create_callback(request):
+        captured["url"] = request.url
+        captured["body"] = json.loads(request.body)
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "$uri": f"/api/v1/jobs/{new_job_id}",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "name": "my-custom-job",
+                    "analysis_type": "custom",
+                    "public": False,
+                    "job_args_schema": {},
+                    "script": "echo hi",
+                    "image_uri": "docker.io/library/python:3.12",
+                    "job_type": "shell_script",
+                    "cpu": 1.0,
+                    "ram_gb": 1.0,
+                    "storage_gb": 1.0,
+                }
+            ),
+        )
+
+    parent_job = ocx.Jobs.get("cc1d331e1ee54bac")
+    asset = ocx.Assets.get("057268a2ba9f6d7a")
+
+    with custom_mock_requests({"POST::api/v1/jobs": create_callback}):
+        job = ocx.Jobs.create(
+            name="my-custom-job",
+            script="echo hi",
+            image_uri="docker.io/library/python:3.12",
+            job_type="shell_script",
+            description="A demo job",
+            cpu=1,
+            ram_gb=1,
+            storage_gb=1,
+            inject_bearer_token=True,
+            repository={"url": "https://github.com/example/repo", "tag": "v1.0.0"},
+            assets=[asset],
+            dependencies=[{"job": parent_job, "output_dir": "parent_out"}],
+            arguments_schema=[
+                {
+                    "fields": [
+                        {"name": "min_quality", "type": "integer", "default": 20},
+                        {"name": "adapter", "type": "string"},
+                    ],
+                },
+            ],
+        )
+
+    assert captured["url"].endswith("/api/v1/jobs")
+    assert captured["body"] == {
+        "name": "my-custom-job",
+        "script": "echo hi",
+        "image_uri": "docker.io/library/python:3.12",
+        "job_type": "shell_script",
+        "description": "A demo job",
+        "cpu": 1,
+        "ram_gb": 1,
+        "storage_gb": 1,
+        "inject_bearer_token": True,
+        "repository": {"url": "https://github.com/example/repo", "tag": "v1.0.0"},
+        "assets": [{"$ref": "/api/v1/assets/057268a2ba9f6d7a"}],
+        "dependencies": [
+            {
+                "job": {"$ref": "/api/v1/jobs/cc1d331e1ee54bac"},
+                "output_dir": "parent_out",
+            },
+        ],
+        "arguments_schema": [
+            {
+                "fields": [
+                    {"name": "min_quality", "type": "integer", "default": 20},
+                    {"name": "adapter", "type": "string"},
+                ],
+            },
+        ],
+    }
+    assert job.id == new_job_id
+    assert job.name == "my-custom-job"
+    assert job.script == "echo hi"
+    assert job.cpu == 1.0
+
+
+def test_jobs_update(ocx, api_data, custom_mock_requests):
+    job_id = "cc1d331e1ee54bac"
+    captured = {}
+
+    def patch_callback(request):
+        captured["url"] = request.url
+        captured["body"] = json.loads(request.body)
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "$uri": f"/api/v1/jobs/{job_id}",
+                    "created_at": "2016-05-05T17:27:02.116480+00:00",
+                    "name": "Renamed Job",
+                    "analysis_type": "classification",
+                    "public": True,
+                    "job_args_schema": {},
+                }
+            ),
+        )
+
+    with custom_mock_requests({f"PATCH::api/v1/jobs/{job_id}": patch_callback}):
+        job = ocx.Jobs.get(job_id)
+        job.update(name="Renamed Job")
+
+    assert captured["url"].endswith(f"/api/v1/jobs/{job_id}")
+    assert captured["body"] == {"name": "Renamed Job"}
+    assert job.name == "Renamed Job"
+
+
+def test_jobs_update_rejects_unknown_field(ocx, api_data):
+    job = ocx.Jobs.get("cc1d331e1ee54bac")
+    with pytest.raises(MethodNotSupported):
+        job.update(analysis_type="something_else")
+
+
 def test_analyses_refresh(ocx, custom_mock_requests):
     analysis_id = "593601a797914cbf"
     base_payload = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -234,6 +234,125 @@ def test_workflow_instances(runner, api_data, mocked_creds_file):
     assert result.exit_code == 0
 
 
+# Jobs create/update
+def test_jobs_create_cli(runner, api_data, custom_mock_requests, mocked_creds_file, tmp_path):
+    new_job_id = "0123456789abcdef"
+    captured = {}
+
+    def create_callback(request):
+        captured["body"] = json.loads(request.body)
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "$uri": f"/api/v1/jobs/{new_job_id}",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "name": "my-job",
+                    "analysis_type": "custom",
+                    "public": False,
+                    "job_args_schema": {},
+                }
+            ),
+        )
+
+    script = tmp_path / "run.sh"
+    script.write_text("echo hello\n")
+    schema = tmp_path / "schema.json"
+    schema.write_text(json.dumps([{"fields": [{"name": "min_quality", "type": "integer"}]}]))
+
+    asset_id = "057268a2ba9f6d7a"
+    parent_job_id = "cc1d331e1ee54bac"
+
+    with custom_mock_requests({"POST::api/v1/jobs": create_callback}):
+        result = runner.invoke(
+            Cli,
+            [
+                "jobs",
+                "create",
+                *("--name", "my-job"),
+                *("--script", str(script)),
+                *("--image-uri", "docker.io/library/python:3.12"),
+                *("--cpu", "1"),
+                *("--ram-gb", "1"),
+                *("--storage-gb", "1"),
+                *("--asset-id", asset_id),
+                *("-d", f"{parent_job_id}=outdir"),
+                *("--arguments-schema", str(schema)),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert f"Created job {new_job_id}" in result.output
+    assert captured["body"] == {
+        "name": "my-job",
+        "script": "echo hello\n",
+        "image_uri": "docker.io/library/python:3.12",
+        "cpu": 1.0,
+        "ram_gb": 1.0,
+        "storage_gb": 1.0,
+        "assets": [{"$ref": f"/api/v1/assets/{asset_id}"}],
+        "dependencies": [
+            {"job": {"$ref": f"/api/v1/jobs/{parent_job_id}"}, "output_dir": "outdir"}
+        ],
+        "arguments_schema": [{"fields": [{"name": "min_quality", "type": "integer"}]}],
+    }
+
+
+def test_jobs_create_missing_image_uri(runner, mocked_creds_file, tmp_path):
+    script = tmp_path / "run.sh"
+    script.write_text("echo hi\n")
+    result = runner.invoke(
+        Cli,
+        ["jobs", "create", *("--name", "x"), *("--script", str(script))],
+    )
+    assert result.exit_code != 0
+    assert "image-uri" in result.output
+
+
+def test_jobs_update_cli(runner, api_data, custom_mock_requests, mocked_creds_file):
+    job_id = "cc1d331e1ee54bac"
+    captured = {}
+
+    def patch_callback(request):
+        captured["body"] = json.loads(request.body)
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "$uri": f"/api/v1/jobs/{job_id}",
+                    "created_at": "2016-05-05T17:27:02.116480+00:00",
+                    "name": "Renamed",
+                    "analysis_type": "classification",
+                    "public": True,
+                    "job_args_schema": {},
+                }
+            ),
+        )
+
+    with custom_mock_requests({f"PATCH::api/v1/jobs/{job_id}": patch_callback}):
+        result = runner.invoke(Cli, ["jobs", "update", job_id, *("--name", "Renamed")])
+
+    assert result.exit_code == 0, result.output
+    assert captured["body"] == {"name": "Renamed"}
+    assert f"Updated job {job_id}" in result.output
+
+
+def test_jobs_update_no_fields(runner, api_data, mocked_creds_file):
+    job_id = "cc1d331e1ee54bac"
+    result = runner.invoke(Cli, ["jobs", "update", job_id])
+    assert result.exit_code != 0
+    assert "No fields provided" in result.output
+
+
+def test_jobs_update_rejects_job_type(runner, api_data, mocked_creds_file):
+    job_id = "cc1d331e1ee54bac"
+    result = runner.invoke(Cli, ["jobs", "update", job_id, *("--job-type", "shell_script")])
+    assert result.exit_code != 0
+    assert "job-type" in result.output
+
+
 # Samples
 def test_samples(runner, api_data, mocked_creds_file):
     r0 = runner.invoke(Cli, ["samples"])


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

- Add methods for creating and updating the `Jobs` model
- Add `onecodex jobs create,update` CLI commands. For now, `arguments_schema` is provided as a JSON file.

## Related PRs

- [x] This PR is independent

## TODOs

- [x] Tests
- [x] Documentation
