### PR TITLE
Handle colons in Altair chart field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collection contains more than one sample without functional profile results.
   Samples lacking functional results are now dropped from the plot (they were
   never plotted anyway).
+- Plots no longer raise a `ValueError` when a metadata field name contains a colon character (`:`).
 
 ## [v1.1.0] - 2026-06-18
 

--- a/onecodex/viz/_pca.py
+++ b/onecodex/viz/_pca.py
@@ -240,12 +240,12 @@ class VizPCAMixin(BaseSampleCollection):
             )
 
         chart = chart.encode(**alt_kwargs)
+        escape_chart_fields(chart)
 
         if vector_chart:
             chart = alt.layer(chart, vector_chart).resolve_scale(color="independent")
 
         chart = chart.properties(**prepare_props(title=title, height=height, width=width))
-        escape_chart_fields(chart)
 
         if return_chart:
             return chart

--- a/onecodex/viz/_primitives.py
+++ b/onecodex/viz/_primitives.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
 import os
 from itertools import chain
 from collections.abc import Iterable
 from math import ceil
+from typing import TYPE_CHECKING
 
 from onecodex.exceptions import OneCodexException
+
+if TYPE_CHECKING:
+    import altair as alt
 
 
 # We use custom IDs in some databases and we don't want to link them to NCBI. They are always after 2e9
@@ -164,8 +170,33 @@ def get_unique_column(preferred_name, existing_columns):
     return result
 
 
-def escape_chart_fields(chart):
-    """Escape fields to be not evaluated as JS object access pathes.
+# Altair shorthand type codes (trailing ":<code>", e.g. "foo:N")
+_ALTAIR_TYPECODES = frozenset(
+    ["O", "N", "Q", "T", "G", "ordinal", "nominal", "quantitative", "temporal", "geojson"]
+)
+
+
+def _escape_field(field: str) -> str:
+    """Escape nested object/array access path characters for Vega-Lite's field accessor."""
+    return field.replace(".", r"\.").replace("[", r"\[").replace("]", r"\]")
+
+
+def _field_name_has_colon(shorthand: str, columns: set[str]) -> bool:
+    """Report whether the shorthand's field name contains a colon Altair would misread as a type."""
+    if ":" not in shorthand:
+        return False
+
+    if shorthand in columns:
+        # column literally named e.g. "foo:N"
+        return True
+
+    field, sep, maybe_type = shorthand.rpartition(":")
+    real_field = field if (sep and maybe_type in _ALTAIR_TYPECODES) else shorthand
+    return ":" in real_field
+
+
+def escape_chart_fields(chart: alt.Chart) -> None:
+    """Escape characters in field names that Altair/Vega-Lite would otherwise treat as syntax.
 
     WARNING: it modifies `chart` in-place.
 
@@ -175,8 +206,33 @@ def escape_chart_fields(chart):
 
     """
     import altair as alt
+    import pandas as pd
+    from altair.utils import parse_shorthand
 
-    def _escape_iter(schema_item):
+    data = chart.data if isinstance(getattr(chart, "data", None), pd.DataFrame) else None
+    columns = set(data.columns) if data is not None else set()
+
+    def _to_explicit_field(schema_item: alt.VegaLiteSchema, shorthand: str) -> None:
+        schema_item._kwds["shorthand"] = alt.Undefined
+        schema_item._kwds["field"] = _escape_field(shorthand)
+        if shorthand not in columns:
+            # Not in the data, let Vega-Lite infer the type at render
+            return
+
+        # Infer type/sort if they aren't explicitly declared
+        infer_type = schema_item._kwds.get("type") is alt.Undefined
+        infer_sort = schema_item._kwds.get("sort") is alt.Undefined
+        if not infer_type and not infer_sort:
+            return
+
+        # Infer type/sort using Altair
+        attrs = parse_shorthand({"field": shorthand.replace(":", r"\:")}, data)
+        if infer_type and "type" in attrs:
+            schema_item._kwds["type"] = attrs["type"]
+        if infer_sort and "sort" in attrs:
+            schema_item._kwds["sort"] = attrs["sort"]
+
+    def _escape_iter(schema_item: alt.VegaLiteSchema) -> None:
         for key, val in schema_item._kwds.items():
             if isinstance(val, alt.VegaLiteSchema):
                 _escape_iter(val)
@@ -186,9 +242,10 @@ def escape_chart_fields(chart):
                         _escape_iter(v)
 
             elif key == "shorthand" and isinstance(val, str):
