### PR TITLE
Fix plot_functional_heatmap() MergeError with multiple samples lacking functional results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `plot_functional_heatmap()` no longer raises a `MergeError` when the sample
+  collection contains more than one sample without functional profile results.
+  Samples lacking functional results are now dropped from the plot (they were
+  never plotted anyway).
+
 ## [v1.1.0] - 2026-06-18
 
 ### Added

--- a/onecodex/viz/_functional.py
+++ b/onecodex/viz/_functional.py
@@ -149,12 +149,13 @@ class VizFunctionalHeatmapMixin(BaseSampleCollection):
         }
 
         metadata["functional_profile_id"] = [
-            sample_id_to_functional_profile_id[sample_id]
-            if sample_id in sample_id_to_functional_profile_id
-            else None
-            for sample_id in metadata["sample_id"]
+            sample_id_to_functional_profile_id.get(sample_id) for sample_id in metadata["sample_id"]
         ]
 
+        # Drop samples without a functional profile. They aren't in `df` (so the
+        # left join would drop them anyway), and keeping them would put multiple
+        # null join keys in the index, breaking the one-to-one merge (DEV-11818).
+        metadata = metadata[metadata["functional_profile_id"].notna()]
         metadata = metadata.set_index("functional_profile_id")
 
         df = df.join(metadata, validate="one_to_one", how="left")

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1100,3 +1100,23 @@ def test_plot_bargraph_to_calc_total_errors_out_if_df_is_empty(samples):
 
     assert len(values) == 1
     assert values[0] == 0.0
+
+
+def test_plot_functional_heatmap_multiple_samples_without_functional_results(ocx, api_data):
+    # DEV-11818: >1 sample lacking functional results put multiple null join keys
+    # in the metadata index, breaking the one-to-one merge with the functional df.
+    sample_ids = [
+        "543c9c046e3e4e09",
+        "66c1531cb0b244f6",
+        "37e5151e7bcb4f87",
+        "7428cca4nocaffe1",  # no functional results
+        "7428cca4nocaffe2",  # no functional results
+    ]
+    samples = SampleCollection([ocx.Samples.get(x) for x in sample_ids], skip_missing=True)
+
+    with pytest.warns(UserWarning, match="Functional profile not found"):
+        chart = samples.plot_functional_heatmap(return_chart=True, top_n=3)
+
+    # Only the 3 samples with functional results are plotted (3 samples * 3 top_n).
+    assert len(chart.data.index) == 9
+    assert set(chart.data["Label"]) == {p.sample.filename for p in samples._functional_profiles}


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

Samples without a functional profile produced multiple null join keys in the metadata index, breaking the one-to-one merge. Drop them before the join (they were never plotted anyway).

Closes DEV-11818

## Related PRs

- [x] This PR is independent