### PR TITLE
Add filtering samples by tax ids

### DIFF
--- a/onecodex/models/base.py
+++ b/onecodex/models/base.py
@@ -166,6 +166,9 @@ class OneCodexBase(PydanticBaseModel, metaclass=_DirMeta):
     _client: ClassVar[Optional["HTTPClient"]] = None  # noqa: F821
     _resource_path: ClassVar[str]  # Default resource path, subclasses override
     _allowed_methods: ClassVar[AllowedMethods] = {}
+    _filter_only_fields: ClassVar[frozenset[str]] = (
+        frozenset()
+    )  # Extra filter-only fields not on the model
 
     model_config = ConfigDict(
         populate_by_alias=True,

--- a/onecodex/models/helpers.py
+++ b/onecodex/models/helpers.py
@@ -48,7 +48,7 @@ def generate_potion_keyword_where(keyword_filters, where_schema, base_class):
         if keyword == "id":
             keyword = "$uri"
 
-        if keyword not in base_class.model_fields:
+        if keyword not in base_class.model_fields and keyword not in base_class._filter_only_fields:
             raise AttributeError("{} cannot be searched on {}".format(base_class.__name__, keyword))
 
         if isinstance(search_value, list):

--- a/onecodex/models/sample.py
+++ b/onecodex/models/sample.py
@@ -318,7 +318,7 @@ class Samples(OneCodexBase, _SampleSchema, ResourceDownloadMixin):
                     raise OneCodexException("Unknown tag specified: {}".format(t))
             new_tags.append(new_tag)
 
-        # Merge inline field kwargs with leftover **keyword_filters.
+        # merge inline field kwargs with leftover **keyword_filters
         merged_filters = _drop_unset(
             created_at=created_at,
             updated_at=updated_at,
@@ -345,16 +345,24 @@ class Samples(OneCodexBase, _SampleSchema, ResourceDownloadMixin):
             for k, v in merged_filters.items()
             if k in Metadata.model_fields and k not in Samples.model_fields
         }
-        if not public and not organization:
-            if md_search_keywords:
-                metadata_samples = [md.sample for md in Metadata.where(**md_search_keywords)]
+        # drop Metadata filters from Samples filters
+        sample_filters = {k: v for k, v in merged_filters.items() if k not in md_search_keywords}
+
+        if md_search_keywords and (public or organization):
+            endpoint = "public" if public else "organization"
+            invalid_fields = ", ".join(sorted(md_search_keywords))
+            raise OneCodexException(
+                f"Cannot filter {endpoint} samples by metadata field(s): {invalid_fields}"
+            )
 
         if md_search_keywords:
-            # we tried searching by metadata fields
+            # we'll try searching by metadata fields
+            metadata_samples = [md.sample for md in Metadata.where(**md_search_keywords)]
+
             if not metadata_samples:
                 # there were no results, so don't bother with a slower query on Samples
                 samples = []
-            elif not (filters or merged_filters):
+            elif not (filters or sample_filters or filter or sort):
                 # there were results, and there are no other filters to apply, so return them
                 samples = metadata_samples
             else:
@@ -367,7 +375,7 @@ class Samples(OneCodexBase, _SampleSchema, ResourceDownloadMixin):
                     limit=effective_limit,
                     filter=filter,
                     _instances=instances_route,
-                    **merged_filters,
+                    **sample_filters,
                 )
                 samples = [s for s in samples if s.id in metadata_sample_ids]
         else:
@@ -379,7 +387,7 @@ class Samples(OneCodexBase, _SampleSchema, ResourceDownloadMixin):
                 limit=effective_limit,
                 filter=filter,
                 _instances=instances_route,
-                **merged_filters,
+                **sample_filters,
             )
 
         return SampleCollection([s for s in samples[:effective_limit]], Samples)

--- a/onecodex/models/sample.py
+++ b/onecodex/models/sample.py
@@ -189,6 +189,7 @@ class Samples(OneCodexBase, _SampleSchema, ResourceDownloadMixin):
         "update": SampleUpdateSchema,
         "instances_public": None,
     }
