### PR TITLE
Add logs to Analyses model and CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `onecodex analyses await <analysis_id>` CLI command, with `--timeout`,
   `--initial-interval`, and `--max-interval` options. Also available as
   `onecodex await <analysis_id>` for backward compatibility.
+- `Analyses.logs()` fetches the job run logs for an analysis, with an optional
+  `tail` parameter to limit the output to the last N lines.
+- `onecodex analyses logs <analysis_id>` CLI command, with `--tail` to limit
+  the number of log lines returned (defaults to 1000). Only available for
+  custom workflow runs.
 
 ## [v1.0.2] - 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ The top-level `onecodex await <analysis_id>` is kept as an alias for backward co
 
 The command exits non-zero if the analysis finishes unsuccessfully or times out.
 
+### Fetching analysis logs
+
+To view the job run logs for a custom workflow analysis, use `analyses logs`:
+
+```shell
+onecodex analyses logs 0123456789abcdef
+onecodex analyses logs 0123456789abcdef --tail 200
+```
+
+`--tail` defaults to the last 1000 lines. Logs are only available for custom
+workflow runs.
+
 # Using the Python client library
 
 ## Initialization
@@ -217,6 +229,14 @@ For long-running analyses, `await_completion()` polls until the analysis reaches
 analysis = ocx.Analyses.get("0123456789abcdef")
 analysis.await_completion()                # block indefinitely
 analysis.await_completion(timeout=600)     # raise TimeoutError after 10 minutes
