### PR TITLE
Set boxplot width dynamically when width == 'container'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed the `Metric.is_filtered_readcount_metric` property to
   `Metric.is_abundance_sensitive` to better describe what it flags.
+- In `plot_metadata(width="container", ...)`, boxplot width is now dynamically adjusted based on the
+  number of boxes
 
 ### Removed
 

--- a/onecodex/viz/_metadata.py
+++ b/onecodex/viz/_metadata.py
@@ -12,6 +12,14 @@ from onecodex.viz._primitives import (
 )
 
 
+# Constants used for automatic boxplot sizing. The width automatically decreases as more boxes are added
+# Since we cannot know the true container width, we based it off of the nominal (min. supported) width
+MAX_BOXPLOT_SIZE = 45
+MIN_BOXPLOT_SIZE = 5
+BOXPLOT_SIZE_INCREMENT = 5
+NOMINAL_BOXPLOT_WIDTH = 400
+
+
 class PlotType(BaseEnum):
     Auto = "auto"
     BoxPlot = "boxplot"
@@ -269,15 +277,25 @@ class VizMetadataMixin(BaseSampleCollection):
                 raise OneCodexException("Must not specify sort_x when plot_type is boxplot")
 
             boxplot_kwargs = {"median": {"stroke": "black"}}
+
+            # when the width is set by the container, we cannot know the true container size.
+            # So in order to ensure that the boxes do not overlap, we assume a container width
+            # (NOMINAL_BOXPLOT_WIDTH) and set the individual box widths based on the number of
+            # boxes with a floor set by MIN_BOXPLOT_SIZE
             if not secondary_haxis or width == "container":
-                box_size = 45
-                increment = 5
                 n_boxes = len(df[magic_fields[haxis]].unique())
+                if secondary_haxis and secondary_haxis in df.columns:
+                    n_boxes *= len(df[secondary_haxis].unique())
+                if facet_by and facet_by in df.columns:
+                    n_boxes *= len(df[facet_by].unique())
 
-                if width and width != "container" and (n_boxes * (box_size + increment)) > width:
-                    box_size = ((width / n_boxes) // increment) * increment - increment
+                effective_width = width if isinstance(width, int) else NOMINAL_BOXPLOT_WIDTH
 
-                boxplot_kwargs["size"] = box_size
+                box_size = (
+                    effective_width // n_boxes // BOXPLOT_SIZE_INCREMENT
+                ) * BOXPLOT_SIZE_INCREMENT
+
+                boxplot_kwargs["size"] = min(MAX_BOXPLOT_SIZE, max(MIN_BOXPLOT_SIZE, box_size))
 
             chart = (
                 alt.Chart(df)


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

Dynamically adjust the boxplot width in `plot_metadata` based on the number of boxes. This prevents overlapping boxplots when the number of boxes is high and/or the screen width is small:

https://github.com/user-attachments/assets/55fab4fc-9137-42de-a060-ad0c4cd21bc6

## Related PRs

- [x] This PR is independent

## TODOs

Add any todos here as needed for work in progress code. This section can be deleted if not relevant. Examples:

- [x] Documentation
- [x] Update `CHANGELOG`
