### PR TITLE
Add `--sample` to `onecodex download samples`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `dependencies=[{"job": parent_job, "output_dir": "..."}]` accepts `Jobs`
   instances directly.
 - `onecodex jobs create` and `onecodex jobs update <job_id>` CLI commands.
-- `onecodex download samples` accepts `-s/--sample-id` (repeatable) to download
+- `onecodex download samples` accepts `-s/--sample` (repeatable) to download
   specific samples by ID. Mutually exclusive with `--project` and `--tags`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `dependencies=[{"job": parent_job, "output_dir": "..."}]` accepts `Jobs`
   instances directly.
 - `onecodex jobs create` and `onecodex jobs update <job_id>` CLI commands.
+- `onecodex download samples` accepts `-s/--sample-id` (repeatable) to download
+  specific samples by ID. Mutually exclusive with `--project` and `--tags`.
 
 ### Changed
 

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -557,7 +557,7 @@ def download_group():
 )
 @click.option(
     "-s",
-    "--sample-id",
+    "--sample",
     "sample_ids",
     multiple=True,
     help="Download a specific sample by its ID. Can be passed multiple times. Mutually "

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -556,6 +556,14 @@ def download_group():
     "-t", "--tags", multiple=True, help="Filter to samples that include *any* of these tag names."
 )
 @click.option(
+    "-s",
+    "--sample-id",
+    "sample_ids",
+    multiple=True,
+    help="Download a specific sample by its ID. Can be passed multiple times. Mutually "
+    "exclusive with --project and --tags.",
+)
+@click.option(
     "--prompt/--no-prompt",
     is_flag=True,
     default=True,
@@ -566,22 +574,26 @@ def download_group():
 @pretty_errors
 @telemetry
 @login_required
-def download_samples_command(ctx, outdir, project, tags, prompt):
+def download_samples_command(ctx, outdir, project, tags, sample_ids, prompt):
     """Download FASTA/Q files from One Codex.
 
-    Samples may optionally be filtered by project and/or tags. By default, all samples in your
-    account will be downloaded.
+    Samples may optionally be filtered by project and/or tags, or selected directly by ID with
+    --sample-id. By default, all samples in your account will be downloaded.
 
     OUTDIR is the name of the output directory where downloaded files will be saved.
 
     """
     from onecodex.lib.download import download_samples
 
+    if sample_ids and (project or tags):
+        raise click.UsageError("--sample-id cannot be combined with --project or --tags.")
+
     download_samples(
         ctx.obj["API"],
         outdir,
         project_name_or_id=project,
         tag_names=tags,
+        sample_ids=sample_ids or None,
         prompt=prompt,
         progressbar=True,
     )

--- a/onecodex/lib/download.py
+++ b/onecodex/lib/download.py
@@ -58,7 +58,7 @@ def download_samples(
     if sample_ids:
         samples = []
         for sample_id in sample_ids:
-            log.info("Fetching sample '{}'...".format(sample_id))
+            log.info(f"Fetching sample '{sample_id}")
             sample = ocx.Samples.get(sample_id)
             if sample is None:
                 warnings.warn("No sample found with ID '{}'.".format(sample_id))

--- a/onecodex/lib/download.py
+++ b/onecodex/lib/download.py
@@ -50,11 +50,21 @@ def download_samples(
     outdir,
     project_name_or_id=None,
     tag_names=None,
+    sample_ids=None,
     prompt=False,
     min_samples_for_prompt=50,
     progressbar=False,
 ):
-    if project_name_or_id:
+    if sample_ids:
+        samples = []
+        for sample_id in sample_ids:
+            log.info("Fetching sample '{}'...".format(sample_id))
+            sample = ocx.Samples.get(sample_id)
+            if sample is None:
+                warnings.warn("No sample found with ID '{}'.".format(sample_id))
+                continue
+            samples.append(sample)
+    elif project_name_or_id:
         log.info("Fetching samples in project '{}'...".format(project_name_or_id))
         project = get_project(ocx, project_name_or_id)
         samples = ocx.Samples.where(project=project)


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

Adds `--sample-id` flag to `onecodex download samples`. The flag can be repeated to fetch more than one sample by ID. Cannot be used with `--project` or `--tags` (it does not make sense to filter by project and/or tags when specifying exact sample ID(s)).

## Related PRs

- [x] This PR is independent


## TODOs

- [x] Documentation