### PR TITLE
Fix: interleaved files not detected + other upload fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `onecodex upload` no longer asks whether to merge files by sample when none of the
+  files are split into numbered chunks. Files without an ordinal (e.g. `sample_R1.fq.gz`)
+  were each treated as a single-file ONT group.
+- `onecodex upload` no longer interleaves two separate ONT samples whose merged filenames
+  differ only by a trailing ordinal (e.g. `sample_1` and `sample_2`).
+- `onecodex upload` now marks paired end mates that were found on disk but not passed on
+  the command line with a `*` in the confirmation prompt.
 - `plot_functional_heatmap()` no longer raises a `MergeError` when the sample
   collection contains more than one sample without functional profile results.
   Samples lacking functional results are now dropped from the plot (they were

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ Multiple files can be uploaded in a single command as well:
 onecodex upload file1.fq.gz file2.fq.gz ...
 ```
 
+Files are grouped into samples based on their filenames. Paired end reads (`sample_R1.fq.gz`
+and `sample_R2.fq.gz`) are interleaved, ONT files split into numbered chunks (`sample_0.fq.gz`,
+`sample_1.fq.gz`, ...) are merged, and files split across sequencing lanes (`sample_L001.fq.gz`,
+`sample_L002.fq.gz`, ...) are concatenated. You are asked to confirm before any of this happens.
+
+If you pass only one half of a paired end sample, its mate is picked up from the same directory
+and marked with a `*` in the confirmation prompt. Pass `--no-prompt` to upload only the files
+named on the command line, or `--forward`/`--reverse` to pair two files explicitly.
+
 You can also upload files using the Python client library:
 
 ```python

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -828,7 +828,18 @@ def upload(
     sample_id,
     external_sample_id,
 ):
-    """Upload a FASTA or FASTQ (optionally gzip'd) to One Codex."""
+    """Upload a FASTA or FASTQ (optionally gzip'd) to One Codex.
+
+    Files are grouped into samples based on their filenames: paired end reads (e.g.
+    `sample_R1.fq` and `sample_R2.fq`) are interleaved, ONT files split into numbered
+    chunks (e.g. `sample_0.fq`, `sample_1.fq`) are merged, and files split across
+    sequencing lanes (e.g. `sample_L001.fq`, `sample_L002.fq`) are concatenated.
+
+    If one half of a paired end sample is passed, its mate is picked up from the same
+    directory; it is marked with a * when you are asked to confirm. Pass --no-prompt to
+    upload only the files given on the command line, or --forward/--reverse to pair two
+    files explicitly.
+    """
     appendables = {}
     if tags:
         appendables["tags"] = []

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -873,8 +873,8 @@ def upload(
 
             # Detecting ONT groups comes first as otherwise part of ONT group could
             # be mistaken for a paired file
-            files = concatenate_ont_groups(files, prompt, tempdir)
-            files = auto_detect_pairs(files, prompt)
+            ont_files, files = concatenate_ont_groups(files, prompt, tempdir)
+            files = auto_detect_pairs(files, prompt) + ont_files
 
         files = concatenate_multilane_files(files, prompt, tempdir)
 

--- a/onecodex/cli.py
+++ b/onecodex/cli.py
@@ -19,7 +19,7 @@ from onecodex.auth import (
     login_required,
 )
 from onecodex.input_helpers import (
-    auto_detect_pairs,
+    auto_detect_illumina_pairs,
     concatenate_multilane_files,
     concatenate_ont_groups,
 )
@@ -874,7 +874,7 @@ def upload(
             # Detecting ONT groups comes first as otherwise part of ONT group could
             # be mistaken for a paired file
             ont_files, files = concatenate_ont_groups(files, prompt, tempdir)
-            files = auto_detect_pairs(files, prompt) + ont_files
+            files = auto_detect_illumina_pairs(files, prompt) + ont_files
 
         files = concatenate_multilane_files(files, prompt, tempdir)
 

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -153,7 +153,6 @@ def auto_detect_illumina_pairs(files: Sequence[str], prompt: bool) -> list[str |
     Such files are marked as not specified in the prompt.
     """
 
-    # files the user actually asked us to upload
     passed_files = set(files)
 
     # files left ungrouped

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -79,6 +79,11 @@ def concatenate_ont_groups(files, prompt, tempdir):
     auto_group = True
 
     for filename in files:
+        # without an ordinal, the substitution below is a no-op and the file
+        # would be matched against itself
+        if not re.search(ORDINAL_MULTI_REV_PATTERN, filename):
+            continue
+
         ont_zero_filename = _replace_filename_ordinal(filename, "0", multi_digit=True)
         if os.path.exists(ont_zero_filename):
             # strip the ordinal and preceding . or _
@@ -87,8 +92,8 @@ def concatenate_ont_groups(files, prompt, tempdir):
 
             ont_groups[base_filename].add(filename)
 
-    # filter to groups of at least 1 files
-    ont_groups = {k: v for k, v in ont_groups.items()}
+    if not ont_groups:
+        return files
 
     # if there is only one group; do not prompt for concatenation
     if len(files) == 1 and len(ont_groups) == 1:

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import logging
 from collections import defaultdict
+from collections.abc import Sequence
 
 # Captures parts before and after ordinal
 # (. or _ followed by num followed by . or _ and non-digits)
@@ -72,13 +73,12 @@ def prompt_user_for_concatenation(ont_groups: dict) -> bool:
     return False
 
 
-def concatenate_ont_groups(files, prompt, tempdir):
+def concatenate_ont_groups(
+    files: Sequence[str], prompt: bool, tempdir: str
+) -> tuple[list[str], list[str]]:
     """Concatenate ONT split files.
 
-    Returns `(concatenated, remaining)`. The concatenated files are complete samples and
-    must not be considered for paired-end detection: their names no longer carry the
-    ordinal, so two ONT samples named e.g. `sample_1` and `sample_2` would otherwise look
-    like a read pair.
+    Returns `(concatenated, remaining)`.
     """
     single_files = set(files)
     concatenated = []
@@ -144,7 +144,7 @@ def concatenate_ont_groups(files, prompt, tempdir):
     return concatenated, list(single_files)
 
 
-def auto_detect_illumina_pairs(files, prompt):
+def auto_detect_illumina_pairs(files: Sequence[str], prompt: bool) -> list[str | tuple[str, str]]:
     """Group paired-end files in the files list.
 
     Returns the files list with paired-end files represented as tuples on that list.

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -144,7 +144,7 @@ def concatenate_ont_groups(files, prompt, tempdir):
     return concatenated, list(single_files)
 
 
-def auto_detect_pairs(files, prompt):
+def auto_detect_illumina_pairs(files, prompt):
     """Group paired-end files in the files list.
 
     Returns the files list with paired-end files represented as tuples on that list.

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -148,8 +148,13 @@ def auto_detect_illumina_pairs(files, prompt):
     """Group paired-end files in the files list.
 
     Returns the files list with paired-end files represented as tuples on that list.
-    If `prompt` is set to True, the user is asked whether this should happen first.
+    If `prompt` is set to True, the user is asked whether this should happen first, and
+    the mate of a paired file may be picked up from disk even if it was not passed in.
+    Such files are marked as not specified in the prompt.
     """
+
+    # files the user actually asked us to upload
+    passed_files = set(files)
 
     # files left ungrouped
     single_files = set(files)
@@ -187,9 +192,18 @@ def auto_detect_illumina_pairs(files, prompt):
 
     auto_pair = True
     if prompt and pairs:
+
+        def _label(filename):
+            # mark files we found on disk but that were not passed on the command line
+            marker = "" if filename in passed_files else " *"
+            return f"{os.path.basename(filename)}{marker}"
+
         pair_list = ""
         for pair in pairs:
-            pair_list += f"\n  {os.path.basename(pair[0])}  &  {os.path.basename(pair[1])}"
+            pair_list += f"\n  {_label(pair[0])}  &  {_label(pair[1])}"
+        if any(f not in passed_files for pair in pairs for f in pair):
+            pair_list += "\n* not specified on the command line; found alongside its mate"
+
         answer = click.confirm(
             "It appears there are {n_paired_files} paired files (of {n_files} total):{pair_list}\nInterleave them after upload?".format(
                 n_paired_files=len(pairs) * 2,

--- a/onecodex/input_helpers.py
+++ b/onecodex/input_helpers.py
@@ -73,8 +73,15 @@ def prompt_user_for_concatenation(ont_groups: dict) -> bool:
 
 
 def concatenate_ont_groups(files, prompt, tempdir):
-    """Concatenate ONT split files and return the group as a single entry on the files list."""
+    """Concatenate ONT split files.
+
+    Returns `(concatenated, remaining)`. The concatenated files are complete samples and
+    must not be considered for paired-end detection: their names no longer carry the
+    ordinal, so two ONT samples named e.g. `sample_1` and `sample_2` would otherwise look
+    like a read pair.
+    """
     single_files = set(files)
+    concatenated = []
     ont_groups = defaultdict(set)
     auto_group = True
 
@@ -93,7 +100,7 @@ def concatenate_ont_groups(files, prompt, tempdir):
             ont_groups[base_filename].add(filename)
 
     if not ont_groups:
-        return files
+        return concatenated, list(files)
 
     # if there is only one group; do not prompt for concatenation
     if len(files) == 1 and len(ont_groups) == 1:
@@ -104,17 +111,18 @@ def concatenate_ont_groups(files, prompt, tempdir):
         auto_group = True
 
     if not auto_group:
-        return files
+        return concatenated, list(files)
 
     # Ensure there is no gap in the file sequences
-    for base_ont_filename, files in ont_groups.items():
-        ont_file = next(iter(files))
+    for base_ont_filename, group_files in ont_groups.items():
+        ont_file = next(iter(group_files))
         expected_sequence = [
-            _replace_filename_ordinal(ont_file, idx, multi_digit=True) for idx in range(len(files))
+            _replace_filename_ordinal(ont_file, idx, multi_digit=True)
+            for idx in range(len(group_files))
         ]
         full_sequence = True
         for expected_file in expected_sequence:
-            if expected_file not in files:
+            if expected_file not in group_files:
                 log.warning(
                     "Detected a gap in the ONT file sequence for "
                     f"{os.path.basename(base_ont_filename)}, missing file:"
@@ -132,8 +140,8 @@ def concatenate_ont_groups(files, prompt, tempdir):
                 with open(ont_filename, "rb") as inf:
                     shutil.copyfileobj(inf, outf)
                 single_files.remove(ont_filename)
-        single_files.add(base_ont_filename)
-    return list(single_files)
+        concatenated.append(base_ont_filename)
+    return concatenated, list(single_files)
 
 
 def auto_detect_pairs(files, prompt):
@@ -197,7 +205,7 @@ def auto_detect_pairs(files, prompt):
     if auto_pair:
         return pairs + list(single_files)
     else:
-        return files
+        return list(files)
 
 
 def _find_multilane_groups(files):

--- a/onecodex/utils.py
+++ b/onecodex/utils.py
@@ -63,8 +63,12 @@ OPTION_HELP = {
         "the files themselves."
     ),
     "prompt": (
-        "Manually prompt about automatic paired file interleaving. Setting --no-prompt "
-        "will allow running without any user intervention, e.g. in a script."
+        "Manually prompt about automatic paired file interleaving, ONT file merging, and "
+        "multi-lane file concatenation. When prompting, the mate of a paired end file may "
+        "be picked up from the same directory even if it was not passed on the command "
+        "line; it is marked with a * in the prompt. Setting --no-prompt will allow running "
+        "without any user intervention, e.g. in a script, and never uploads a file that "
+        "was not passed on the command line."
     ),
     "validate": (
         "Do not validate the FASTA/Q file before uploading. Incompatible with automatic "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1002,6 +1002,36 @@ def test_paired_and_multiline_files(
         assert multilane_prompt not in result.output
 
 
+def test_paired_file_found_on_disk_is_marked(
+    runner, generate_fastq, mock_file_upload, mock_sample_get, mocked_creds_path, upload_mocks
+):
+    """The mate is inferred from disk; the user must be told which file that is."""
+    forward = generate_fastq("test_R1.fq")
+    generate_fastq("test_R2.fq")
+
+    args = ["--api-key", "01234567890123456789012345678901", "upload", forward]
+    result = runner.invoke(Cli, args, catch_exceptions=False, input="\n")
+
+    assert result.exit_code == 0
+    assert "test_R1.fq  &  test_R2.fq *" in result.output
+    assert "* not specified on the command line" in result.output
+    assert mock_file_upload.call_count == 2
+    assert mock_sample_get.call_count == 1
+
+
+def test_paired_files_passed_explicitly_are_not_marked(
+    runner, generate_fastq, mock_file_upload, mock_sample_get, mocked_creds_path, upload_mocks
+):
+    files = [generate_fastq(x) for x in ["test_R1.fq", "test_R2.fq"]]
+
+    args = ["--api-key", "01234567890123456789012345678901", "upload"] + files
+    result = runner.invoke(Cli, args, catch_exceptions=False, input="\n")
+
+    assert result.exit_code == 0
+    assert "test_R1.fq  &  test_R2.fq" in result.output
+    assert "*" not in result.output
+
+
 def test_paired_files_with_forward_and_reverse_args(
     runner, generate_fastq, mock_file_upload, mock_sample_get, mocked_creds_path, upload_mocks
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1101,6 +1101,8 @@ def test_paired_files_with_forward_and_reverse_args(
         (["dir_r1_test/test_0.fq", "dir_r1_test/test_1.fq"], 1, 1, 0, 2),
         # 3 files, 2 samples
         (["test_0.fq", "other.fq", "test_1.fq"], 2, 2, 0, 2),
+        # 2 paired files, no ONT parts
+        (["test_R1.fq", "test_R2.fq"], 1, 2, 2, 0),
     ],
 )
 def test_paired_and_ont_files(
@@ -1132,7 +1134,7 @@ def test_paired_and_ont_files(
     else:
         assert paired_files_prompt not in result.output
 
-    ont_prompt = f"It appears there are {n_samples_uploaded} sample(s)"
+    ont_prompt = "Would you like to merge files by sample?"
     if n_ont_files > 0:
         assert ont_prompt in result.output
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1103,6 +1103,21 @@ def test_paired_files_with_forward_and_reverse_args(
         (["test_0.fq", "other.fq", "test_1.fq"], 2, 2, 0, 2),
         # 2 paired files, no ONT parts
         (["test_R1.fq", "test_R2.fq"], 1, 2, 2, 0),
+        # 6 files, 2 ONT samples whose merged names look like a read pair
+        (
+            [
+                "test_1_0.fq",
+                "test_1_1.fq",
+                "test_1_2.fq",
+                "test_2_0.fq",
+                "test_2_1.fq",
+                "test_2_2.fq",
+            ],
+            2,
+            2,
+            0,
+            6,
+        ),
     ],
 )
 def test_paired_and_ont_files(

--- a/tests/test_input_helpers.py
+++ b/tests/test_input_helpers.py
@@ -158,8 +158,8 @@ def test_concatenate_gzipped_multilane_files(generate_fastq_gz):
 def test_concatenate_ont_groups(generate_fastq, files, expected_grouping):
     files = [generate_fastq(x) for x in files]
     with use_tempdir() as tempdir:
-        pairs = concatenate_ont_groups(files, prompt=False, tempdir=tempdir)
-        basenames = _get_basenames(pairs)
+        concatenated, remaining = concatenate_ont_groups(files, prompt=False, tempdir=tempdir)
+        basenames = _get_basenames(concatenated + remaining)
         assert sorted(basenames) == sorted(expected_grouping)
 
 
@@ -167,8 +167,9 @@ def test_concatenate_ont_groups_leaves_paired_files_alone(generate_fastq):
     """Files without an ONT ordinal must not be grouped."""
     files = [generate_fastq(x) for x in ["test_R1.fq", "test_R2.fq"]]
     with use_tempdir() as tempdir:
-        groups = concatenate_ont_groups(files, prompt=False, tempdir=tempdir)
-        assert sorted(os.path.realpath(x) for x in groups) == sorted(
+        concatenated, remaining = concatenate_ont_groups(files, prompt=False, tempdir=tempdir)
+        assert concatenated == []
+        assert sorted(os.path.realpath(x) for x in remaining) == sorted(
             os.path.realpath(x) for x in files
         )
 
@@ -177,8 +178,9 @@ def test_concatenate_ont_group_inform_about_missing_file(generate_fastq, caplog)
     filenames = ["test_0.fq", "test_1.fq", "test_3.fq"]
     files = [generate_fastq(x) for x in filenames]
     with use_tempdir() as tempdir:
-        pairs = concatenate_ont_groups(files, prompt=False, tempdir=tempdir)
-        assert len(pairs) == len(filenames)
+        concatenated, remaining = concatenate_ont_groups(files, prompt=False, tempdir=tempdir)
+        assert concatenated == []
+        assert len(remaining) == len(filenames)
         assert (
             "Detected a gap in the ONT file sequence for test.fq, missing file: test_2.fq"
             in caplog.text

--- a/tests/test_input_helpers.py
+++ b/tests/test_input_helpers.py
@@ -4,7 +4,7 @@ import pytest
 from onecodex.input_helpers import (
     _find_multilane_groups,
     concatenate_multilane_files,
-    auto_detect_pairs,
+    auto_detect_illumina_pairs,
     concatenate_ont_groups,
 )
 from onecodex.utils import use_tempdir
@@ -35,9 +35,9 @@ def _get_basenames(elems):
         (["test_R1.fq", "test_R2.fq", "other.fq"], [("test_R1.fq", "test_R2.fq"), "other.fq"]),
     ],
 )
-def test_auto_detect_pairs(generate_fastq, files, expected_pairing):
+def test_auto_detect_illumina_pairs(generate_fastq, files, expected_pairing):
     files = [generate_fastq(x) for x in files]
-    pairs = auto_detect_pairs(files, prompt=False)
+    pairs = auto_detect_illumina_pairs(files, prompt=False)
     basenames = _get_basenames(pairs)
     assert basenames == expected_pairing
 

--- a/tests/test_input_helpers.py
+++ b/tests/test_input_helpers.py
@@ -163,6 +163,16 @@ def test_concatenate_ont_groups(generate_fastq, files, expected_grouping):
         assert sorted(basenames) == sorted(expected_grouping)
 
 
+def test_concatenate_ont_groups_leaves_paired_files_alone(generate_fastq):
+    """Files without an ONT ordinal must not be grouped."""
+    files = [generate_fastq(x) for x in ["test_R1.fq", "test_R2.fq"]]
+    with use_tempdir() as tempdir:
+        groups = concatenate_ont_groups(files, prompt=False, tempdir=tempdir)
+        assert sorted(os.path.realpath(x) for x in groups) == sorted(
+            os.path.realpath(x) for x in files
+        )
+
+
 def test_concatenate_ont_group_inform_about_missing_file(generate_fastq, caplog):
     filenames = ["test_0.fq", "test_1.fq", "test_3.fq"]
     files = [generate_fastq(x) for x in filenames]


### PR DESCRIPTION
## Status

- [ ] **Ready**
- [x] **In progress** -- see discussion

## Description

Fixes three defects in `onecodex upload`'s filename-based sample detection:

### 1. Fix: ONT samples could get interleaved as Illumina

There is an edge-case where samples that were concatenated as ONT files could then also get interleaved. In practice, there should never be a case where FASTQ files get merged _and_ interleaved. I've refactored the code so that now files can only ever get processed as ONT or Illumina but never as both.

```console
$ onecodex upload s_1_0.fq s_1_1.fq s_1_2.fq s_2_0.fq s_2_1.fq s_2_2.fq
It appears there are 2 sample(s) split across 6 individual file(s).
Would you like to merge files by sample?
[Y]es; [n]o; [d]isplay files; [c]ancel (Y, n, d, c) [Y]:
It appears there are 2 paired files (of 2 total):
  s_1.fq  &  s_2.fq                  ← two different samples
Interleave them after upload? [Y/n]:
```

### 2. Fix: Illumina files could get concatenated as ONT

Another edge-case where a single pair of R1/R2 files would get treated as "split" ONT files. The CLI would prompt to concatenate them, which would be a noop. This caused the actual bug in DEV-12030.

Before:

```console
$ onecodex upload s_R1.fq s_R2.fq
It appears there are 2 sample(s) split across 2 individual file(s).
Would you like to merge files by sample?
[Y]es; [n]o; [d]isplay files; [c]ancel (Y, n, d, c) [Y]: c
Upload canceled
```

(answering [Y] is a noop, which would then prompt you to interleave them)

After:

```console
$ onecodex upload s_R1.fq s_R2.fq
It appears there are 2 paired files (of 2 total):
  s_R1.fq  &  s_R2.fq
Interleave them after upload? [Y/n]:
```

### 3. Fix: the merge prompt appeared when nothing was eligible to merge

```console
$ onecodex upload a_1.fq a_2.fq
It appears there are 0 sample(s) split across 0 individual file(s).
Would you like to merge files by sample?
[Y]es; [n]o; [d]isplay files; [c]ancel (Y, n, d, c) [Y]:
```

After: goes straight to the interleave prompt.

### 4. Change: paired end mates found on disk are now marked

`onecodex upload input_R1.fq` automatically picks up `input_R2.fq` from the same directory but the user was not informed. Now there is a message printed to the console. There's no change to the existing behavior. I've also added documentation to the readme + CLI help.

```console
$ onecodex upload demo_R1.fq
It appears there are 2 paired files (of 2 total):
  demo_R1.fq  &  demo_R2.fq *
* not specified on the command line; found alongside its mate
Interleave them after upload? [Y/n]:
```

## Related PRs

- [x] This PR is independent

## TODOs

- [x] Tests
- [x] Documentation
- [x] Update `CHANGELOG`
