### PR TITLE
Passing non-exising `group_by` to `.plot_bargraph` should not throw error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `onecodex jobs publish` CLI command.
 - Added `description` argument to `Jobs.run()`.
 - Added `--description` option to `onecodex jobs run` CLI command.
-- Fixed `plot_bargraph`: passing non-existing `group_by` should not throw an error.
 
 ### Changed
 
@@ -43,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Samples lacking functional results are now dropped from the plot (they were
   never plotted anyway).
 - Plots no longer raise a `ValueError` when a metadata field name contains a colon character (`:`).
+- Passing non-existing `group_by` to `plot_bargraph` should not throw an error.
 
 ## [v1.1.0] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and are consistent across samples with and without abundance estimates.
 - Added `Jobs.publish()` for publishing draft Workflows.
 - Added `onecodex jobs publish` CLI command.
+- Fixed `plot_bargraph`: passing non-existing `group_by` should not throw an error.
 
 ### Changed
 

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -1,5 +1,7 @@
 from typing import Union
 
+import numpy as np
+
 from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.lib.enums import Link, Metric, Rank
 from onecodex.models.base_sample_collection import BaseSampleCollection
@@ -109,10 +111,6 @@ class VizBargraphMixin(BaseSampleCollection):
                 raise OneCodexException(
                     "`tooltip`, `haxis`, `label`, and `sort_x` are not supported with `group_by`."
                 )
-            if group_by not in self.metadata:
-                raise OneCodexException(
-                    f"Metadata field {group_by} not found. Choose from: {', '.join(self.metadata.keys())}"
-                )
 
         metric, rank = self._parse_classification_config_args(metric=metric, rank=rank)
 
@@ -138,6 +136,10 @@ class VizBargraphMixin(BaseSampleCollection):
 
         if group_by:
             # calculate per-group mean of each taxon
+
+            # In case `group_by` does not exist
+            if group_by not in self.metadata:
+                self.metadata[group_by] = np.nan
 
             df = df.fillna(0.0).join(self.metadata[group_by]).groupby(group_by, dropna=False).mean()
 

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -1,7 +1,5 @@
 from typing import Union
 
-import numpy as np
-
 from onecodex.exceptions import OneCodexException, PlottingException
 from onecodex.lib.enums import Link, Metric, Rank
 from onecodex.models.base_sample_collection import BaseSampleCollection
@@ -102,6 +100,7 @@ class VizBargraphMixin(BaseSampleCollection):
 
         # Deferred imports
         import altair as alt
+        import numpy as np
 
         if not (threshold or top_n):
             raise OneCodexException("Please specify at least one of: threshold, top_n")

--- a/onecodex/viz/_bargraph.py
+++ b/onecodex/viz/_bargraph.py
@@ -100,7 +100,7 @@ class VizBargraphMixin(BaseSampleCollection):
 
         # Deferred imports
         import altair as alt
-        import numpy as np
+        import pandas as pd
 
         if not (threshold or top_n):
             raise OneCodexException("Please specify at least one of: threshold, top_n")
@@ -136,11 +136,13 @@ class VizBargraphMixin(BaseSampleCollection):
         if group_by:
             # calculate per-group mean of each taxon
 
-            # In case `group_by` does not exist
-            if group_by not in self.metadata:
-                self.metadata[group_by] = np.nan
+            if group_by in self.metadata:
+                metadata_series = self.metadata[group_by]
+            else:
+                # Let's group everything into one artificial/fake group
+                metadata_series = pd.Series(pd.NA, index=self.metadata.index, name=group_by)
 
-            df = df.fillna(0.0).join(self.metadata[group_by]).groupby(group_by, dropna=False).mean()
+            df = df.fillna(0.0).join(metadata_series).groupby(group_by, dropna=False).mean()
 
             # Nicer display for missing metadata values than `null`
             df.index = df.index.fillna("N/A")

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -796,7 +796,6 @@ def test_plot_mds_exceptions(samples):
         ({"group_by": "foo", "haxis": "bar"}, None, "not supported with `group_by`"),
         ({"group_by": "foo", "label": "bar"}, None, "not supported with `group_by`"),
         ({"group_by": "foo", "sort_x": []}, None, "not supported with `group_by`"),
-        ({"group_by": "foo"}, None, "field foo not found"),
     ],
 )
 def test_plot_bargraph_errors(samples, kwargs, metric, msg):
@@ -869,6 +868,13 @@ def test_plot_bargraph_with_group_by(samples, metric, kwargs):
 
     assert [x.shorthand for x in chart.encoding.tooltip] == ["barley", "tax_name", metric_label]
     assert not hasattr(chart.encoding.href, "shorthand")
+
+
+def test_plot_bargraph_with_nonexisting_group_by(samples):
+    chart = samples.plot_bargraph(group_by="does_not_exist", return_chart=True)
+    values = set(chart.data["does_not_exist"])
+    assert len(values) == 1
+    assert values.pop() == "N/A"
 
 
 def test_plot_bargraph_include_other_with_empty_samples(samples_without_abundances):

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -875,6 +875,7 @@ def test_plot_bargraph_with_nonexisting_group_by(samples):
     values = set(chart.data["does_not_exist"])
     assert len(values) == 1
     assert values.pop() == "N/A"
+    assert "does_not_exist" not in samples.metadata
 
 
 def test_plot_bargraph_include_other_with_empty_samples(samples_without_abundances):


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

`haxis` param also accepts metadata fields but it does not throw an error if field does not exist. `group_by` should act the same.

Other option would be to convert `OneCodexException` to `PlottingException`, but it still would be inconsistent with `haxis`.

## Related PRs

- [x] This PR is independent