### PR TITLE
Custom Plots: raise ConnectivityError for transient sample-load failures

### DIFF
--- a/onecodex/exceptions.py
+++ b/onecodex/exceptions.py
@@ -16,6 +16,10 @@ class ServerError(OneCodexException):
     pass
 
 
+class ConnectivityError(OneCodexException):
+    pass
+
+
 class UnboundObject(OneCodexException):
     """To use against the One Codex server, all classes must be derived from an Api() instance."""
 

--- a/onecodex/viz/_custom_plots/__init__.py
+++ b/onecodex/viz/_custom_plots/__init__.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 import orjson
 
 from onecodex.viz import configure_onecodex_theme
-from onecodex.exceptions import OneCodexException
+from onecodex.exceptions import ConnectivityError, OneCodexException
 from .collection import SampleCollection, Samples
 from .enums import PlotType, SamplesFilter, SuggestionType
 from .models import BaseParams, PlotParams, StatsParams
@@ -124,8 +124,8 @@ async def _fetch_ndjson(url: str, headers: dict | None = None) -> list[dict[str,
         return [orjson.loads(line) for line in text.splitlines() if line.strip()]
     except AttributeError:
         # Converting pyfetch exceptions to Python exceptions sometimes fails with AttributeError
-        # Raising a OneCodexException that will get handled gracefully
-        raise OneCodexException("Cannot load samples, please try again later")
+        # Raising a ConnectivityError that will get handled gracefully
+        raise ConnectivityError("Cannot load samples, please try again later")
 
 
 async def _fetch_batch_sample_results(base_url: str, data: list[dict], headers: dict | None = None):


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description
So that we can show the error message to the user instead of treating it as an unexpected error.

## Related PRs

- [x] This PR is independent