+```
+
+For custom workflow runs, `.logs()` returns the job run logs as a string:
+
+```python
+analysis = ocx.Analyses.get("0123456789abcdef")
+print(analysis.logs())                     # full log
+print(analysis.logs(tail=200))             # last 200 lines
 ```
 
 The method refreshes `analysis` in place and returns it; check `analysis.success` to see whether it finished cleanly. `analysis.refresh()` is also available if you just need to re-fetch the current state without blocking.

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -424,6 +424,31 @@ onecodex.add_command(analyses_await, "await")
 analyses.add_command(analyses_await, "await")
 
 
+@click.command("logs")
+@click.argument("analysis_id", nargs=1, required=True)
+@click.option(
+    "--tail",
+    "tail",
+    type=click.IntRange(min=1),
+    default=1000,
+    show_default=True,
+    help="Fetch only the last N log lines.",
+)
+@click.pass_context
+@pretty_errors
+@telemetry
+@login_required
+def analyses_logs(ctx, analysis_id, tail):
+    """Fetch the job run logs for an analysis."""
+    analysis = ctx.obj["API"].Analyses.get(analysis_id)
+    if not analysis:
+        raise click.ClickException(f"Could not find analysis {analysis_id} (404 status code)")
+    click.echo(analysis.logs(tail=tail), nl=False)
+
+
+analyses.add_command(analyses_logs, "logs")
+
+
 @onecodex.command("classifications")
 @click.option("--read-level", "readlevel", is_flag=True, help=OPTION_HELP["readlevel"])
 @click.option(

--- a/onecodex/models/analysis.py
+++ b/onecodex/models/analysis.py
@@ -132,6 +132,34 @@ class _AnalysesBase(OneCodexBase):
 
         return self
 
+    def logs(self, tail: Optional[int] = None) -> str:
+        """Fetch the job run logs for this analysis.
+
+        Parameters
+        ----------
+        tail : int, optional
+            If set, return only the last ``tail`` lines of the logs. Must be >= 1.
+
+        Returns
+        -------
+        str
+            The job run logs as a plain-text string. Empty if the analysis has not
+            produced any logs.
+        """
+        params = {}
+        if tail is not None:
+            if tail < 1:
+                raise ValueError("tail must be >= 1.")
+            params["tail"] = tail
+        resp = self._client.get(f"{self._api._base_url}{self.field_uri}/logs", params=params)
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                raise OneCodexException(f"Logs not found for analysis {self.id}.")
+            raise
+        return resp.text
+
     def results(self, json: bool = True):
         """Fetch the results of an Analyses resource.
 

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -884,6 +884,64 @@ def test_analyses_await_completion_timeout(ocx, custom_mock_requests):
                     analysis.await_completion(timeout=10.0, initial_interval=5, backoff=1.0)
 
 
+def test_analyses_logs(ocx, api_data, custom_mock_requests):
+    analysis_id = "593601a797914cbf"
+    captured = {}
+
+    def logs_callback(request):
+        captured["url"] = request.url
+        return (200, {"Content-Type": "text/plain"}, "line 1\nline 2\nline 3\n")
+
+    with custom_mock_requests(
+        {f"GET:text/plain:api/v1/analyses/{analysis_id}/logs": logs_callback}
+    ):
+        analysis = ocx.Analyses.get(analysis_id)
+        out = analysis.logs()
+
+    assert out == "line 1\nline 2\nline 3\n"
+    assert "tail" not in captured["url"]
+
+
+def test_analyses_logs_tail(ocx, api_data, custom_mock_requests):
+    analysis_id = "593601a797914cbf"
+    captured = {}
+
+    def logs_callback(request):
+        captured["url"] = request.url
+        return (200, {"Content-Type": "text/plain"}, "line 2\nline 3\n")
+
+    with custom_mock_requests(
+        {f"GET:text/plain:api/v1/analyses/{analysis_id}/logs": logs_callback}
+    ):
+        analysis = ocx.Analyses.get(analysis_id)
+        out = analysis.logs(tail=2)
+
+    assert out == "line 2\nline 3\n"
+    assert "tail=2" in captured["url"]
+
+
+def test_analyses_logs_tail_invalid(ocx, api_data):
+    analysis = ocx.Analyses.get("593601a797914cbf")
+    with pytest.raises(ValueError, match="tail must be >= 1"):
+        analysis.logs(tail=0)
+
+
+def test_analyses_logs_404(ocx, api_data, custom_mock_requests):
+    from onecodex.exceptions import OneCodexException
+
+    analysis_id = "593601a797914cbf"
+
+    def logs_callback(request):
+        return (404, {"Content-Type": "text/plain"}, "Not Found")
+
+    with custom_mock_requests(
+        {f"GET:text/plain:api/v1/analyses/{analysis_id}/logs": logs_callback}
+    ):
+        analysis = ocx.Analyses.get(analysis_id)
+        with pytest.raises(OneCodexException, match="Logs not found"):
+            analysis.logs()
+
+
 def test_sample_preupload(ocx, upload_mocks, api_data):
     projects = ocx.Projects.where(project_name="One Codex Project")
     sample_id = ocx.Samples.preupload(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,6 +98,82 @@ def test_analyses_await(runner, custom_mock_requests, mocked_creds_file, monkeyp
     assert "success=True" in result.output
 
 
+def test_analyses_logs(runner, custom_mock_requests, mocked_creds_file):
+    analysis_id = "593601a797914cbf"
+    base_payload = {
+        "$uri": f"/api/v1/analyses/{analysis_id}",
+        "analysis_type": "classification",
+        "created_at": "2015-09-25T17:27:30.622286-07:00",
+        "complete": True,
+        "success": True,
+        "error_msg": None,
+        "job": {"$ref": "/api/v1/jobs/e4b1ab37ff554c53"},
+        "sample": {"$ref": "/api/v1/samples/7428cca4a3a04a8e"},
+        "cost": None,
+        "dependencies": [],
+        "draft": False,
+        "job_args": {},
+    }
+
+    captured = {}
+
+    def get_callback(request):
+        return (200, {"Content-Type": "application/json"}, json.dumps(base_payload))
+
+    def logs_callback(request):
+        captured["url"] = request.url
+        return (200, {"Content-Type": "text/plain"}, "log line A\nlog line B\n")
+
+    with custom_mock_requests(
+        {
+            f"GET::api/v1/analyses/{analysis_id}": get_callback,
+            f"GET:text/plain:api/v1/analyses/{analysis_id}/logs": logs_callback,
+        }
+    ):
+        result = runner.invoke(Cli, ["analyses", "logs", analysis_id, "--tail", "2"])
+
+    assert result.exit_code == 0, result.output
+    assert "log line A" in result.output
+    assert "log line B" in result.output
+    assert "tail=2" in captured["url"]
+
+
+def test_analyses_logs_404(runner, custom_mock_requests, mocked_creds_file):
+    analysis_id = "593601a797914cbf"
+    base_payload = {
+        "$uri": f"/api/v1/analyses/{analysis_id}",
+        "analysis_type": "classification",
+        "created_at": "2015-09-25T17:27:30.622286-07:00",
+        "complete": True,
+        "success": True,
+        "error_msg": None,
+        "job": {"$ref": "/api/v1/jobs/e4b1ab37ff554c53"},
+        "sample": {"$ref": "/api/v1/samples/7428cca4a3a04a8e"},
+        "cost": None,
+        "dependencies": [],
+        "draft": False,
+        "job_args": {},
+    }
+
+    def get_callback(request):
+        return (200, {"Content-Type": "application/json"}, json.dumps(base_payload))
+
+    def logs_callback(request):
+        return (404, {"Content-Type": "text/plain"}, "Not Found")
+
+    with custom_mock_requests(
+        {
+            f"GET::api/v1/analyses/{analysis_id}": get_callback,
+            f"GET:text/plain:api/v1/analyses/{analysis_id}/logs": logs_callback,
+        }
+    ):
+        result = runner.invoke(Cli, ["analyses", "logs", analysis_id])
+
+    assert result.exit_code != 0
+    assert "Logs not found" in result.output
+    assert "Traceback" not in result.output
+
+
 # Classifications
 def test_classification_instance(runner, api_data, mocked_creds_file):
     result = runner.invoke(Cli, ["classifications", "593601a797914cbf"])


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

Add the ability to fetch logs for custom workflow runs (analyses):

```bash
onecodex analyses logs --tail 100 <analysis id>
```

```python
print(ocx.Analyses.get("...").logs(tail=100))
```

## Related PRs

- [x] This PR is independent

## TODOs

- [x] Tests
- [x] Documentation
