### PR TITLE
CLI commands to list and download an analysis' output files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   filtering](https://docs.onecodex.com/en/articles/3761205-one-codex-database)
   and are consistent across samples with and without abundance estimates.
 - Added `Jobs.publish()` for publishing draft Workflows.
+- Added `onecodex analyses files` and `onecodex analyses download` CLI commands for listing
+  and downloading an analysis's output files.
 - Added `onecodex jobs publish` CLI command.
 - Added `description` argument to `Jobs.run()`.
 - Added `--description` option to `onecodex jobs run` CLI command.
@@ -52,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never plotted anyway).
 - Plots no longer raise a `ValueError` when a metadata field name contains a colon character (`:`).
 - Passing non-existing `group_by` to `plot_bargraph` should not throw an error.
+- `onecodex analyses <subcommand> --help` (e.g. `onecodex analyses logs --help`) no longer
+  requires being logged in.
 
 ## [v1.1.0] - 2026-06-18
 

--- a/README.md
+++ b/README.md
@@ -384,6 +384,19 @@ for file in output_files:
     analysis.download_file(file, progressbar=True)
 ```
 
+The CLI exposes the same functionality:
+
+```bash
+# List the analysis's output files:
+onecodex analyses files 0123456789abcdef
+
+# Download them all into ./results/, preserving the analysis's directory structure:
+onecodex analyses download 0123456789abcdef --out results
+
+# Or download specific files by filepath:
+onecodex analyses download 0123456789abcdef -f report.tsv -f logs/nextflow.log
+```
+
 ## Upgrading from 0.19.x to 1.0
 
 In 1.0, `SampleCollection` no longer takes `metric`, `normalize`, or `rank` at construction time. These are now passed directly to `.to_df()` and the `.plot_*()` functions instead, so you can switch metrics or ranks without rebuilding the collection. `normalize=True` has been removed; use the explicit `normalized_*` metric value instead (e.g. `normalized_readcount_w_children`). In alpha- and beta-diversity functions, the old `metric` argument was also renamed to `diversity_metric` / `distance_metric`, with `metric` now referring to the underlying abundance metric.

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -25,6 +25,8 @@ from onecodex.input_helpers import (
 )
 from onecodex.lib.upload import DEFAULT_THREADS
 from onecodex.metadata_upload import validate_appendables
+from onecodex.models import Analyses
+from onecodex.models.schemas.misc import FileDetailSchema
 from onecodex.scripts import export_functional_metric, interleave, subset_reads
 from onecodex.utils import (
     OPTION_HELP,
@@ -382,15 +384,26 @@ class _AnalysesGroup(click.Group):
 @click.argument("analyses", nargs=-1, required=False, type=OCX_ID)
 @click.pass_context
 @telemetry
-@login_required
-def analyses(ctx, analyses):
+def analyses(ctx: click.Context, analyses: tuple[str, ...]) -> None:
     """Retrieve performed analyses.
 
     With no arguments, lists all analyses in your account. Pass one or more
     analysis IDs to fetch those analyses specifically.
     """
     if ctx.invoked_subcommand is None:
-        cli_resource_fetcher(ctx, "analyses", analyses)
+        _fetch_analyses(ctx, analyses)
+
+
+@login_required
+def _fetch_analyses(ctx: click.Context, analysis_ids: tuple[str, ...]) -> None:
+    cli_resource_fetcher(ctx, "analyses", analysis_ids)
+
+
+def _get_analysis(ctx: click.Context, analysis_id: str) -> Analyses:
+    analysis = ctx.obj["API"].Analyses.get(analysis_id)
+    if not analysis:
+        raise click.ClickException(f"Could not find analysis {analysis_id} (404 status code)")
+    return analysis
 
 
 @click.command("await")
@@ -423,12 +436,14 @@ def analyses(ctx, analyses):
 @telemetry
 @login_required
 def analyses_await(
-    ctx, analysis_id, timeout_seconds, initial_interval_seconds, max_interval_seconds
-):
+    ctx: click.Context,
+    analysis_id: str,
+    timeout_seconds: float | None,
+    initial_interval_seconds: int,
+    max_interval_seconds: int,
+) -> None:
     """Poll an analysis until it reaches a terminal state."""
-    analysis = ctx.obj["API"].Analyses.get(analysis_id)
-    if not analysis:
-        raise click.ClickException(f"Could not find analysis {analysis_id} (404 status code)")
+    analysis = _get_analysis(ctx, analysis_id)
 
     try:
         analysis.await_completion(
@@ -464,15 +479,131 @@ analyses.add_command(analyses_await, "await")
 @pretty_errors
 @telemetry
 @login_required
-def analyses_logs(ctx, analysis_id, tail):
+def analyses_logs(ctx: click.Context, analysis_id: str, tail: int) -> None:
     """Fetch the job run logs for an analysis."""
-    analysis = ctx.obj["API"].Analyses.get(analysis_id)
-    if not analysis:
-        raise click.ClickException(f"Could not find analysis {analysis_id} (404 status code)")
+    analysis = _get_analysis(ctx, analysis_id)
     click.echo(analysis.logs(tail=tail), nl=False)
 
 
 analyses.add_command(analyses_logs, "logs")
+
+
+@click.command("files")
+@click.argument("analysis_id", nargs=1, required=True, type=OCX_ID)
+@click.option(
+    "--json", "as_json", is_flag=True, default=False, help="Output JSON instead of prettified table"
+)
+@click.pass_context
+@pretty_errors
+@telemetry
+@login_required
+def analyses_files(ctx: click.Context, analysis_id: str, as_json: bool) -> None:
+    """List the output files of an analysis."""
+    files = _get_analysis(ctx, analysis_id).get_files()
+
+    if as_json:
+        pprint([x.model_dump() for x in files], ctx.obj["NOPPRINT"])
+        return
+
+    if not files:
+        click.echo(f"Analysis {analysis_id} has no output files.")
+        return
+
+    rows = [("Filepath", "Size (bytes)")] + [(x.filepath, str(x.size)) for x in files]
+    width = max(len(filepath) for filepath, _ in rows)
+    for filepath, size in rows:
+        click.echo(f"{filepath:<{width}}  {size}")
+
+
+analyses.add_command(analyses_files, "files")
+
+
+def _plan_downloads(
+    analysis_id: str, files: dict[str, FileDetailSchema], outdir: str
+) -> dict[str, tuple[str, FileDetailSchema]]:
+    downloads: dict[str, tuple[str, FileDetailSchema]] = {}
+
+    for filepath, file_detail in files.items():
+        out_path = os.path.abspath(os.path.join(outdir, filepath.lstrip("/")))
+        if out_path == outdir or os.path.commonpath([outdir, out_path]) != outdir:
+            raise click.ClickException(f"Refusing to write {filepath!r} outside of {outdir}.")
+        if os.path.lexists(out_path):
+            raise click.ClickException(f"{out_path} already exists. Will not overwrite.")
+        if out_path in downloads:
+            raise click.ClickException(
+                f"Analysis {analysis_id} lists both {downloads[out_path][0]!r} and {filepath!r} as "
+                f"output files, which both resolve to {out_path}."
+            )
+        downloads[out_path] = (filepath, file_detail)
+
+    for out_path, (filepath, _) in downloads.items():
+        parent = os.path.dirname(out_path)
+        while parent != outdir:
+            if parent in downloads:
+                raise click.ClickException(
+                    f"Analysis {analysis_id} lists {downloads[parent][0]!r} as an output file and "
+                    f"as a directory containing {filepath!r}."
+                )
+            if os.path.lexists(parent) and not os.path.isdir(parent):
+                raise click.ClickException(
+                    f"Cannot save {filepath!r}: {parent} already exists and is not a directory."
+                )
+            parent = os.path.dirname(parent)
+
+    return downloads
+
+
+@click.command("download")
+@click.argument("analysis_id", nargs=1, required=True, type=OCX_ID)
+@click.option(
+    "-o",
+    "--out",
+    default=".",
+    show_default=True,
+    type=click.Path(file_okay=False, dir_okay=True, writable=True),
+    help="Directory where output file(s) will be saved. Created if it doesn't exist.",
+    shell_complete=partial(click_path_autocomplete_helper, filename=False),
+)
+@click.option(
+    "-f",
+    "--file",
+    "filepaths",
+    multiple=True,
+    help="Download a specific output file by its filepath (see `onecodex analyses files`). Can be "
+    "passed multiple times. By default, all output files are downloaded.",
+)
+@click.pass_context
+@pretty_errors
+@telemetry
+@login_required
+def analyses_download(
+    ctx: click.Context, analysis_id: str, out: str, filepaths: tuple[str, ...]
+) -> None:
+    """Download the output files of an analysis."""
+    analysis = _get_analysis(ctx, analysis_id)
+    files = {x.filepath: x for x in analysis.get_files()}
+
+    if filepaths:
+        missing = [x for x in filepaths if x not in files]
+        if missing:
+            raise click.ClickException(
+                f"Analysis {analysis_id} has no output file(s): {', '.join(missing)}"
+            )
+        files = {x: files[x] for x in filepaths}
+
+    if not files:
+        click.echo(f"Analysis {analysis_id} has no output files.", err=True)
+        return
+
+    for out_path, (filepath, file_detail) in _plan_downloads(
+        analysis_id, files, os.path.abspath(out)
+    ).items():
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        analysis.download_file(file_detail, out_path=out_path, progressbar=True)
+        click.echo(f"{filepath} saved to {out_path}", err=True)
+
+
+analyses.add_command(analyses_download, "download")
 
 
 @onecodex.command("classifications")
@@ -1170,8 +1301,7 @@ def jobs_create(
     if job_type == NEXTFLOW_JOB_TYPE:
         if image_uri is not None:
             raise click.BadParameter(
-                "--image-uri is not supported for Nextflow jobs, "
-                "use --nextflow-version instead.",
+                "--image-uri is not supported for Nextflow jobs, use --nextflow-version instead.",
                 param_hint="--image-uri",
             )
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,12 +66,14 @@ def test_analyses(runner, api_data, mocked_creds_file):
     assert API_DATA["GET::api/v1/analyses/593601a797914cbf"]["$uri"] in r1.output
 
 
-def test_analyses_await(runner, custom_mock_requests, mocked_creds_file, monkeypatch):
-    analysis_id = "593601a797914cbf"
-    base_payload = {
+def _analysis_payload(analysis_id, **overrides):
+    payload = {
         "$uri": f"/api/v1/analyses/{analysis_id}",
         "analysis_type": "classification",
         "created_at": "2015-09-25T17:27:30.622286-07:00",
+        "complete": True,
+        "success": True,
+        "error_msg": None,
         "job": {"$ref": "/api/v1/jobs/e4b1ab37ff554c53"},
         "sample": {"$ref": "/api/v1/samples/7428cca4a3a04a8e"},
         "cost": None,
@@ -79,10 +81,16 @@ def test_analyses_await(runner, custom_mock_requests, mocked_creds_file, monkeyp
         "draft": False,
         "job_args": {},
     }
+    payload.update(overrides)
+    return payload
+
+
+def test_analyses_await(runner, custom_mock_requests, mocked_creds_file, monkeypatch):
+    analysis_id = "593601a797914cbf"
     bodies = [
-        {**base_payload, "complete": False, "success": False, "error_msg": None},
-        {**base_payload, "complete": False, "success": False, "error_msg": None},
-        {**base_payload, "complete": True, "success": True, "error_msg": None},
+        _analysis_payload(analysis_id, complete=False, success=False),
+        _analysis_payload(analysis_id, complete=False, success=False),
+        _analysis_payload(analysis_id),
     ]
 
     def get_callback(request):
@@ -100,25 +108,15 @@ def test_analyses_await(runner, custom_mock_requests, mocked_creds_file, monkeyp
 
 def test_analyses_logs(runner, custom_mock_requests, mocked_creds_file):
     analysis_id = "593601a797914cbf"
-    base_payload = {
-        "$uri": f"/api/v1/analyses/{analysis_id}",
-        "analysis_type": "classification",
-        "created_at": "2015-09-25T17:27:30.622286-07:00",
-        "complete": True,
-        "success": True,
-        "error_msg": None,
-        "job": {"$ref": "/api/v1/jobs/e4b1ab37ff554c53"},
-        "sample": {"$ref": "/api/v1/samples/7428cca4a3a04a8e"},
-        "cost": None,
-        "dependencies": [],
-        "draft": False,
-        "job_args": {},
-    }
 
     captured = {}
 
     def get_callback(request):
-        return (200, {"Content-Type": "application/json"}, json.dumps(base_payload))
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(_analysis_payload(analysis_id)),
+        )
 
     def logs_callback(request):
         captured["url"] = request.url
@@ -140,23 +138,13 @@ def test_analyses_logs(runner, custom_mock_requests, mocked_creds_file):
 
 def test_analyses_logs_404(runner, custom_mock_requests, mocked_creds_file):
     analysis_id = "593601a797914cbf"
-    base_payload = {
-        "$uri": f"/api/v1/analyses/{analysis_id}",
-        "analysis_type": "classification",
-        "created_at": "2015-09-25T17:27:30.622286-07:00",
-        "complete": True,
-        "success": True,
-        "error_msg": None,
-        "job": {"$ref": "/api/v1/jobs/e4b1ab37ff554c53"},
-        "sample": {"$ref": "/api/v1/samples/7428cca4a3a04a8e"},
-        "cost": None,
-        "dependencies": [],
-        "draft": False,
-        "job_args": {},
-    }
 
     def get_callback(request):
-        return (200, {"Content-Type": "application/json"}, json.dumps(base_payload))
+        return (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(_analysis_payload(analysis_id)),
+        )
 
     def logs_callback(request):
         return (404, {"Content-Type": "text/plain"}, "Not Found")
@@ -172,6 +160,268 @@ def test_analyses_logs_404(runner, custom_mock_requests, mocked_creds_file):
     assert result.exit_code != 0
     assert "Logs not found" in result.output
     assert "Traceback" not in result.output
+
+
+FILE_DETAILS = {
+    "files": [
+        {
+            "filename": "report.tsv",
+            "filepath": "results/report.tsv",
+            "size": 11,
+            "url": "http://localhost:3000/files/report.tsv",
+        },
+        {
+            "filename": "summary.txt",
+            "filepath": "summary.txt",
+            "size": 7,
+            "url": "http://localhost:3000/files/summary.txt",
+        },
+    ]
+}
+
+
+@pytest.fixture
+def mock_analysis_files(custom_mock_requests):
+    from onecodex.models.analysis import _AnalysesBase
+
+    _AnalysesBase.get_files.cache_clear()
+
+    analysis_id = "593601a797914cbf"
+
+    def make_mocks(file_details=FILE_DETAILS):
+        return custom_mock_requests(
+            {
+                f"GET::api/v1/analyses/{analysis_id}": _analysis_payload(analysis_id),
+                f"GET::api/v1/analyses/{analysis_id}/file_details": file_details,
+                "GET:text/plain:files/report.tsv": lambda request: (
+                    200,
+                    {"Content-Type": "text/plain"},
+                    "report data",
+                ),
+                "GET:text/plain:files/summary.txt": lambda request: (
+                    200,
+                    {"Content-Type": "text/plain"},
+                    "summary",
+                ),
+            }
+        )
+
+    return analysis_id, make_mocks
+
+
+def test_analyses_files(runner, mock_analysis_files, mocked_creds_file):
+    analysis_id, make_mocks = mock_analysis_files
+    with make_mocks():
+        result = runner.invoke(Cli, ["analyses", "files", analysis_id])
+
+    assert result.exit_code == 0, result.output
+    assert "Filepath" in result.output
+    assert "results/report.tsv  11" in result.output
+    assert "summary.txt         7" in result.output
+
+
+def test_analyses_files_json(runner, mock_analysis_files, mocked_creds_file):
+    analysis_id, make_mocks = mock_analysis_files
+    with make_mocks():
+        result = runner.invoke(Cli, ["analyses", "files", analysis_id, "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == FILE_DETAILS["files"]
+
+
+def test_analyses_files_empty(runner, mock_analysis_files, mocked_creds_file):
+    analysis_id, make_mocks = mock_analysis_files
+    with make_mocks(file_details={"files": []}):
+        result = runner.invoke(Cli, ["analyses", "files", analysis_id])
+
+    assert result.exit_code == 0, result.output
+    assert "no output files" in result.output
+
+
+def test_analyses_download(runner, mock_analysis_files, mocked_creds_file):
+    analysis_id, make_mocks = mock_analysis_files
+    with runner.isolated_filesystem():
+        with make_mocks():
+            result = runner.invoke(Cli, ["analyses", "download", analysis_id, "-o", "out"])
+
+        assert result.exit_code == 0, result.output
+        with open(os.path.join("out", "results", "report.tsv")) as f:
+            assert f.read() == "report data"
+        with open(os.path.join("out", "summary.txt")) as f:
+            assert f.read() == "summary"
+
+
+def test_analyses_download_single_file(runner, mock_analysis_files, mocked_creds_file):
+    analysis_id, make_mocks = mock_analysis_files
+    with runner.isolated_filesystem():
+        with make_mocks():
+            result = runner.invoke(
+                Cli, ["analyses", "download", analysis_id, "-f", "results/report.tsv"]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert os.path.exists(os.path.join("results", "report.tsv"))
+        assert not os.path.exists("summary.txt")
+
+
+def test_analyses_download_nonexistent_file(runner, mock_analysis_files, mocked_creds_file):
+    analysis_id, make_mocks = mock_analysis_files
+    with runner.isolated_filesystem():
+        with make_mocks():
+            result = runner.invoke(Cli, ["analyses", "download", analysis_id, "-f", "nope.tsv"])
+
+        assert result.exit_code != 0
+        assert "has no output file(s): nope.tsv" in result.output
+
+
+def test_analyses_download_refuses_path_traversal(runner, mock_analysis_files, mocked_creds_file):
+    analysis_id, make_mocks = mock_analysis_files
+    file_details = {
+        "files": [
+            {
+                "filename": "report.tsv",
+                "filepath": "../report.tsv",
+                "size": 11,
+                "url": "http://localhost:3000/files/report.tsv",
+            }
+        ]
+    }
+    with runner.isolated_filesystem():
+        with make_mocks(file_details=file_details):
+            result = runner.invoke(Cli, ["analyses", "download", analysis_id, "-o", "out"])
+
+        assert result.exit_code != 0
+        assert "Refusing to write '../report.tsv'" in result.output
+        assert not os.path.exists(os.path.join("..", "report.tsv"))
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["analyses", "--help"],
+        ["analyses", "files", "--help"],
+        ["analyses", "download", "--help"],
+        ["analyses", "logs", "--help"],
+        ["analyses", "await", "--help"],
+    ],
+)
+def test_analyses_help_does_not_require_login(runner, mocked_creds_path, args):
+    result = runner.invoke(Cli, args)
+
+    assert result.exit_code == 0, result.output
+    assert "requires authentication" not in result.output
+
+
+def test_analyses_download_existing_file_aborts(runner, mock_analysis_files, mocked_creds_file):
+    analysis_id, make_mocks = mock_analysis_files
+    with runner.isolated_filesystem():
+        os.makedirs(os.path.join("out", "results"))
+        with open(os.path.join("out", "results", "report.tsv"), "w") as f:
+            f.write("mine")
+
+        with make_mocks():
+            result = runner.invoke(Cli, ["analyses", "download", analysis_id, "-o", "out"])
+
+        assert result.exit_code != 0
+        assert "already exists. Will not overwrite." in result.output
+        with open(os.path.join("out", "results", "report.tsv")) as f:
+            assert f.read() == "mine"
+        assert not os.path.exists(os.path.join("out", "summary.txt"))
+
+
+def test_analyses_download_existing_outdir(runner, mock_analysis_files, mocked_creds_file):
+    analysis_id, make_mocks = mock_analysis_files
+    with runner.isolated_filesystem():
+        os.makedirs("out")
+        with make_mocks():
+            result = runner.invoke(Cli, ["analyses", "download", analysis_id, "-o", "out"])
+
+        assert result.exit_code == 0, result.output
+        assert os.path.exists(os.path.join("out", "results", "report.tsv"))
+
+
+def test_analyses_download_outdir_is_a_file(runner, mock_analysis_files, mocked_creds_file):
+    analysis_id, make_mocks = mock_analysis_files
+    with runner.isolated_filesystem():
+        with open("out", "w") as f:
+            f.write("not a directory")
+
+        with make_mocks():
+            result = runner.invoke(Cli, ["analyses", "download", analysis_id, "-o", "out"])
+
+        assert result.exit_code != 0
+        assert "is a file" in result.output
+
+
+def _file_details(*filepaths):
+    return {
+        "files": [
+            {
+                "filename": os.path.basename(filepath),
+                "filepath": filepath,
+                "size": 11,
+                "url": "http://localhost:3000/files/report.tsv",
+            }
+            for filepath in filepaths
+        ]
+    }
+
+
+def test_analyses_download_file_and_directory_collide(
+    runner, mock_analysis_files, mocked_creds_file
+):
+    analysis_id, make_mocks = mock_analysis_files
+    with runner.isolated_filesystem():
+        with make_mocks(file_details=_file_details("a", "a/b")):
+            result = runner.invoke(Cli, ["analyses", "download", analysis_id, "-o", "out"])
+
+        assert result.exit_code != 0
+        assert "lists 'a' as an output file and as a directory containing 'a/b'" in result.output
+        assert "Traceback" not in result.output
+        assert not os.path.exists("out")
+
+
+def test_analyses_download_directory_blocked_by_existing_file(
+    runner, mock_analysis_files, mocked_creds_file
+):
+    analysis_id, make_mocks = mock_analysis_files
+    with runner.isolated_filesystem():
+        os.makedirs("out")
+        with open(os.path.join("out", "a"), "w") as f:
+            f.write("mine")
+
+        with make_mocks(file_details=_file_details("a/b/c")):
+            result = runner.invoke(Cli, ["analyses", "download", analysis_id, "-o", "out"])
+
+        assert result.exit_code != 0
+        assert "already exists and is not a directory" in result.output
+        assert "Traceback" not in result.output
+        with open(os.path.join("out", "a")) as f:
+            assert f.read() == "mine"
+
+
+def test_analyses_download_duplicate_filepaths(runner, mock_analysis_files, mocked_creds_file):
+    analysis_id, make_mocks = mock_analysis_files
+    with runner.isolated_filesystem():
+        with make_mocks(file_details=_file_details("a/b", "/a/b")):
+            result = runner.invoke(Cli, ["analyses", "download", analysis_id, "-o", "out"])
+
+        assert result.exit_code != 0
+        assert "which both resolve to" in result.output
+        assert not os.path.exists("out")
+
+
+@pytest.mark.parametrize("filepath", ["", "/", "."])
+def test_analyses_download_degenerate_filepath(
+    runner, mock_analysis_files, mocked_creds_file, filepath
+):
+    analysis_id, make_mocks = mock_analysis_files
+    with runner.isolated_filesystem():
+        with make_mocks(file_details=_file_details(filepath)):
+            result = runner.invoke(Cli, ["analyses", "download", analysis_id, "-o", "out"])
+
+        assert result.exit_code != 0
+        assert "Refusing to write" in result.output
 
 
 # Classifications


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

- `onecodex analyses files ID` lists output files (tabular or JSON format)
- `onecodex analyses download ID` saves output files under `-o/--out`. A subset of output files can be downloaded via `-f/--file`
- `onecodex analyses <subcommand> --help` (e.g. `onecodex analyses logs --help`) no longer requires being logged in

Closes DEV-11796

## Related PRs

- [x] This PR is independent