+    _filter_only_fields = frozenset({"tax_ids"})
 
     def __repr__(self):
         return '<{} {}: "{}">'.format(
@@ -204,7 +205,8 @@ class Samples(OneCodexBase, _SampleSchema, ResourceDownloadMixin):
         public: bool = False,
         organization: bool = False,
         filter: Any = None,
-        tags: list | None = None,
+        tags: list[str] | None = None,
+        tax_ids: list[str] | None = None,
         created_at: datetime | DatetimeFilter = UNSET,
         updated_at: datetime | DatetimeFilter = UNSET,
         filename: str | StrFilter | None = UNSET,
@@ -238,6 +240,10 @@ class Samples(OneCodexBase, _SampleSchema, ResourceDownloadMixin):
 
             ocx.Samples.where(tags=["trimmed", "human-depleted"])
 
+        Filter by tax ids (returns samples containing *all* the listed taxa)::
+
+            ocx.Samples.where(tax_ids=["543", "590"])
+
         Filter by a metadata field — transparently joined::
 
             ocx.Samples.where(platform="Illumina NovaSeq 6000")
@@ -263,6 +269,9 @@ class Samples(OneCodexBase, _SampleSchema, ResourceDownloadMixin):
             Tags to filter by. Accepts :class:`Tags` instances, tag ids, or
             tag names — all resolved to refs and combined with
             ``$containsall``.
+        tax_ids
+            Taxonomy ids (as str) to filter by. Only samples containing *every*
+            listed taxon are returned.
 
         Returns
         -------
@@ -325,6 +334,8 @@ class Samples(OneCodexBase, _SampleSchema, ResourceDownloadMixin):
         merged_filters.update(keyword_filters)
         if new_tags:
             merged_filters["tags"] = {"$containsall": new_tags}
+        if tax_ids:
+            merged_filters["tax_ids"] = {"$containsall": tax_ids}
 
         # we can only search metadata on our own samples currently
         # FIXME: we need to add `instances_public` and `instances_project` metadata routes to

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -544,16 +544,16 @@ def test_where_clauses_with_tags(ocx, api_data):
     assert any(query_in_urls)
 
 
-def _extract_sample_where_clauses(path="/api/v1/samples") -> list[dict]:
-    """Extract the `where` clauses from every recorded request to `path`."""
+def _extract_query_clauses(clause: str, path: str = "/api/v1/samples") -> list[dict]:
+    """Extract `clause` (e.g. "where" or "sort") query arg from each recorded request to `path`."""
     clauses = []
     for c in responses.calls:
         parsed = urlparse(c.request.url)
         if parsed.path != path:
             continue
-        where = parse_qs(parsed.query).get("where")
-        if where:
-            clauses.append(json.loads(where[0]))
+        value = parse_qs(parsed.query).get(clause)
+        if value:
+            clauses.append(json.loads(value[0]))
     return clauses
 
 
@@ -562,21 +562,21 @@ def test_where_clauses_with_tax_ids(ocx, api_data):
     samples = ocx.Samples.where(tax_ids=["543", "590"])
 
     assert sample in samples
-    assert _extract_sample_where_clauses() == [{"tax_ids": {"$containsall": ["543", "590"]}}]
+    assert _extract_query_clauses("where") == [{"tax_ids": {"$containsall": ["543", "590"]}}]
 
 
 @pytest.mark.parametrize("tax_ids", [None, []])
 def test_where_clauses_with_empty_tax_ids(ocx, api_data, tax_ids):
     ocx.Samples.where(tax_ids=tax_ids)
 
-    assert _extract_sample_where_clauses() == [{}]
+    assert _extract_query_clauses("where") == [{}]
 
 
 def test_where_clauses_with_tax_ids_and_tags(ocx, api_data):
     tag = ocx.Tags.get("5c1e9e41043e4435")
     ocx.Samples.where(tags=[tag], tax_ids=["543"])
 
-    assert _extract_sample_where_clauses() == [
+    assert _extract_query_clauses("where") == [
         {
             "tags": {"$containsall": [{"$ref": "/api/v1/tags/5c1e9e41043e4435"}]},
             "tax_ids": {"$containsall": ["543"]},
@@ -587,7 +587,7 @@ def test_where_clauses_with_tax_ids_and_tags(ocx, api_data):
 def test_where_clauses_with_tax_ids_and_sample_field(ocx, api_data):
     ocx.Samples.where(tax_ids=["543"], visibility="private")
 
-    assert _extract_sample_where_clauses() == [
+    assert _extract_query_clauses("where") == [
         {"visibility": "private", "tax_ids": {"$containsall": ["543"]}}
     ]
 
@@ -595,8 +595,8 @@ def test_where_clauses_with_tax_ids_and_sample_field(ocx, api_data):
 def test_where_clauses_with_tax_ids_public_endpoint(ocx, api_data):
     ocx.Samples.where(tax_ids=["543"], public=True)
 
-    assert _extract_sample_where_clauses("/api/v1/samples") == []
-    assert _extract_sample_where_clauses("/api/v1/samples/public") == [
+    assert _extract_query_clauses("where", "/api/v1/samples") == []
+    assert _extract_query_clauses("where", "/api/v1/samples/public") == [
         {"tax_ids": {"$containsall": ["543"]}}
     ]
 
@@ -604,41 +604,102 @@ def test_where_clauses_with_tax_ids_public_endpoint(ocx, api_data):
 def test_where_clauses_with_tax_ids_org_endpoint(ocx, api_data):
     ocx.Samples.where(tax_ids=["543"], organization=True)
 
-    assert _extract_sample_where_clauses("/api/v1/samples") == []
-    assert _extract_sample_where_clauses("/api/v1/samples/organization") == [
+    assert _extract_query_clauses("where", "/api/v1/samples") == []
+    assert _extract_query_clauses("where", "/api/v1/samples/organization") == [
         {"tax_ids": {"$containsall": ["543"]}}
     ]
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Pre-existing bug, not specific to tax_ids: metadata-only fields aren't "
-        "stripped from merged_filters before the intersecting Samples query, so "
-        "combining any metadata field with any sample-side filter raises "
-        "AttributeError. Reproduces on master with "
-        "`Samples.where(starred=True, visibility='private')`."
-    ),
-    raises=AttributeError,
-)
-def test_where_clauses_with_tax_ids_and_metadata_field(ocx, raw_api_data, custom_mock_requests):
+def _mock_metadata_record(raw_api_data, **fields):
     raw_api_data["GET::api/v1/metadata"] = [
         {
             "$uri": "/api/v1/metadata/4fe05e748b5a4f0e",
             "sample": {"$ref": "/api/v1/samples/761bc54b97f64980"},
             "custom": {},
-            "starred": True,
+            **fields,
         }
     ]
+    return raw_api_data
+
+
+def test_where_clauses_with_tax_ids_and_metadata_field(ocx, raw_api_data, custom_mock_requests):
+    _mock_metadata_record(raw_api_data, starred=True)
 
     with custom_mock_requests(raw_api_data):
         samples = ocx.Samples.where(tax_ids=["543"], starred=True)
 
-    # the sample query keeps `tax_ids` and drops the metadata-only field
-    assert _extract_sample_where_clauses() == [{"tax_ids": {"$containsall": ["543"]}}]
-    assert _extract_sample_where_clauses("/api/v1/metadata") == [{"starred": True}]
+        # the sample query keeps `tax_ids` and drops the metadata-only field
+        assert _extract_query_clauses("where") == [{"tax_ids": {"$containsall": ["543"]}}]
+        assert _extract_query_clauses("where", "/api/v1/metadata") == [{"starred": True}]
 
     # results are the intersection of the two queries
     assert [s.id for s in samples] == ["761bc54b97f64980"]
+
+
+def test_where_metadata_field_with_sample_field(ocx, raw_api_data, custom_mock_requests):
+    _mock_metadata_record(raw_api_data, starred=True)
+
+    with custom_mock_requests(raw_api_data):
+        samples = ocx.Samples.where(starred=True, visibility="private")
+
+        assert _extract_query_clauses("where") == [{"visibility": "private"}]
+        assert _extract_query_clauses("where", "/api/v1/metadata") == [{"starred": True}]
+
+    assert [s.id for s in samples] == ["761bc54b97f64980"]
+
+
+def test_where_metadata_field_only(ocx, raw_api_data, custom_mock_requests):
+    _mock_metadata_record(raw_api_data, starred=True)
+
+    with custom_mock_requests(raw_api_data):
+        samples = ocx.Samples.where(starred=True)
+
+        assert _extract_query_clauses("where") == []
+
+    assert [s.id for s in samples] == ["761bc54b97f64980"]
+
+
+def test_where_metadata_field_no_matches(ocx, raw_api_data, custom_mock_requests):
+    raw_api_data["GET::api/v1/metadata"] = []
+
+    with custom_mock_requests(raw_api_data):
+        samples = ocx.Samples.where(starred=True, visibility="private")
+
+        assert _extract_query_clauses("where") == []
+
+    assert list(samples) == []
+
+
+def test_where_metadata_field_with_local_filter(ocx, raw_api_data, custom_mock_requests):
+    _mock_metadata_record(raw_api_data, starred=True)
+
+    with custom_mock_requests(raw_api_data):
+        # Local filter is still applied after a Metadata search
+        kept = ocx.Samples.where(starred=True, filter=lambda s: s.filename.endswith(".fastq.gz"))
+        dropped = ocx.Samples.where(starred=True, filter=lambda s: s.filename == "nope.fastq.gz")
+
+    assert [s.id for s in kept] == ["761bc54b97f64980"]
+    assert list(dropped) == []
+
+
+def test_where_metadata_field_with_sort(ocx, raw_api_data, custom_mock_requests):
+    _mock_metadata_record(raw_api_data, starred=True)
+
+    with custom_mock_requests(raw_api_data):
+        # Filter is applied to Metadata but sort to Samples
+        samples = ocx.Samples.where(starred=True, sort="filename")
+
+        assert _extract_query_clauses("sort") == [{"filename": True}]
+
+    assert [s.id for s in samples] == ["761bc54b97f64980"]
+
+
+@pytest.mark.parametrize("scope", ["public", "organization"])
+def test_where_metadata_field_not_supported_for_public_and_org_samples(ocx, api_data, scope):
+    with pytest.raises(OneCodexException) as e:
+        ocx.Samples.where(starred=True, **{scope: True})
+
+    assert "Cannot filter {} samples by metadata field(s): starred".format(scope) in str(e.value)
 
 
 def test_where_filter(ocx, api_data):

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -544,6 +544,103 @@ def test_where_clauses_with_tags(ocx, api_data):
     assert any(query_in_urls)
 
 
+def _extract_sample_where_clauses(path="/api/v1/samples") -> list[dict]:
+    """Extract the `where` clauses from every recorded request to `path`."""
+    clauses = []
+    for c in responses.calls:
+        parsed = urlparse(c.request.url)
+        if parsed.path != path:
+            continue
+        where = parse_qs(parsed.query).get("where")
+        if where:
+            clauses.append(json.loads(where[0]))
+    return clauses
+
+
+def test_where_clauses_with_tax_ids(ocx, api_data):
+    sample = ocx.Samples.get("7428cca4a3a04a8e")
+    samples = ocx.Samples.where(tax_ids=["543", "590"])
+
+    assert sample in samples
+    assert _extract_sample_where_clauses() == [{"tax_ids": {"$containsall": ["543", "590"]}}]
+
+
+@pytest.mark.parametrize("tax_ids", [None, []])
+def test_where_clauses_with_empty_tax_ids(ocx, api_data, tax_ids):
+    ocx.Samples.where(tax_ids=tax_ids)
+
+    assert _extract_sample_where_clauses() == [{}]
+
+
+def test_where_clauses_with_tax_ids_and_tags(ocx, api_data):
+    tag = ocx.Tags.get("5c1e9e41043e4435")
+    ocx.Samples.where(tags=[tag], tax_ids=["543"])
+
+    assert _extract_sample_where_clauses() == [
+        {
+            "tags": {"$containsall": [{"$ref": "/api/v1/tags/5c1e9e41043e4435"}]},
+            "tax_ids": {"$containsall": ["543"]},
+        }
+    ]
+
+
+def test_where_clauses_with_tax_ids_and_sample_field(ocx, api_data):
+    ocx.Samples.where(tax_ids=["543"], visibility="private")
+
+    assert _extract_sample_where_clauses() == [
+        {"visibility": "private", "tax_ids": {"$containsall": ["543"]}}
+    ]
+
+
+def test_where_clauses_with_tax_ids_public_endpoint(ocx, api_data):
+    ocx.Samples.where(tax_ids=["543"], public=True)
+
+    assert _extract_sample_where_clauses("/api/v1/samples") == []
+    assert _extract_sample_where_clauses("/api/v1/samples/public") == [
+        {"tax_ids": {"$containsall": ["543"]}}
+    ]
+
+
+def test_where_clauses_with_tax_ids_org_endpoint(ocx, api_data):
+    ocx.Samples.where(tax_ids=["543"], organization=True)
+
+    assert _extract_sample_where_clauses("/api/v1/samples") == []
+    assert _extract_sample_where_clauses("/api/v1/samples/organization") == [
+        {"tax_ids": {"$containsall": ["543"]}}
+    ]
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Pre-existing bug, not specific to tax_ids: metadata-only fields aren't "
+        "stripped from merged_filters before the intersecting Samples query, so "
+        "combining any metadata field with any sample-side filter raises "
+        "AttributeError. Reproduces on master with "
+        "`Samples.where(starred=True, visibility='private')`."
+    ),
+    raises=AttributeError,
+)
+def test_where_clauses_with_tax_ids_and_metadata_field(ocx, raw_api_data, custom_mock_requests):
+    raw_api_data["GET::api/v1/metadata"] = [
+        {
+            "$uri": "/api/v1/metadata/4fe05e748b5a4f0e",
+            "sample": {"$ref": "/api/v1/samples/761bc54b97f64980"},
+            "custom": {},
+            "starred": True,
+        }
+    ]
+
+    with custom_mock_requests(raw_api_data):
+        samples = ocx.Samples.where(tax_ids=["543"], starred=True)
+
+    # the sample query keeps `tax_ids` and drops the metadata-only field
+    assert _extract_sample_where_clauses() == [{"tax_ids": {"$containsall": ["543"]}}]
+    assert _extract_sample_where_clauses("/api/v1/metadata") == [{"starred": True}]
+
+    # results are the intersection of the two queries
+    assert [s.id for s in samples] == ["761bc54b97f64980"]
+
+
 def test_where_filter(ocx, api_data):
     samples = ocx.Samples.where(filter=lambda s: s.filename.endswith("9.fastq.gz"))
     assert all([s.filename.endswith("9.fastq.gz") for s in samples])


### PR DESCRIPTION
## Status

- [X] **Ready**

## Description

This PR adds filtering samples by tax ids. **Important**: wait until the corresponding mainline PR is merged and deployed.
Also in this PR: fixing metadata filtering on samples where _both_ sample and metadata filters were present. Adding a bunch of tests to ensure all cases are covered and work as expected.

## Related PRs

- [X] This PR is independent

## TODOs

- [x] Merge sample taxa filter API v1 PR first
