### PR TITLE
Add `--args-json` to `onecodex jobs run ...`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `onecodex jobs create` and `onecodex jobs update <job_id>` CLI commands.
 - `onecodex download samples` accepts `-s/--sample` (repeatable) to download
   specific samples by ID. Mutually exclusive with `--project` and `--tags`.
+- `onecodex jobs run` accepts `--args-json` to pass runtime arguments as a JSON
+  object, preserving non-string types (integers, floats, booleans, arrays,
+  objects). `-a/--arg` only supports string values; use `--args-json` when a job
+  argument expects another type. Mutually exclusive with `-a/--arg`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,19 @@ onecodex analyses await <analysis_id>
 onecodex jobs run <job_id> <sample_id> --arg min_quality=30 --await
 ```
 
+`-a/--arg` only supports string values — every `key=value` is sent to the server as a
+string. If a job argument expects another type (integer, float, boolean, array, object),
+use `--args-json` to pass the full argument set as a JSON object, which preserves types:
+
+```shell
+onecodex jobs run <job_id> <sample_id> --args-json '{"min_quality": 30, "trim": true}'
+
+# To read arguments from a file, use shell substitution:
+onecodex jobs run <job_id> <sample_id> --args-json "$(cat args.json)"
+```
+
+`--args-json` is mutually exclusive with `-a/--arg`.
+
 ## Creating and updating jobs
 
 You can create and update custom jobs from the client.

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -790,6 +790,17 @@ def jobs_group():
     help="Additional runtime arguments, example: -a min_quality=1 -a adapter=AGATC.",
 )
 @click.option(
+    "--args-json",
+    "args_json",
+    default=None,
+    help=(
+        "Runtime arguments as a JSON object (preserves non-string types). "
+        'Example: --args-json \'{"min_quality": 1, "adapter": "AGATC"}\'. '
+        'To read from a file: --args-json "$(cat args.json)". '
+        "Mutually exclusive with -a/--arg."
+    ),
+)
+@click.option(
     "-d",
     "--dependency-override",
     "dependency_overrides",
@@ -820,6 +831,7 @@ def jobs_run(
     job_id,
     sample_id,
     args,
+    args_json,
     dependency_overrides,
     populate_default_arguments,
     await_completion,
@@ -827,14 +839,29 @@ def jobs_run(
     """Run a OneCodex job with optional arguments."""
     from onecodex.models.misc import DependencyOverride
 
-    parsed_args = {}
-    for arg in args:
-        if "=" not in arg:
+    if args and args_json is not None:
+        raise click.BadParameter(
+            "Cannot combine -a/--arg with --args-json.", param_hint="--args-json"
+        )
+
+    if args_json is not None:
+        try:
+            parsed_args = json.loads(args_json)
+        except json.JSONDecodeError as e:
+            raise click.BadParameter(f"Invalid JSON: {e}", param_hint="--args-json")
+        if not isinstance(parsed_args, dict):
             raise click.BadParameter(
-                f"Expected key=value format, got {arg!r}.", param_hint="-a/--arg"
+                "Expected a JSON object (e.g. '{\"key\": value}').", param_hint="--args-json"
             )
-        key, value = arg.split("=", 1)
-        parsed_args[key] = value
+    else:
+        parsed_args = {}
+        for arg in args:
+            if "=" not in arg:
+                raise click.BadParameter(
+                    f"Expected key=value format, got {arg!r}.", param_hint="-a/--arg"
+                )
+            key, value = arg.split("=", 1)
+            parsed_args[key] = value
 
     parsed_dependencies = []
     for dep in dependency_overrides:

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -787,7 +787,10 @@ def jobs_group():
     "--arg",
     "args",
     multiple=True,
-    help="Additional runtime arguments, example: -a min_quality=1 -a adapter=AGATC.",
+    help=(
+        "Additional runtime arguments, example: -a min_quality=1 -a adapter=AGATC. "
+        "Always interpreted as a string. For typed arguments, use --args-json"
+    ),
 )
 @click.option(
     "--args-json",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -339,6 +339,80 @@ def test_jobs_update_cli(runner, api_data, custom_mock_requests, mocked_creds_fi
     assert f"Updated job {job_id}" in result.output
 
 
+def _jobs_run_mock(captured, analysis_id):
+    def callback(request):
+        captured["body"] = json.loads(request.body)
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps({"$ref": f"/api/v1/analyses/{analysis_id}"}),
+        )
+
+    return callback
+
+
+def test_jobs_run_args_json(runner, api_data, custom_mock_requests, mocked_creds_file):
+    job_id = "47c4fe23588640a9"
+    sample_id = "7428cca4a3a04a8e"
+    analysis_id = "593601a797914cbf"
+    captured = {}
+
+    with custom_mock_requests(
+        {f"POST::api/v1/jobs/{job_id}/run": _jobs_run_mock(captured, analysis_id)}
+    ):
+        result = runner.invoke(
+            Cli,
+            [
+                "jobs",
+                "run",
+                job_id,
+                sample_id,
+                *("--args-json", '{"min_quality": 30, "trim": true, "adapter": "AGATC"}'),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured["body"]["job_args"] == {
+        "min_quality": 30,
+        "trim": True,
+        "adapter": "AGATC",
+    }
+
+
+def test_jobs_run_args_json_mutually_exclusive(runner, mocked_creds_file):
+    result = runner.invoke(
+        Cli,
+        [
+            "jobs",
+            "run",
+            "47c4fe23588640a9",
+            "7428cca4a3a04a8e",
+            *("-a", "x=1"),
+            *("--args-json", "{}"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Cannot combine" in result.output
+
+
+def test_jobs_run_args_json_invalid_json(runner, mocked_creds_file):
+    result = runner.invoke(
+        Cli,
+        ["jobs", "run", "47c4fe23588640a9", "7428cca4a3a04a8e", *("--args-json", "not json")],
+    )
+    assert result.exit_code != 0
+    assert "Invalid JSON" in result.output
+
+
+def test_jobs_run_args_json_not_object(runner, mocked_creds_file):
+    result = runner.invoke(
+        Cli,
+        ["jobs", "run", "47c4fe23588640a9", "7428cca4a3a04a8e", *("--args-json", "[1, 2, 3]")],
+    )
+    assert result.exit_code != 0
+    assert "JSON object" in result.output
+
+
 def test_jobs_update_no_fields(runner, api_data, mocked_creds_file):
     job_id = "cc1d331e1ee54bac"
     result = runner.invoke(Cli, ["jobs", "update", job_id])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,8 +105,12 @@ def test_init_sentry(
 ):
     if ONE_CODEX_NO_TELEMETRY:
         monkeypatch.setenv("ONE_CODEX_NO_TELEMETRY", ONE_CODEX_NO_TELEMETRY)
+    else:
+        monkeypatch.delenv("ONE_CODEX_NO_TELEMETRY", raising=False)
     if ONE_CODEX_SENTRY_DSN:
         monkeypatch.setenv("ONE_CODEX_SENTRY_DSN", ONE_CODEX_SENTRY_DSN)
+    else:
+        monkeypatch.delenv("ONE_CODEX_SENTRY_DSN", raising=False)
 
     with (
         mock.patch("onecodex.utils._setup_sentry_for_ipython") as _,


### PR DESCRIPTION
## Status

- [x] **Ready**


## Description

`onecodex jobs run --arg FOO=123` will always interpret 123 as a string due to how command-line parsing works. To make it possible to pass other types (ints, bools, lists, etc...), this PR adds the `--args-json` flag which allows passing a JSON-formatted string of arguments. This flag is mutually-exclusive with `--arg`.


Bonus: Fix Sentry tests that fail if you have `ONE_CODEX_NO_TELEMETRY` defined on your system.

## Related PRs

- [x] This PR is independent

## TODOs

- [x] tests
- [x] docs