### PR TITLE
Bump Python version in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
 
 ENV UV_LINK_MODE=copy \
     UV_NO_INSTALLER_METADATA=1
@@ -10,12 +10,13 @@ COPY . .
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system ".[all]"
 
-FROM python:3.11-slim-bookworm
+FROM python:3.13-slim-bookworm
 
 RUN groupadd --system --gid 65532 nonroot \
  && useradd  --system --uid 65532 --gid 65532 --home /home/nonroot --create-home --shell /sbin/nologin nonroot
 
-COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+COPY --from=builder /usr/local/bin/onecodex /usr/local/bin/onecodex
 
 USER nonroot
 WORKDIR /home/nonroot


### PR DESCRIPTION
## Status

- [X] **Ready**

## Description

This PR bumps the Python version used in the docker image from 3.11 -> 3.13.
Also in this PR, the docker image gets the `onecodex` command line tool.

## Related PRs

- [X] This PR is independent