-                schema_item._kwds[key] = (
-                    val.replace(".", r"\.").replace("[", r"\[").replace("]", r"\]")
-                )
+                if _field_name_has_colon(val, columns):
+                    _to_explicit_field(schema_item, val)
+                else:
+                    schema_item._kwds[key] = _escape_field(val)
 
     if isinstance(chart.encoding, alt.VegaLiteSchema):
         _escape_iter(chart.encoding)

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -21,6 +21,7 @@ from onecodex.lib.enums import Link, Metric, Rank
 from onecodex.models.collection import SampleCollection
 from onecodex.utils import has_missing_values
 from onecodex.viz._primitives import (
+    escape_chart_fields,
     get_classification_url,
     get_ncbi_taxonomy_browser_url,
     interleave_palette,
@@ -384,6 +385,13 @@ def test_plot_pca_color_by_field_with_nans(samples):
     assert_expected_legend_title(chart, "name")
     assert_expected_color_scale_domain_len(chart, 3)
     assert_expected_color_scale_range_len(chart, 1)
+
+
+def test_plot_pca_layered_biplot_color_field_with_colon(samples):
+    for i, sample in enumerate(samples):
+        sample.metadata.custom["group:name"] = f"g{i}"
+    chart = samples.plot_pca(color="group:name", org_vectors=3, return_chart=True).to_dict()
+    assert chart["layer"][0]["encoding"]["color"]["field"] == "group:name"
 
 
 def test_plot_pca_missing_abundances(ocx, api_data, samples, samples_without_abundances):
@@ -1033,14 +1041,78 @@ def test_plot_functional_heatmap_when_metadata_contains_function_id(ocx, api_dat
     }
 
 
+def test_escape_chart_fields_colon_field_keeps_inferred_type():
+    df = pd.DataFrame({"str:col": ["a", "b"], "num:col": [1.0, 2.0], "y": [1.0, 2.0]})
+    chart = (
+        alt.Chart(df)
+        .mark_bar()
+        .encode(
+            x=alt.X("str:col"),
+            color=alt.Color("num:col"),
+            tooltip=["str:col"],
+            y="y",
+        )
+    )
+    escape_chart_fields(chart)
+    enc = chart.to_dict()["encoding"]
+    assert enc["x"] == {"field": "str:col", "type": "nominal"}
+    assert enc["color"] == {"field": "num:col", "type": "quantitative"}
+    assert enc["tooltip"][0]["field"] == "str:col"
+
+
+def test_escape_chart_fields_colon_field_ordered_categorical_sort():
+    cat = pd.Categorical(["lo", "hi", "lo"], categories=["lo", "hi"], ordered=True)
+    df = pd.DataFrame({"cat:col": cat, "y": [1.0, 2.0, 3.0]})
+    chart = (
+        alt.Chart(df)
+        .mark_bar()
+        .encode(
+            x=alt.X("cat:col"),
+            tooltip=["cat:col"],
+            y="y",
+        )
+    )
+    escape_chart_fields(chart)
+    enc = chart.to_dict()["encoding"]
+    assert enc["x"] == {"field": "cat:col", "type": "ordinal", "sort": ["lo", "hi"]}
+    assert enc["tooltip"][0] == {"field": "cat:col", "type": "ordinal"}
+
+
+def test_escape_chart_fields_colon_field_infers_sort_when_type_explicit():
+    cat = pd.Categorical(["lo", "hi", "lo"], categories=["lo", "hi"], ordered=True)
+    df = pd.DataFrame({"cat:col": cat, "y": [1.0, 2.0, 3.0]})
+    chart = alt.Chart(df).mark_bar().encode(x=alt.X("cat:col", type="ordinal"), y="y")
+    escape_chart_fields(chart)
+    assert chart.to_dict()["encoding"]["x"] == {
+        "field": "cat:col",
+        "type": "ordinal",
+        "sort": ["lo", "hi"],
+    }
+
+
+def test_escape_chart_fields_colon_field_on_secondary_channel():
+    df = pd.DataFrame({"a": [1.0, 2.0], "foo:bar": [3.0, 4.0]})
+    chart = alt.Chart(df).mark_bar().encode(x="a", x2="foo:bar")
+    escape_chart_fields(chart)
+    assert chart.to_dict()["encoding"]["x2"] == {"field": "foo:bar"}
+
+
 @pytest.mark.parametrize(
-    ("metadata_key", "escaped_key"),
+    ("metadata_key", "expected_field"),
     [
+        # `.`, `[`, and `]` are escaped (Vega-Lite nested-access syntax)...
         ("foo.bar", r"foo\.bar"),
         ("foo[bar]", r"foo\[bar\]"),
+        # ...while `:` is kept literal
+        ("foo:", "foo:"),
+        ("foo:bar", "foo:bar"),
+        ("foo:bar:baz", "foo:bar:baz"),
+        ("foo:N", "foo:N"),
+        ("foo.bar:baz", r"foo\.bar:baz"),
+        ("a.b[c]:d", r"a\.b\[c\]:d"),
     ],
 )
-def test_plot_bargraph_escape_js_like_fields(samples, metadata_key, escaped_key):
+def test_plot_bargraph_escape_special_field_chars(samples, metadata_key, expected_field):
     for i, sample in enumerate(samples):
         sample.metadata.custom[metadata_key] = f"value_{i}"
     chart = samples.plot_bargraph(
@@ -1049,7 +1121,7 @@ def test_plot_bargraph_escape_js_like_fields(samples, metadata_key, escaped_key)
         metric="readcount_w_children",
         rank="genus",
     ).to_dict()
-    assert chart["encoding"]["x"]["field"] == escaped_key
+    assert chart["encoding"]["x"]["field"] == expected_field
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

Metadata field names containing a colon (e.g. "foo:bar") were passed to Altair as encoding shorthands and raised a ValueError.

`escape_chart_fields()` now sets field names explicitly with `field=`, which skips shorthand parsing.

Closes DEV-11880

## Related PRs

- [x] This PR is independent