### PR TITLE
Jobs run: allowing to pass `description` param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and are consistent across samples with and without abundance estimates.
 - Added `Jobs.publish()` for publishing draft Workflows.
 - Added `onecodex jobs publish` CLI command.
+- Added `description` argument to `Jobs.run()`.
+- Added `--description` option to `onecodex jobs run` CLI command.
 
 ### Changed
 

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -871,6 +871,11 @@ def jobs_group():
     default=False,
     help="Block until the new analysis reaches a terminal state.",
 )
+@click.option(
+    "--description",
+    default=None,
+    help="Human-readable description. Maximum 250 characters.",
+)
 @click.pass_context
 @pretty_errors
 @telemetry
@@ -884,6 +889,7 @@ def jobs_run(
     dependency_overrides,
     populate_default_arguments,
     await_completion,
+    description,
 ):
     """Run a OneCodex job with optional arguments."""
     from onecodex.models.misc import DependencyOverride
@@ -933,6 +939,7 @@ def jobs_run(
         parsed_args,
         dependency_overrides=parsed_dependencies or None,
         populate_default_arguments=populate_default_arguments,
+        description=description,
     )
     click.echo(f"Job run created successfully. New analysis ID: {run.id}")
 

--- a/onecodex/models/misc.py
+++ b/onecodex/models/misc.py
@@ -253,6 +253,7 @@ class Jobs(OneCodexBase, JobSchema):
         job_args: dict[str, Any] | None = None,
         dependency_overrides: list[DependencyOverride] | None = None,
         populate_default_arguments: bool = True,
+        description: str | None = None,
     ) -> "Analyses":
         from onecodex.models.analysis import Analyses
 
@@ -267,6 +268,8 @@ class Jobs(OneCodexBase, JobSchema):
                 {"analysis": dep.analysis.id, "download_path": dep.download_path}
                 for dep in dependency_overrides
             ]
+        if description:
+            payload["description"] = description.strip()
 
         resp = self._client.post(url, json=payload)
         if not resp.ok:

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -812,6 +812,26 @@ def test_jobs_run_http_error(ocx, api_data, custom_mock_requests):
             job.run(sample, {})
 
 
+def test_jobs_run_with_description(ocx, api_data, custom_mock_requests):
+    job_id = "47c4fe23588640a9"
+    sample_id = "7428cca4a3a04a8e"
+    analysis_id = "593601a797914cbf"
+
+    def run_callback(request):
+        payload = json.loads(request.body)
+        assert payload["description"] == "Test Description"
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps({"$ref": f"/api/v1/analyses/{analysis_id}"}),
+        )
+
+    with custom_mock_requests({f"POST::api/v1/jobs/{job_id}/run": run_callback}):
+        job = ocx.Jobs.get(job_id)
+        sample = ocx.Samples.get(sample_id)
+        job.run(sample, description="   Test Description  ")
+
+
 def test_jobs_publish(ocx, api_data, custom_mock_requests):
     job_id = "8d2609ce2a0841a2"
     job = ocx.Jobs.get(job_id)


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

API V1 is going to support passing a description. `onecodex` lib should support it too.

## Related PRs

- [x] This PR is independent