### PR TITLE
Add `nextflow_version` for Nextflow jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `description` argument to `Jobs.run()`.
 - Added `--description` option to `onecodex jobs run` CLI command.
 - Added `--gzip-output` and `--gzip-output-compresslevel` to `onecodex scripts subset_reads`.
+- Added a `nextflow_version` argument to `Jobs.create()` and `Jobs.update()`, and a
+  `--nextflow-version` option to the `onecodex jobs create` and `onecodex jobs update` CLI
+  commands. Defaults to the latest supported Nextflow version. `Jobs.details()` reports the
+  version a workflow runs.
 
 ### Changed
 
+- Nextflow Workflows no longer accept an image URI. Use `nextflow_version`
+  (`--nextflow-version`) instead. `image_uri` (`--image-uri`) is still required for shell script
+  Workflows.
 - Renamed the `Metric.is_filtered_readcount_metric` property to
   `Metric.is_abundance_sensitive` to better describe what it flags.
 - In `plot_metadata(width="container", ...)`, boxplot width is now dynamically adjusted based on the

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ job = ocx.Jobs.create(
     name="my-custom-job",
     script=open("run.sh").read(),
     image_uri="docker.io/library/python:3.12",
-    job_type="shell_script",  # or "nextflow"
+    job_type="shell_script",
     cpu=1, ram_gb=1, storage_gb=1,
     assets=[asset],
     dependencies=[{"job": parent, "output_dir": "parent_out"}],
@@ -257,6 +257,56 @@ onecodex jobs create \
     -d <parent_job_id>=parent_out
 
 onecodex jobs update <job_id> --name renamed
+```
+
+Nextflow jobs take a `nextflow_version` instead of an `image_uri`, and their CPU, RAM, and
+storage are fixed (Nextflow itself sets the resources for the tasks it spawns). The version
+defaults to the latest supported one; passing an unsupported version returns an error listing
+the ones you can use.
+
+The pipeline itself lives in `repository`, which is cloned to `$REPOSITORY_DIR` at run time.
+`script` is a shell script that prepares the inputs and then invokes the pipeline. The output
+directory must be named `output` or start with `output-` for the results to be captured. The
+web app's Nextflow editor starts you off with a fully commented version of this script:
+
+```bash
+# run_nextflow.sh
+set -eo pipefail
+
+# FASTQs are stored interleaved; split them for pipelines that expect paired end reads
+deinterleave "$OCX_SAMPLE_FILENAME"
+
+SAMPLE_NAME=$(echo -n "$OCX_SAMPLE_FILENAME" | cut -d. -f1)
+cat <<_EOF > input.csv
+sample,fastq_1,fastq_2
+${SAMPLE_NAME},${SAMPLE_NAME}_R1.fastq.gz,${SAMPLE_NAME}_R2.fastq.gz
+_EOF
+
+# input_params.json is generated from the pipeline's schema and the job's arguments
+nextflow run "${REPOSITORY_DIR}/main.nf" \
+    --input input.csv \
+    -params-file input_params.json \
+    --outdir "output-$OCX_ANALYSIS_UUID"
+```
+
+```python
+job = ocx.Jobs.create(
+    name="my-nextflow-job",
+    script=open("run_nextflow.sh").read(),
+    job_type="nextflow",
+    nextflow_version="26.04.6",  # optional
+    repository={"url": "https://github.com/my-org/my-pipeline", "tag": "v0.1.0"},
+)
+```
+
+```bash
+onecodex jobs create \
+    --name my-nextflow-job \
+    --script ./run_nextflow.sh \
+    --job-type nextflow \
+    --nextflow-version 26.04.6 \
+    --repository-url https://github.com/my-org/my-pipeline \
+    --repository-tag v0.1.0
 ```
 
 For long-running analyses, `await_completion()` polls until the analysis reaches a terminal state (`complete=True`). The cadence backs off over time, so failures surface in seconds while longer jobs poll on the order of minutes:

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -954,7 +954,8 @@ def jobs_run(
         click.echo(f"Get its status using `onecodex analyses {run.id}`", err=True)
 
 
-JOB_TYPE_CHOICES = ["shell_script", "nextflow"]
+NEXTFLOW_JOB_TYPE = "nextflow"
+JOB_TYPE_CHOICES = ["shell_script", NEXTFLOW_JOB_TYPE]
 
 
 def _parse_dependency_specs(deps: tuple[str, ...]) -> list[tuple[str, str]]:
@@ -986,6 +987,7 @@ def _job_kwargs_from_options(
     name,
     script_path,
     image_uri,
+    nextflow_version,
     job_type,
     description,
     cpu,
@@ -1014,6 +1016,7 @@ def _job_kwargs_from_options(
         "name": name,
         "script": script,
         "image_uri": image_uri,
+        "nextflow_version": nextflow_version,
         "job_type": job_type,
         "description": description,
         "cpu": cpu,
@@ -1030,7 +1033,16 @@ def _job_kwargs_from_options(
 
 
 _JOB_OPTIONS_COMMON = [
-    click.option("--image-uri", default=None, help="Fully qualified OCI image URI."),
+    click.option(
+        "--image-uri",
+        default=None,
+        help="Fully qualified OCI image URI (shell_script jobs).",
+    ),
+    click.option(
+        "--nextflow-version",
+        default=None,
+        help="Nextflow version, e.g. 26.04.6 (nextflow jobs). Defaults to the latest supported.",
+    ),
     click.option(
         "--job-type",
         type=click.Choice(JOB_TYPE_CHOICES),
@@ -1141,6 +1153,7 @@ def jobs_create(
     name,
     script_path,
     image_uri,
+    nextflow_version,
     job_type,
     description,
     cpu,
@@ -1154,14 +1167,28 @@ def jobs_create(
     arguments_schema_path,
 ):
     """Create a new Job."""
-    if image_uri is None:
-        raise click.BadParameter("--image-uri is required.", param_hint="--image-uri")
+    if job_type == NEXTFLOW_JOB_TYPE:
+        if image_uri is not None:
+            raise click.BadParameter(
+                "--image-uri is not supported for Nextflow jobs, "
+                "use --nextflow-version instead.",
+                param_hint="--image-uri",
+            )
+    else:
+        if image_uri is None:
+            raise click.BadParameter("--image-uri is required.", param_hint="--image-uri")
+        if nextflow_version is not None:
+            raise click.BadParameter(
+                f"--nextflow-version requires --job-type {NEXTFLOW_JOB_TYPE}.",
+                param_hint="--nextflow-version",
+            )
 
     kwargs = _job_kwargs_from_options(
         api=ctx.obj["API"],
         name=name,
         script_path=script_path,
         image_uri=image_uri,
+        nextflow_version=nextflow_version,
         job_type=job_type,
         description=description,
         cpu=cpu,
@@ -1205,6 +1232,7 @@ def jobs_update(
     name,
     script_path,
     image_uri,
+    nextflow_version,
     job_type,
     description,
     cpu,
@@ -1230,6 +1258,7 @@ def jobs_update(
         name=name,
         script_path=script_path,
         image_uri=image_uri,
+        nextflow_version=nextflow_version,
         job_type=None,
         description=description,
         cpu=cpu,

--- a/onecodex/models/schemas/misc.py
+++ b/onecodex/models/schemas/misc.py
@@ -61,6 +61,7 @@ class _JobMutableFields(BaseModel):
     name: Optional[str] = None
     script: Optional[str] = None
     image_uri: Optional[str] = None
+    nextflow_version: Optional[str] = None
     description: Optional[str] = None
     cpu: Optional[float] = None
     ram_gb: Optional[float] = None
@@ -106,6 +107,7 @@ class JobDetails(BaseModel):
     job_type: str
     script: str
     image_uri: str
+    nextflow_version: str
     cpu: float
     ram_gb: float
     storage_gb: float
@@ -153,7 +155,6 @@ class JobCreateSchema(_JobMutableFields):
 
     name: str
     script: str
-    image_uri: str
     job_type: Optional[str] = None
 
 

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -749,6 +749,7 @@ def test_jobs_details(ocx, api_data, custom_mock_requests):
                     "description": "My custom job",
                     "script": "echo 'hi'",
                     "image_uri": "docker.io/library/python:3.12",
+                    "nextflow_version": "",
                     "cpu": 1.5,
                     "ram_gb": 2.0,
                     "storage_gb": 3.0,
@@ -770,6 +771,7 @@ def test_jobs_details(ocx, api_data, custom_mock_requests):
     assert isinstance(details, onecodex.models.schemas.misc.JobDetails)
     assert details.script == "echo 'hi'"
     assert details.image_uri == "docker.io/library/python:3.12"
+    assert details.nextflow_version == ""
     assert details.cpu == 1.5
     assert details.ram_gb == 2.0
     assert details.storage_gb == 3.0
@@ -780,6 +782,106 @@ def test_jobs_details(ocx, api_data, custom_mock_requests):
     assert details.dependencies == []
     assert details.inject_bearer_token is False
     assert details.autorun_on_org_sample_upload is False
+
+
+def test_jobs_details_nextflow(ocx, api_data, custom_mock_requests):
+    job_id = "47c4fe23588640a9"
+
+    def details_callback(request):
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "job_type": "nextflow",
+                    "description": "My Nextflow job",
+                    "script": "workflow {}",
+                    "image_uri": "",
+                    "nextflow_version": "25.10.0",
+                    "cpu": 1.5,
+                    "ram_gb": 6.0,
+                    "storage_gb": 150.0,
+                    "repository": {"url": "https://github.com/org/repo", "tag": "v0.1.0"},
+                    "assets": [],
+                    "dependencies": [],
+                    "arguments_schema": [],
+                    "inject_bearer_token": False,
+                    "autorun_on_org_sample_upload": False,
+                }
+            ),
+        )
+
+    with custom_mock_requests({f"GET::api/v1/jobs/{job_id}/details": details_callback}):
+        details = ocx.Jobs.get(job_id).details()
+
+    assert details.job_type == "nextflow"
+    assert details.nextflow_version == "25.10.0"
+    assert details.image_uri == ""
+
+
+def _jobs_write_mock(captured, job_id="0123456789abcdef"):
+    def callback(request):
+        captured["body"] = json.loads(request.body)
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "$uri": f"/api/v1/jobs/{job_id}",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "name": "my-nextflow-job",
+                    "analysis_type": "workflow",
+                    "public": False,
+                    "draft": True,
+                    "job_args_schema": {},
+                }
+            ),
+        )
+
+    return callback
+
+
+@pytest.mark.parametrize(
+    "version_kwargs,expected_version_body",
+    [
+        ({"nextflow_version": "25.10.0"}, {"nextflow_version": "25.10.0"}),
+        # Omitted rather than sent as null, so the server picks the latest supported version
+        ({}, {}),
+    ],
+)
+def test_jobs_create_nextflow(
+    ocx, api_data, custom_mock_requests, version_kwargs, expected_version_body
+):
+    new_job_id = "0123456789abcdef"
+    captured = {}
+
+    with custom_mock_requests({"POST::api/v1/jobs": _jobs_write_mock(captured, new_job_id)}):
+        job = ocx.Jobs.create(
+            name="my-nextflow-job",
+            script="workflow {}",
+            job_type="nextflow",
+            repository={"url": "https://github.com/org/repo", "tag": "v0.1.0"},
+            **version_kwargs,
+        )
+
+    assert job.id == new_job_id
+    assert captured["body"] == {
+        "name": "my-nextflow-job",
+        "script": "workflow {}",
+        "job_type": "nextflow",
+        "repository": {"url": "https://github.com/org/repo", "tag": "v0.1.0"},
+        **expected_version_body,
+    }
+
+
+def test_jobs_update_nextflow_version(ocx, api_data, custom_mock_requests):
+    job_id = "47c4fe23588640a9"
+    captured = {}
+
+    with custom_mock_requests({f"PATCH::api/v1/jobs/{job_id}": _jobs_write_mock(captured, job_id)}):
+        ocx.Jobs.get(job_id).update(nextflow_version="24.10.5")
+
+    assert captured["body"] == {"nextflow_version": "24.10.5"}
 
 
 def test_jobs_details_http_error(ocx, api_data, custom_mock_requests):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -300,15 +300,99 @@ def test_jobs_create_cli(runner, api_data, custom_mock_requests, mocked_creds_fi
     }
 
 
-def test_jobs_create_missing_image_uri(runner, mocked_creds_file, tmp_path):
+def _jobs_write_mock(captured, job_id="0123456789abcdef"):
+    def callback(request):
+        captured["body"] = json.loads(request.body)
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "$uri": f"/api/v1/jobs/{job_id}",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "name": "my-nf-job",
+                    "analysis_type": "workflow",
+                    "public": False,
+                    "draft": True,
+                    "job_args_schema": {},
+                }
+            ),
+        )
+
+    return callback
+
+
+def test_jobs_create_nextflow_cli(
+    runner, api_data, custom_mock_requests, mocked_creds_file, tmp_path
+):
+    new_job_id = "0123456789abcdef"
+    captured = {}
+
+    script = tmp_path / "run_nextflow.sh"
+    script.write_text("nextflow run main.nf\n")
+
+    with custom_mock_requests({"POST::api/v1/jobs": _jobs_write_mock(captured, new_job_id)}):
+        result = runner.invoke(
+            Cli,
+            [
+                "jobs",
+                "create",
+                *("--name", "my-nf-job"),
+                *("--script", str(script)),
+                *("--job-type", "nextflow"),
+                *("--nextflow-version", "25.10.0"),
+                *("--repository-url", "https://github.com/org/repo"),
+                *("--repository-tag", "v0.1.0"),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured["body"] == {
+        "name": "my-nf-job",
+        "script": "nextflow run main.nf\n",
+        "nextflow_version": "25.10.0",
+        "job_type": "nextflow",
+        "repository": {"url": "https://github.com/org/repo", "tag": "v0.1.0"},
+    }
+
+
+def test_jobs_update_nextflow_version_cli(
+    runner, api_data, custom_mock_requests, mocked_creds_file
+):
+    job_id = "cc1d331e1ee54bac"
+    captured = {}
+
+    with custom_mock_requests({f"PATCH::api/v1/jobs/{job_id}": _jobs_write_mock(captured, job_id)}):
+        result = runner.invoke(Cli, ["jobs", "update", job_id, *("--nextflow-version", "24.10.5")])
+
+    assert result.exit_code == 0, result.output
+    assert captured["body"] == {"nextflow_version": "24.10.5"}
+
+
+@pytest.mark.parametrize(
+    "image_args,expected_error",
+    [
+        ([], "image-uri"),
+        (
+            ["--job-type", "nextflow", "--image-uri", "docker.io/library/python:3.12"],
+            "--image-uri is not supported for Nextflow jobs",
+        ),
+        (
+            ["--image-uri", "docker.io/library/python:3.12", "--nextflow-version", "25.10.0"],
+            "--nextflow-version requires --job-type nextflow",
+        ),
+    ],
+)
+def test_jobs_create_invalid_image_options(
+    runner, mocked_creds_file, tmp_path, image_args, expected_error
+):
     script = tmp_path / "run.sh"
     script.write_text("echo hi\n")
     result = runner.invoke(
-        Cli,
-        ["jobs", "create", *("--name", "x"), *("--script", str(script))],
+        Cli, ["jobs", "create", *("--name", "x"), *("--script", str(script)), *image_args]
     )
     assert result.exit_code != 0
-    assert "image-uri" in result.output
+    assert expected_error in result.output
 
 
 def test_jobs_update_cli(runner, api_data, custom_mock_requests, mocked_creds_file):


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

- `Jobs.create()` / `Jobs.update()` take `nextflow_version`, and `image_uri` is now optional (still required for shell script jobs)
- `onecodex jobs create` / `update` take `--nextflow-version`, and reject `--image-uri` for Nextflow jobs (and `--nextflow-version` for shell script jobs)
- `Jobs.details()` includes `nextflow_version`

Closes DEV-11800

## Related PRs

- [x] This PR is independent