### PR TITLE
Fix: spurious warning raised when plotting PCoA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that the substring be a valid enum member which behaved unintuitively.
 - `onecodex analyses <subcommand> --help` (e.g. `onecodex analyses logs --help`) no longer
   requires being logged in.
+- `SampleCollection.plot_distance` no longer incorrectly warns about
+  non-comparable metrics when plotting with comparable metrics.
 
 ## [v1.1.0] - 2026-06-18
 

--- a/onecodex/viz/_distance.py
+++ b/onecodex/viz/_distance.py
@@ -465,7 +465,10 @@ class VizDistanceMixin(DistanceMixin):
             tooltip.insert(2, size)
 
         metadata_results = self._metadata_fetch(
-            tooltip, results_df=self.to_df(), label=label, match_taxonomy=match_taxonomy
+            tooltip,
+            results_df=self.to_df(rank=rank, metric=metric),
+            label=label,
+            match_taxonomy=match_taxonomy,
         )
         magic_metadata = metadata_results.df
         magic_fields = metadata_results.renamed_fields

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from datetime import datetime
 
 import mock
@@ -747,6 +748,22 @@ def test_plot_mds_missing_abundances(ocx, api_data, samples, samples_without_abu
         (PlottingWarning, OneCodexUserWarning), match=r"2 sample\(s\) have no abundances calculated"
     ):
         samples.plot_mds(metric="abundance", return_chart=True)
+
+
+@pytest.mark.parametrize("metric", [Metric.Abundance, Metric.FilteredReadcount])
+def test_plot_mds_no_spurious_mixed_abundance_warning(
+    ocx, api_data, samples, samples_without_abundances, metric
+):
+    """The metadata fetch must use the requested metric, not the collection default."""
+    samples = samples + samples_without_abundances[:2]
+    assert len(samples._classification_ids_without_abundances) == 2
+    assert samples.automatic_metric.is_abundance_sensitive
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        samples.plot_mds(metric=metric, return_chart=True)
+
+    assert not [w for w in caught if "may not be comparable" in str(w.message)]
 
 
 def test_plot_pcoa(samples):


### PR DESCRIPTION
## Status

- [x] **Ready**

## Description

Plotting a PCoA would raise a warning if the input samples had mixed abundance status. The issue was that the results dataframe was being generated in two places, and the 2nd place did not receive the appropriate `metric` argument. This PR fixes the issue by passing the metric/rank arguments.

## Related PRs

- [x] This PR is independent

## TODOs

- [x] Tests
- [x] Update `CHANGELOG`
